### PR TITLE
fix build with octomap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,14 @@ set(BOOST_COMPONENTS
 search_for_boost()
 # Optional dependencies
 add_optional_dependency("octomap >= 1.6")
+if (OCTOMAP_INCLUDE_DIRS AND OCTOMAP_LIBRARY_DIRS)
+	include_directories(${OCTOMAP_INCLUDE_DIRS})
+	link_directories(${OCTOMAP_LIBRARY_DIRS})
+	set(FCL_HAVE_OCTOMAP 1)
+	message(STATUS "FCL uses Octomap")
+else()
+	message(STATUS "FCL does not use Octomap")
+endif()
 # flann package ill defined: comment.
 # add_optional_dependency("flann >= 1.7")
 # if (${FLANN_FOUND})

--- a/include/hpp/fcl/traversal/traversal_node_octree.h
+++ b/include/hpp/fcl/traversal/traversal_node_octree.h
@@ -1040,6 +1040,11 @@ public:
   {
     return false;
   }
+  
+  bool BVTesting(int, int, FCL_REAL&) const
+  {
+    return false;
+  }
 
   void leafTesting(int, int, FCL_REAL&) const
   {
@@ -1072,6 +1077,11 @@ public:
   {
     return -1;
   }
+  
+  bool BVTesting(int, int, FCL_REAL&) const
+  {
+    return false;
+  }
 
   void leafTesting(int, int) const
   {
@@ -1098,6 +1108,11 @@ public:
   }
 
   bool BVTesting(int, int) const
+  {
+    return false;
+  }
+  
+  bool BVTesting(int, int, FCL_REAL&) const
   {
     return false;
   }
@@ -1129,6 +1144,11 @@ public:
   }
 
   bool BVTesting(int, int) const
+  {
+    return false;
+  }
+  
+  bool BVTesting(int, int, fcl::FCL_REAL&) const
   {
     return false;
   }
@@ -1221,6 +1241,11 @@ public:
   {
     return false;
   }
+  
+  bool BVTesting(int, int, FCL_REAL&) const
+  {
+    return false;
+  }
 
   void leafTesting(int, int, FCL_REAL&) const
   {
@@ -1249,6 +1274,11 @@ public:
   }
 
   bool BVTesting(int, int) const
+  {
+    return false;
+  }
+  
+  bool BVTesting(int, int, FCL_REAL&) const
   {
     return false;
   }

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -60,7 +60,8 @@ std::size_t ShapeOcTreeCollide(const CollisionGeometry* o1, const Transform3f& t
   OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
   initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, request, result);
-  collide(&node);
+  FCL_REAL sqrDistance = 0;
+  collide(&node, sqrDistance);
 
   return result.numContacts();
 }
@@ -78,12 +79,13 @@ std::size_t OcTreeShapeCollide(const CollisionGeometry* o1, const Transform3f& t
   OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
   initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, request, result);
-  collide(&node);
+  FCL_REAL sqrDistance = 0;
+  collide(&node, sqrDistance);
 
   return result.numContacts();
 }
 
-etemplate<typename NarrowPhaseSolver>
+template<typename NarrowPhaseSolver>
 std::size_t OcTreeCollide(const CollisionGeometry* o1, const Transform3f& tf1, const CollisionGeometry* o2, const Transform3f& tf2,
                           const NarrowPhaseSolver* nsolver,
                           const CollisionRequest& request, CollisionResult& result)
@@ -96,7 +98,8 @@ std::size_t OcTreeCollide(const CollisionGeometry* o1, const Transform3f& tf1, c
   OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
   initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, request, result);
-  collide(&node);
+  FCL_REAL sqrDistance = 0;
+  collide(&node, sqrDistance);
 
   return result.numContacts();
 }
@@ -119,7 +122,8 @@ std::size_t OcTreeBVHCollide(const CollisionGeometry* o1, const Transform3f& tf1
     OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
     initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, no_cost_request, result);
-    collide(&node);
+    FCL_REAL sqrDistance = 0;
+    collide(&node, sqrDistance);
 
     Box box;
     Transform3f box_tf;
@@ -140,7 +144,8 @@ std::size_t OcTreeBVHCollide(const CollisionGeometry* o1, const Transform3f& tf1
     OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
     initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, request, result);
-    collide(&node);
+    FCL_REAL sqrDistance = 0;
+    collide(&node, sqrDistance);
   }
   
   return result.numContacts();
@@ -164,7 +169,8 @@ std::size_t BVHOcTreeCollide(const CollisionGeometry* o1, const Transform3f& tf1
     OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
     initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, no_cost_request, result);
-    collide(&node);
+    FCL_REAL sqrDistance = 0;
+    collide(&node, sqrDistance);
 
     Box box;
     Transform3f box_tf;
@@ -185,7 +191,8 @@ std::size_t BVHOcTreeCollide(const CollisionGeometry* o1, const Transform3f& tf1
     OcTreeSolver<NarrowPhaseSolver> otsolver(nsolver);
 
     initialize(node, *obj1, tf1, *obj2, tf2, &otsolver, request, result);
-    collide(&node);
+    FCL_REAL sqrDistance = 0;
+    collide(&node, sqrDistance);
   }
   
   return result.numContacts();


### PR DESCRIPTION
variable FCL_HAVE_OCTOMAP was actually never activated even if octomap was found,
therefore collision methods were not defined.
Upon activating FCL_HAVE_OCTOMAP when required, there was a need to update the API according to modifications induced in hpp_fcl.