### PR TITLE
Add version support

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(LIBRARY_NAME hppfcl)
 INCLUDE_DIRECTORIES("${Boost_INCLUDE_DIRS}" ${PYTHON_INCLUDE_DIRS})
 
 ADD_LIBRARY(${LIBRARY_NAME} SHARED
+  version.cc
   math.cc
   collision-geometries.cc
   collision.cc

--- a/python/fcl.cc
+++ b/python/fcl.cc
@@ -62,6 +62,7 @@ void exposeMeshLoader ()
 
 BOOST_PYTHON_MODULE(hppfcl)
 {
+  exposeVersion();
   exposeMaths();
   exposeCollisionGeometries();
   exposeMeshLoader();

--- a/python/fcl.hh
+++ b/python/fcl.hh
@@ -1,9 +1,11 @@
-void exposeMaths ();
+void exposeVersion();
 
-void exposeCollisionGeometries ();
+void exposeMaths();
 
-void exposeMeshLoader ();
+void exposeCollisionGeometries();
 
-void exposeCollisionAPI ();
+void exposeMeshLoader();
 
-void exposeDistanceAPI ();
+void exposeCollisionAPI();
+
+void exposeDistanceAPI();

--- a/python/version.cc
+++ b/python/version.cc
@@ -4,6 +4,7 @@
 
 #include "hpp/fcl/config.hh"
 #include <boost/python.hpp>
+#include <boost/preprocessor/stringize.hpp>
 
 namespace bp = boost::python;
 
@@ -24,7 +25,9 @@ inline bool checkVersionAtMost(unsigned int major,
 void exposeVersion()
 {
   // Define release numbers of the current hpp-fcl version.
-  bp::scope().attr("__version__") = HPP_FCL_VERSION;
+  bp::scope().attr("__version__") = BOOST_PP_STRINGIZE(HPP_FCL_MAJOR_VERSION) "."
+    BOOST_PP_STRINGIZE(HPP_FCL_MINOR_VERSION) "."
+    BOOST_PP_STRINGIZE(HPP_FCL_PATCH_VERSION);
   bp::scope().attr("HPP_FCL_MAJOR_VERSION") = HPP_FCL_MAJOR_VERSION;
   bp::scope().attr("HPP_FCL_MINOR_VERSION") = HPP_FCL_MINOR_VERSION;
   bp::scope().attr("HPP_FCL_PATCH_VERSION") = HPP_FCL_PATCH_VERSION;

--- a/python/version.cc
+++ b/python/version.cc
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#include "hpp/fcl/config.hh"
+#include <boost/python.hpp>
+
+namespace bp = boost::python;
+
+inline bool checkVersionAtLeast(unsigned int major,
+                                unsigned int minor,
+                                unsigned int patch)
+{
+  return HPP_FCL_VERSION_AT_LEAST(major, minor, patch);
+}
+
+inline bool checkVersionAtMost(unsigned int major,
+                               unsigned int minor,
+                               unsigned int patch)
+{
+  return HPP_FCL_VERSION_AT_MOST(major, minor, patch);
+}
+
+void exposeVersion()
+{
+  // Define release numbers of the current hpp-fcl version.
+  bp::scope().attr("__version__") = HPP_FCL_VERSION;
+  bp::scope().attr("HPP_FCL_MAJOR_VERSION") = HPP_FCL_MAJOR_VERSION;
+  bp::scope().attr("HPP_FCL_MINOR_VERSION") = HPP_FCL_MINOR_VERSION;
+  bp::scope().attr("HPP_FCL_PATCH_VERSION") = HPP_FCL_PATCH_VERSION;
+
+  bp::def("checkVersionAtLeast",&checkVersionAtLeast,
+          bp::args("major","minor","patch"),
+          "Checks if the current version of hpp-fcl is at least"
+          " the version provided by the input arguments.");
+
+  bp::def("checkVersionAtMost",&checkVersionAtMost,
+          bp::args("major","minor","patch"),
+          "Checks if the current version of hpp-fcl is at most"
+          " the version provided by the input arguments.");
+}


### PR DESCRIPTION
Updates the cmake module so that `HPP_VERSION_AT_LEAST` and `HPP_VERSION_AT_MOST` are automatically inserted in the `config` header.

Exposes version-related macros in Python as attributes and wrapper functions