### PR TITLE
[CMake] fix octomap detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif ()
 search_for_boost()
 # Optional dependencies
 add_optional_dependency("octomap >= 1.6")
-if (OCTOMAP_INCLUDE_DIRS AND OCTOMAP_LIBRARY_DIRS)
+if (OCTOMAP_FOUND)
   include_directories(SYSTEM ${OCTOMAP_INCLUDE_DIRS})
   link_directories(${OCTOMAP_LIBRARY_DIRS})
   SET(HPP_FCL_HAVE_OCTOMAP TRUE)


### PR DESCRIPTION
Hi,

On some systems, we don't have `OCTOMAP_INCLUDE_DIRS` & `OCTOMAP_LIBRARY_DIRS` but `OCTOMAP_INCLUDEDIR` & `OCTOMAP_LIBDIR`, and therefore we get:

```
-- Checking for module 'octomap >= 1.6'
--   Found octomap , version 1.9.0
-- Pkg-config module octomap v1.9.0 has been detected with success.
-- FCL does not use Octomap
```