### PR TITLE
[Travis] Update ci on mac.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,6 @@ matrix:
       env:
         - BUILD_TYPE=Debug
         - CXX_FLAGS_DEBUG="-O3"
-        - BUILD_PYTHON_INTERFACE=OFF
       os: osx
       compiler: clang
       addons:
@@ -87,6 +86,7 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source travis_custom/custom_before_install_linux.sh ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source travis_custom/custom_before_install_osx.sh ; fi
 
 script:
   # Create build directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,25 +72,21 @@ matrix:
             - liboctomap-dev
 
     - name: "OSX - Debug - clang"
-      env: BUILD_TYPE=Debug
+      env:
+        - BUILD_TYPE=Debug
+        - CXX_FLAGS_DEBUG="-O3"
+        - BUILD_PYTHON_INTERFACE=OFF
       os: osx
       compiler: clang
       addons:
         homebrew:
-          taps: homebrew/science
           update: true
           packages:
-            - git
-            - cmake
-            - boost
-            - libccd
             - assimp
             - eigen
-            - octomap
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then source travis_custom/custom_before_install_linux.sh ; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then source travis_custom/custom_before_install_osx.sh ; fi
 
 script:
   # Create build directory

--- a/travis_custom/custom_before_install_osx.sh
+++ b/travis_custom/custom_before_install_osx.sh
@@ -1,3 +1,6 @@
+# Disable homebrew auto-update
+export HOMEBREW_NO_AUTO_UPDATE=1
+
 # Add gepetto tap
 brew tap gepetto/homebrew-gepetto
 


### PR DESCRIPTION
Update Travis on Mac so that it completes faster:
- avoid to install newer versions of git, cmake and boost.
- do not install octomap,
- change compilation flag for faster execution of unit tests.