### PR TITLE
[geometric_shape] Fix radius, CoM and inertia computation + Python unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build*
 Xcode/*
+*~
+*.pyc
+

--- a/include/hpp/fcl/collision_object.h
+++ b/include/hpp/fcl/collision_object.h
@@ -125,10 +125,10 @@ public:
   FCL_REAL threshold_free;
 
   /// @brief compute center of mass
-  virtual Vec3f computeCOM() const { return Vec3f(); }
+  virtual Vec3f computeCOM() const { return Vec3f::Zero(); }
 
   /// @brief compute the inertia matrix, related to the origin
-  virtual Matrix3f computeMomentofInertia() const { return Matrix3f(); }
+  virtual Matrix3f computeMomentofInertia() const { return Matrix3f::Zero(); }
 
   /// @brief compute the volume
   virtual FCL_REAL computeVolume() const { return 0; }

--- a/include/hpp/fcl/collision_object.h
+++ b/include/hpp/fcl/collision_object.h
@@ -128,7 +128,7 @@ public:
   virtual Vec3f computeCOM() const { return Vec3f::Zero(); }
 
   /// @brief compute the inertia matrix, related to the origin
-  virtual Matrix3f computeMomentofInertia() const { return Matrix3f::Zero(); }
+  virtual Matrix3f computeMomentofInertia() const { return Matrix3f::Constant(NAN); }
 
   /// @brief compute the volume
   virtual FCL_REAL computeVolume() const { return 0; }

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -143,7 +143,7 @@ public:
 
   FCL_REAL computeVolume() const
   {
-    return 4 * boost::math::constants::pi<FCL_REAL>() * radius * radius / 3;
+    return 4 * boost::math::constants::pi<FCL_REAL>() * radius * radius * radius / 3;
   }
 };
 

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -214,7 +214,6 @@ public:
     return boost::math::constants::pi<FCL_REAL>() * radius * radius * (halfLength * 2) / 3;
   }
 
-  /// \todo verify this formula as it seems different from https://en.wikipedia.org/wiki/List_of_moments_of_inertia#List_of_3D_inertia_tensors
   Matrix3f computeMomentofInertia() const
   {
     FCL_REAL V = computeVolume();

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -178,7 +178,9 @@ public:
     FCL_REAL v_cyl = radius * radius * (halfLength * 2) * boost::math::constants::pi<FCL_REAL>();
     FCL_REAL v_sph = radius * radius * radius * boost::math::constants::pi<FCL_REAL>() * 4 / 3.0;
     
-    FCL_REAL ix = v_cyl * halfLength * halfLength / 3. + 0.25 * v_cyl * radius + 0.4 * v_sph * radius * radius + v_sph * halfLength * halfLength;
+    FCL_REAL h2 = halfLength * halfLength;
+    FCL_REAL r2 = radius * radius;
+    FCL_REAL ix = v_cyl * (h2 / 3. + r2 / 4.) + v_sph * (0.4 * r2 + h2 + 0.75 * radius * halfLength);
     FCL_REAL iz = (0.5 * v_cyl + 0.4 * v_sph) * radius * radius;
 
     return (Matrix3f() << ix, 0, 0,

--- a/test/python_unit/geometric_shapes.py
+++ b/test/python_unit/geometric_shapes.py
@@ -30,15 +30,16 @@ class TestGeometricShapes(TestCase):
         Iz_sphere = 0.4 * V_sphere * capsule.radius * capsule.radius
         Iz_ref = Iz_cylinder + Iz_sphere
         Ix_cylinder = V_cylinder*(3 * capsule.radius**2 + 4 * capsule.halfLength**2)/12.
-# TODO: check this code
-#        Ix_sphere = Iz_sphere + V_sphere*capsule.halfLength**2
-#        Ix_ref = Ix_cylinder + Ix_sphere
-#        print(Ix_cylinder)
-#        print(Ix_sphere) 
-#        I0_ref = np.diag([Ix_ref,Ix_ref,Iz_ref])
-#        self.assertApprox(I0.diagonal(), I0_ref.diagonal())
-#        Ic = capsule.computeMomentofInertiaRelatedToCOM()
-#        self.assertApprox(Ic, I0_ref)
+        V_hemi = 0.5 * V_sphere                                          # volume of hemisphere
+        I0x_hemi = 0.5 * Iz_sphere                                       # inertia of hemisphere w.r.t. origin
+        com_hemi = 3. * capsule.radius / 8.                              # CoM of hemisphere w.r.t. origin
+        Icx_hemi = I0x_hemi - V_hemi * com_hemi * com_hemi               # inertia of hemisphere w.r.t. CoM
+        Ix_hemi = Icx_hemi + V_hemi * (capsule.halfLength + com_hemi)**2 # inertia of hemisphere w.r.t. tip of cylinder
+        Ix_ref = Ix_cylinder + 2*Ix_hemi                                 # total inertia of capsule
+        I0_ref = np.diag([Ix_ref,Ix_ref,Iz_ref])
+        self.assertApprox(I0, I0_ref)
+        Ic = capsule.computeMomentofInertiaRelatedToCOM()
+        self.assertApprox(Ic, I0_ref)
 
     def test_box1(self):
         box = hppfcl.Box(np.matrix([1.,2.,3.]).T)

--- a/test/python_unit/geometric_shapes.py
+++ b/test/python_unit/geometric_shapes.py
@@ -37,12 +37,6 @@ class TestGeometricShapes(unittest.TestCase):
         self.assertEqual(box.halfSide[0],0.5)
         self.assertEqual(box.halfSide[1],1.0)
         self.assertEqual(box.halfSide[2],1.5)
-        box.halfSide[0] = 4.
-        box.halfSide[0] = 5.
-        box.halfSide[0] = 6.
-#         self.assertEqual(box.halfSide[0],4.)
-#         self.assertEqual(box.halfSide[1],5.)
-#         self.assertEqual(box.halfSide[2],6.)
 
     def test_sphere(self):
         sphere = hppfcl.Sphere(1.)
@@ -62,6 +56,10 @@ class TestGeometricShapes(unittest.TestCase):
         self.assertEqual(cylinder.getNodeType(), hppfcl.NODE_TYPE.GEOM_CYLINDER)
         self.assertEqual(cylinder.radius,1.)
         self.assertEqual(cylinder.halfLength,1.)
+        cylinder.radius = 3.
+        cylinder.halfLength = 4.
+        self.assertEqual(cylinder.radius,3.)
+        self.assertEqual(cylinder.halfLength,4.)
 
     def test_cone(self):
         cone = hppfcl.Cone(1.,2.)

--- a/test/python_unit/test_case.py
+++ b/test/python_unit/test_case.py
@@ -1,0 +1,7 @@
+import unittest
+import numpy as np
+
+class TestCase(unittest.TestCase):
+    def assertApprox(self, a, b, epsilon=1e-6):
+        return self.assertTrue(np.allclose(a, b, epsilon), "%s !~= %s" % (a, b))
+


### PR DESCRIPTION
`computeVolume()`, `computeCoM()` and `computeMomentofInertia()` had bugs, one of them really stupid concerning the volume of the sphere.
I fixed them and tested them in Python.
I suspect there is still a bug in the capsule inertia, which is why I have commented that part of the unit test, but I do not have time for that now