### PR TITLE
modify implementation of operator == in /include/hpp/fcl/math/vec_3fx.h

### DIFF
--- a/include/hpp/fcl/math/vec_3fx.h
+++ b/include/hpp/fcl/math/vec_3fx.h
@@ -132,7 +132,8 @@ public:
 
   bool operator == (const Vec3fX& other) const
   {
-    return equal(other, 0);
+  	return (data[0] == other.data[0] && data[1] == other.data[1] 
+			&& data[2] == other.data[2]);
   }
 
   bool operator != (const Vec3fX& other) const


### PR DESCRIPTION
The "equal" function does not return true even in test cases that use the exact same vector as reference and "other". Therefore, I found it reasonable to modify the operator ==.