### PR TITLE
Revert "[OBB] Simplify expression in obbDisjointAndLowerBoundDistance", fix #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       compiler: gcc
     - dist: xenial
       compiler: gcc
-    - dist: trusty
-      compiler: clang
     - dist: xenial
       compiler: clang
     - os: osx

--- a/src/BV/OBB.cpp
+++ b/src/BV/OBB.cpp
@@ -314,13 +314,18 @@ bool obbDisjointAndLowerBoundDistance (const Matrix3f& B, const Vec3f& T,
 
   // Corner of b axis aligned bounding box the closest to the origin
   Vec3f AABB_corner (T.cwiseAbs () - Bf * b);
-  squaredLowerBoundDistance = (AABB_corner - a).cwiseMax (0).squaredNorm ();
+  Vec3f diff3 (AABB_corner - a);
+  diff3 = diff3.cwiseMax (0);
+  //for (Vec3f::Index i=0; i<3; ++i) diff3 [i] = std::max (0, diff3 [i]);
+  squaredLowerBoundDistance = diff3.squaredNorm ();
   if (squaredLowerBoundDistance > breakDistance2)
     return true;
 
   AABB_corner = (B.transpose () * T).cwiseAbs ()  - Bf.transpose () * a;
-  // | B^T T| - b - Bf^T a
-  squaredLowerBoundDistance = (AABB_corner - b).cwiseMax (0).squaredNorm ();
+  // diff3 = | B^T T| - b - Bf^T a
+  diff3 = AABB_corner - b;
+  diff3 = diff3.cwiseMax (0);
+  squaredLowerBoundDistance = diff3.squaredNorm ();
 
   if (squaredLowerBoundDistance > breakDistance2)
     return true;


### PR DESCRIPTION
This reverts commit 31e52cc90748f2a2b80232682ec2214fb71f140d to allow compilation on 14.04 again.

But… It raises yet another issue about one test not passing on [clang on 14.04](https://travis-ci.org/nim65s/hpp-fcl/jobs/477862462):
```
13/14 Test #13: test_fcl_profiling ...............***Exception: Other  1.43 sec
```

I suggest to ignore this error, and just drop support for clang on 14.04.