### PR TITLE
[GJK] Fix GJK::encloseOrigin (fixes unit-tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,8 @@
 [![Pipeline status](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-fcl/badges/master/pipeline.svg)](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-fcl/commits/master)
 [![Coverage report](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-fcl/badges/master/coverage.svg?job=doc-coverage)](http://projects.laas.fr/gepetto/doc/humanoid-path-planner/hpp-fcl/master/coverage/)
 
-This project is a fork from https://github.com/flexible-collision-library/fcl. The main difference is the computation of a lower bound of the distance between two objects when collision checking is performed and no collision is found.
+This project is a fork from https://github.com/flexible-collision-library/fcl.
+
+The main differences are.
+- the use of a safety margin when detecting collision,
+- the computation of a lower bound of the distance between two objects when collision checking is performed and no collision is found.

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -67,6 +67,24 @@ template <> struct shape_traits<Box> : shape_traits_base
   };
 };
 
+template <> struct shape_traits<Cone> : shape_traits_base
+{
+  enum { NeedNormalizedDir = false
+  };
+};
+
+template <> struct shape_traits<Cylinder> : shape_traits_base
+{
+  enum { NeedNormalizedDir = false
+  };
+};
+
+template <> struct shape_traits<Convex> : shape_traits_base
+{
+  enum { NeedNormalizedDir = false
+  };
+};
+
 void getShapeSupport(const TriangleP* triangle, const Vec3f& dir, Vec3f& support)
 {
   FCL_REAL dota = dir.dot(triangle->a);
@@ -138,17 +156,14 @@ void getShapeSupport(const Cone* cone, const Vec3f& dir, Vec3f& support)
 void getShapeSupport(const Cylinder* cylinder, const Vec3f& dir, Vec3f& support)
 {
   static const FCL_REAL eps (sqrt(std::numeric_limits<FCL_REAL>::epsilon()));
-  FCL_REAL zdist = std::sqrt(dir[0] * dir[0] + dir[1] * dir[1]);
   FCL_REAL half_h = cylinder->lz * 0.5;
-  if(zdist == 0.0)
-    support = Vec3f(0, 0, (dir[2]>0)? half_h:-half_h);
-  else {
-    FCL_REAL d = cylinder->radius / zdist;
-    FCL_REAL z (0.);
-    if (dir [2] > eps) z = half_h;
-    else if (dir [2] < -eps) z = -half_h;
-    support << d * dir.head<2>(), z;
-  }
+  if      (dir [2] >  eps) support[2] =  half_h;
+  else if (dir [2] < -eps) support[2] = -half_h;
+  else                     support[2] = 0;
+  if (dir.head<2>().isZero())
+    support.head<2>().setZero();
+  else
+    support.head<2>() = dir.head<2>().normalized() * cylinder->radius;
   assert (fabs (support [0] * dir [1] - support [1] * dir [0]) < eps);
 }
 


### PR DESCRIPTION
The failure was due to a NaN value appearing when checking whether the origin is enclosed.

I started [CI on gitlab](https://gepgitlab.laas.fr/humanoid-path-planner/hpp-fcl/pipelines/5447)