### PR TITLE
core: remove throw from function declarations

### DIFF
--- a/include/hpp/fcl/mesh_loader/assimp.h
+++ b/include/hpp/fcl/mesh_loader/assimp.h
@@ -95,7 +95,7 @@ template<class BoundingVolume>
 inline void meshFromAssimpScene(const std::string & name,
                          const fcl::Vec3f & scale,
                          const aiScene* scene,
-                         const boost::shared_ptr < BVHModel<BoundingVolume> > & mesh) throw (std::invalid_argument)
+                         const boost::shared_ptr < BVHModel<BoundingVolume> > & mesh)
 {
   TriangleAndVertices tv;
   
@@ -128,7 +128,7 @@ inline void meshFromAssimpScene(const std::string & name,
 template<class BoundingVolume>
 inline void loadPolyhedronFromResource (const std::string & resource_path,
                                  const fcl::Vec3f & scale,
-                                 const boost::shared_ptr < BVHModel<BoundingVolume> > & polyhedron) throw (std::invalid_argument)
+                                 const boost::shared_ptr < BVHModel<BoundingVolume> > & polyhedron)
 {
   Assimp::Importer importer;
   // set list of ignored parameters (parameters used for rendering)


### PR DESCRIPTION
This is for making the code compliant with new policy in C++17.