### PR TITLE
Bug fix + prepare optimization of collision using GJK / EPA

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -223,9 +223,16 @@ public:
 
 public:
   CollisionResult()
+    : distance_lower_bound (std::numeric_limits<FCL_REAL>::max())
   {
   }
 
+  /// @brief Update the lower bound only if the distance in inferior.
+  inline void updateDistanceLowerBound (const FCL_REAL& distance_lower_bound_)
+  {
+    if (distance_lower_bound_ < distance_lower_bound)
+      distance_lower_bound = distance_lower_bound_;
+  }
 
   /// @brief add one contact into result structure
   inline void addContact(const Contact& c) 

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -304,7 +304,8 @@ private:
         Transform3f box_tf;
         constructBox(bv1, tf1, box, box_tf);
 
-        if(solver->shapeIntersect(box, box_tf, s, tf2, NULL, NULL, NULL))
+        FCL_REAL distance;
+        if(solver->shapeIntersect(box, box_tf, s, tf2, distance, false, NULL, NULL))
         {
           AABB overlap_part;
           AABB aabb1, aabb2;
@@ -328,9 +329,10 @@ private:
           Transform3f box_tf;
           constructBox(bv1, tf1, box, box_tf);
 
+          FCL_REAL distance;
           if(!crequest->enable_contact)
           {
-            if(solver->shapeIntersect(box, box_tf, s, tf2, NULL, NULL, NULL))
+            if(solver->shapeIntersect(box, box_tf, s, tf2, distance, false, NULL, NULL))
             {
               if(cresult->numContacts() < crequest->num_max_contacts)
                 cresult->addContact(Contact(tree1, &s, static_cast<int>(root1 - tree1->getRoot()), Contact::NONE));
@@ -339,13 +341,12 @@ private:
           else
           {
             Vec3f contact;
-            FCL_REAL depth;
             Vec3f normal;
 
-            if(solver->shapeIntersect(box, box_tf, s, tf2, &contact, &depth, &normal))
+            if(solver->shapeIntersect(box, box_tf, s, tf2, distance, true, &contact, &normal))
             {
               if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, &s, static_cast<int>(root1 - tree1->getRoot()), Contact::NONE, contact, normal, depth));
+                cresult->addContact(Contact(tree1, &s, static_cast<int>(root1 - tree1->getRoot()), Contact::NONE, contact, normal, distance));
             }
           }
 
@@ -819,12 +820,12 @@ private:
           constructBox(bv2, tf2, box2, box2_tf);
 
           Vec3f contact;
-          FCL_REAL depth;
+          FCL_REAL distance;
           Vec3f normal;
-          if(solver->shapeIntersect(box1, box1_tf, box2, box2_tf, &contact, &depth, &normal))
+          if(solver->shapeIntersect(box1, box1_tf, box2, box2_tf, distance, true, &contact, &normal))
           {
             if(cresult->numContacts() < crequest->num_max_contacts)
-              cresult->addContact(Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot()), contact, normal, depth));
+              cresult->addContact(Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot()), contact, normal, distance));
           }
         }
 

--- a/include/hpp/fcl/internal/traversal_node_shapes.h
+++ b/include/hpp/fcl/internal/traversal_node_shapes.h
@@ -84,23 +84,26 @@ public:
   void leafCollides(int, int, FCL_REAL&) const
   {
     bool is_collision = false;
-    if(request.enable_contact)
+    FCL_REAL distance;
+    if(request.enable_contact && request.num_max_contacts > result->numContacts())
     {
       Vec3f contact_point, normal;
-      FCL_REAL penetration_depth;
-      if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, &contact_point,
-                                 &penetration_depth, &normal))
+      if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, distance, true,
+                                 &contact_point, &normal))
       {
         is_collision = true;
-        if(request.num_max_contacts > result->numContacts())
-          result->addContact(Contact(model1, model2, Contact::NONE,
-                                     Contact::NONE, contact_point,
-                                     normal, penetration_depth));
+        result->addContact(Contact(model1, model2, Contact::NONE,
+                                   Contact::NONE, contact_point,
+                                   normal, distance));
       }
     }
     else
     {
-      if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, NULL, NULL, NULL))
+      bool res = nsolver->shapeIntersect(*model1, tf1, *model2, tf2, distance,
+          request.enable_distance_lower_bound, NULL, NULL);
+      if (request.enable_distance_lower_bound)
+        result->updateDistanceLowerBound (distance);
+      if(res)
       {
         is_collision = true;
         if(request.num_max_contacts > result->numContacts())

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -314,7 +314,7 @@ namespace fcl
   /// \{
 
 // param doc is the doxygen detailled description (should be enclosed in /** */
-// and contain no space.
+// and contain no dot for some obscure reasons).
 #define HPP_FCL_DECLARE_SHAPE_INTERSECT(Shape1,Shape2,doc)                     \
   /** @brief Fast implementation for Shape1-Shape2 collision. */               \
   doc                                                                          \
@@ -335,7 +335,17 @@ namespace fcl
   HPP_FCL_DECLARE_SHAPE_INTERSECT_PAIR(Sphere, Halfspace,);
   HPP_FCL_DECLARE_SHAPE_INTERSECT_PAIR(Sphere, Plane,);
 
-  HPP_FCL_DECLARE_SHAPE_INTERSECT_SELF(Box,);
+#ifdef IS_DOXYGEN // for doxygen only
+  /** \todo currently disabled and to re-enable it, API of function
+   *  \ref obbDisjointAndLowerBoundDistance should be modified.
+   *  */
+  template<> bool GJKSolver::shapeIntersect<Box, Box>
+    (const Box& s1, const Transform3f& tf1,
+     const Box& s2, const Transform3f& tf2,
+     FCL_REAL& distance_lower_bound, bool enable_penetration,
+     Vec3f* contact_points, Vec3f* normal) const;
+#endif
+  //HPP_FCL_DECLARE_SHAPE_INTERSECT_SELF(Box,);
   HPP_FCL_DECLARE_SHAPE_INTERSECT_PAIR(Box, Halfspace,);
   HPP_FCL_DECLARE_SHAPE_INTERSECT_PAIR(Box, Plane,);
 
@@ -362,6 +372,8 @@ namespace fcl
   /// \name Shape triangle interaction specializations
   /// \{
 
+// param doc is the doxygen detailled description (should be enclosed in /** */
+// and contain no dot for some obscure reasons).
 #define HPP_FCL_DECLARE_SHAPE_TRIANGLE(Shape,doc)                              \
   /** @brief Fast implementation for Shape-Triangle interaction. */            \
   doc                                                                          \
@@ -382,7 +394,7 @@ namespace fcl
   /// \{
 
 // param doc is the doxygen detailled description (should be enclosed in /** */
-// and contain no space.
+// and contain no dot for some obscure reasons).
 #define HPP_FCL_DECLARE_SHAPE_DISTANCE(Shape1,Shape2,doc)                      \
   /** @brief Fast implementation for Shape1-Shape2 distance. */                \
   doc                                                                          \

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -249,7 +249,11 @@ namespace fcl
               // normal = tf1.getRotation() * epa.normal;
               normal = tf2.getRotation() * epa.normal;
               p1 = p2 = tf1.transform(w0 - epa.normal*(epa.depth *0.5));
+              return false;
             }
+            distance = -std::numeric_limits<FCL_REAL>::max();
+            gjk.getClosestPoints (shape, p1, p2);
+            p1 = p2 = tf1.transform (p1);
           }
           return false;
         }

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -80,16 +80,18 @@ namespace fcl
           } else {
             details::EPA epa(epa_max_face_num, epa_max_vertex_num, epa_max_iterations, epa_tolerance);
             details::EPA::Status epa_status = epa.evaluate(gjk, -guess);
-            if(epa_status & details::EPA::Failed)
+            if(epa_status & details::EPA::Valid
+                || epa_status == details::EPA::OutOfFaces    // Warnings
+                || epa_status == details::EPA::OutOfVertices // Warnings
+                )
             {
               epa.getClosestPoints (shape, w0, w1);
               if(penetration_depth) *penetration_depth = -epa.depth;
-              // TODO The normal computed by GJK in the s1 frame so this should be
-              // if(normal) *normal = tf1.getRotation() * epa.normal;
-              if(normal) *normal = tf2.getRotation() * epa.normal;
+              if(normal) *normal = tf1.getRotation() * epa.normal;
               if(contact_points) *contact_points = tf1.transform(w0 - epa.normal*(epa.depth *0.5));
               return true;
             }
+            if(penetration_depth) *penetration_depth = -std::numeric_limits<FCL_REAL>::max();
             // EPA failed but we know there is a collision so we should
             return true;
           }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -89,7 +89,6 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
     solver.cached_guess = request.cached_gjk_guess;
 
   const CollisionFunctionMatrix& looktable = getCollisionFunctionLookTable();
-  result.distance_lower_bound = -1;
   std::size_t res;
   if(request.num_max_contacts == 0)
   {

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -109,7 +109,7 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1, const Transform3f& tf
     }
     return 1;
   }
-  result.distance_lower_bound = distance;
+  result.updateDistanceLowerBound (distance);
   return 0;
 }
 

--- a/src/collision_node.cpp
+++ b/src/collision_node.cpp
@@ -60,7 +60,7 @@ void collide(CollisionTraversalNodeBase* node,
       collisionRecurse(node, 0, 0, front_list, sqrDistLowerBound);
     else
       collisionNonRecurse(node, front_list, sqrDistLowerBound);
-    result.distance_lower_bound = sqrt (sqrDistLowerBound);
+    result.updateDistanceLowerBound (sqrt (sqrDistLowerBound));
   }
 }
 

--- a/src/distance_sphere_sphere.cpp
+++ b/src/distance_sphere_sphere.cpp
@@ -132,7 +132,7 @@ namespace fcl {
       result.addContact (contact);
       return 1;
     }
-    result.distance_lower_bound = -penetrationDepth;
+    result.updateDistanceLowerBound (-penetrationDepth);
     return 0;
   }
 } // namespace fcl

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -120,7 +120,8 @@ void getShapeSupport(const TriangleP* triangle, const Vec3f& dir, Vec3f& support
 
 inline void getShapeSupport(const Box* box, const Vec3f& dir, Vec3f& support)
 {
-  support.noalias() = (dir.array() > 0).select(box->halfSide, -box->halfSide);
+  const FCL_REAL inflate = (dir.array() == 0).any() ? 1.00000001 : 1.;
+  support.noalias() = (dir.array() > 0).select(inflate * box->halfSide, -inflate * box->halfSide);
 }
 
 inline void getShapeSupport(const Sphere*, const Vec3f& /*dir*/, Vec3f& support)

--- a/src/narrowphase/narrowphase.cpp
+++ b/src/narrowphase/narrowphase.cpp
@@ -127,6 +127,7 @@ bool GJKSolver::shapeIntersect<Box, Sphere>
 
 SHAPE_INTERSECT_INVERTED(Sphere, Box)
 
+/*
 template<>
 bool GJKSolver::shapeIntersect<Box, Box>(const Box& s1, const Transform3f& tf1,
                                          const Box& s2, const Transform3f& tf2,
@@ -136,6 +137,7 @@ bool GJKSolver::shapeIntersect<Box, Box>(const Box& s1, const Transform3f& tf1,
 {
   return details::boxBoxIntersect(s1, tf1, s2, tf2, contact_points, &distance_lower_bound, normal);
 }
+*/
 
 template<>
 bool GJKSolver::shapeIntersect<Sphere, Halfspace>

--- a/src/narrowphase/narrowphase.cpp
+++ b/src/narrowphase/narrowphase.cpp
@@ -78,69 +78,77 @@ namespace fcl
     bool GJKSolver::shapeIntersect<Shape1, Shape2>                             \
     (const Shape1& s1, const Transform3f& tf1,                                 \
      const Shape2& s2, const Transform3f& tf2,                                 \
-     Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const                               \
+     FCL_REAL& distance_lower_bound, bool enable_penetration,                  \
+     Vec3f* contact_points, Vec3f* normal) const                               \
   {                                                                            \
-    bool res = shapeIntersect (s2, tf2, s1, tf1, contact_points,               \
-        penetration_depth, normal);                                            \
+    bool res = shapeIntersect (s2, tf2, s1, tf1, distance_lower_bound,         \
+        enable_penetration, contact_points, normal);                           \
     (*normal) *= -1.0;                                                         \
     return res;                                                                \
   }
 
 template<>
 bool GJKSolver::shapeIntersect<Sphere, Capsule>(const Sphere &s1, const Transform3f& tf1,
-                                                      const Capsule &s2, const Transform3f& tf2,
-                                                      Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+                                                const Capsule &s2, const Transform3f& tf2,
+                                                FCL_REAL& distance_lower_bound,
+                                                bool,
+                                                Vec3f* contact_points, Vec3f* normal) const
 {
-  return details::sphereCapsuleIntersect(s1, tf1, s2, tf2, contact_points, penetration_depth, normal);
+  return details::sphereCapsuleIntersect(s1, tf1, s2, tf2, distance_lower_bound,
+      contact_points, normal);
 }
 
 SHAPE_INTERSECT_INVERTED(Capsule, Sphere)
 
 template<>
 bool GJKSolver::shapeIntersect<Sphere, Sphere>(const Sphere& s1, const Transform3f& tf1,
-                                                     const Sphere& s2, const Transform3f& tf2,
-                                                     Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+                                               const Sphere& s2, const Transform3f& tf2,
+                                               FCL_REAL& distance_lower_bound,
+                                               bool,
+                                               Vec3f* contact_points, Vec3f* normal) const
 {
-  return details::sphereSphereIntersect(s1, tf1, s2, tf2, contact_points, penetration_depth, normal);
+  return details::sphereSphereIntersect(s1, tf1, s2, tf2, distance_lower_bound,
+      contact_points, normal);
 }
 
 template<>
-bool GJKSolver::shapeIntersect<Box, Sphere>(const Box   & s1, const Transform3f& tf1,
-                                                  const Sphere& s2, const Transform3f& tf2,
-                                                  Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+bool GJKSolver::shapeIntersect<Box, Sphere>
+(const Box   & s1, const Transform3f& tf1,
+ const Sphere& s2, const Transform3f& tf2,
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL dist;
   Vec3f ps, pb, n;
-  bool intersect = details::boxSphereDistance (s1, tf1, s2, tf2, dist, ps, pb, n);
-  if (!intersect) return false;
-  if (penetration_depth) *penetration_depth = dist;
+  bool res = details::boxSphereDistance (s1, tf1, s2, tf2, distance, ps, pb, n);
   if (normal)            *normal = n;
   if (contact_points)    *contact_points = pb;
-  return true;
+  return res;
 }
 
 SHAPE_INTERSECT_INVERTED(Sphere, Box)
 
 template<>
 bool GJKSolver::shapeIntersect<Box, Box>(const Box& s1, const Transform3f& tf1,
-                                               const Box& s2, const Transform3f& tf2,
-                                               Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+                                         const Box& s2, const Transform3f& tf2,
+                                         FCL_REAL& distance_lower_bound,
+                                         bool,
+                                         Vec3f* contact_points, Vec3f* normal) const
 {
-  return details::boxBoxIntersect(s1, tf1, s2, tf2, contact_points, penetration_depth, normal);
+  return details::boxBoxIntersect(s1, tf1, s2, tf2, contact_points, &distance_lower_bound, normal);
 }
 
 template<>
 bool GJKSolver::shapeIntersect<Sphere, Halfspace>
 (const Sphere& s1, const Transform3f& tf1,
  const Halfspace& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::sphereHalfspaceIntersect(s1, tf1, s2, tf2, distance, p1,
-                                               p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+                                               p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -150,14 +158,14 @@ template<>
 bool GJKSolver::shapeIntersect<Box, Halfspace>
 (const Box& s1, const Transform3f& tf1,
  const Halfspace& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::boxHalfspaceIntersect(s1, tf1, s2, tf2, distance, p1,
-                                            p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+                                            p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -167,14 +175,14 @@ template<>
 bool GJKSolver::shapeIntersect<Capsule, Halfspace>
 (const Capsule& s1, const Transform3f& tf1,
  const Halfspace& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res =  details::capsuleHalfspaceIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -184,14 +192,14 @@ template<>
 bool GJKSolver::shapeIntersect<Cylinder, Halfspace>
 (const Cylinder& s1, const Transform3f& tf1,
  const Halfspace& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res =  details::cylinderHalfspaceIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -201,41 +209,49 @@ template<>
 bool GJKSolver::shapeIntersect<Cone, Halfspace>
 (const Cone& s1, const Transform3f& tf1,
  const Halfspace& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res =  details::coneHalfspaceIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
 SHAPE_INTERSECT_INVERTED(Halfspace, Cone)
 
 template<>
-bool GJKSolver::shapeIntersect<Halfspace, Halfspace>(const Halfspace& s1, const Transform3f& tf1,
-                                                           const Halfspace& s2, const Transform3f& tf2,
-                                                           Vec3f* /*contact_points*/, FCL_REAL* /*penetration_depth*/, Vec3f* /*normal*/) const
+bool GJKSolver::shapeIntersect<Halfspace, Halfspace>
+(const Halfspace& s1, const Transform3f& tf1,
+ const Halfspace& s2, const Transform3f& tf2,
+ FCL_REAL& distance, bool,
+ Vec3f* /*contact_points*/, Vec3f* /*normal*/) const
 {
   Halfspace s;
   Vec3f p, d;
   FCL_REAL depth;
   int ret;
-  return details::halfspaceIntersect(s1, tf1, s2, tf2, p, d, s, depth, ret);
+  bool res = details::halfspaceIntersect(s1, tf1, s2, tf2, p, d, s, depth, ret);
+  distance = - depth;
+  return res;
 }
 
 template<>
-bool GJKSolver::shapeIntersect<Plane, Halfspace>(const Plane& s1, const Transform3f& tf1,
-                                                       const Halfspace& s2, const Transform3f& tf2,
-                                                       Vec3f* /*contact_points*/, FCL_REAL* /*penetration_depth*/, Vec3f* /*normal*/) const
+bool GJKSolver::shapeIntersect<Plane, Halfspace>
+(const Plane& s1, const Transform3f& tf1,
+ const Halfspace& s2, const Transform3f& tf2,
+ FCL_REAL& distance, bool,
+ Vec3f* /*contact_points*/, Vec3f* /*normal*/) const
 {
   Plane pl;
   Vec3f p, d;
   FCL_REAL depth;
   int ret;
-  return details::planeHalfspaceIntersect(s1, tf1, s2, tf2, pl, p, d, depth, ret);
+  bool res = details::planeHalfspaceIntersect(s1, tf1, s2, tf2, pl, p, d, depth, ret);
+  distance = - depth;
+  return res;
 }
 
 SHAPE_INTERSECT_INVERTED(Halfspace, Plane)
@@ -244,14 +260,14 @@ template<>
 bool GJKSolver::shapeIntersect<Sphere, Plane>
 (const Sphere& s1, const Transform3f& tf1,
  const Plane& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::spherePlaneIntersect(s1, tf1, s2, tf2, distance, p1,
-                                           p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+                                           p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -261,14 +277,14 @@ template<>
 bool GJKSolver::shapeIntersect<Box, Plane>
 (const Box& s1, const Transform3f& tf1,
  const Plane& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::boxPlaneIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -278,14 +294,14 @@ template<>
 bool GJKSolver::shapeIntersect<Capsule, Plane>
 (const Capsule& s1, const Transform3f& tf1,
  const Plane& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::capsulePlaneIntersect(s1, tf1, s2, tf2, distance, p1,
-                                            p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+                                            p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -295,14 +311,14 @@ template<>
 bool GJKSolver::shapeIntersect<Cylinder, Plane>
 (const Cylinder& s1, const Transform3f& tf1,
  const Plane& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::cylinderPlaneIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
@@ -312,25 +328,27 @@ template<>
 bool GJKSolver::shapeIntersect<Cone, Plane>
 (const Cone& s1, const Transform3f& tf1,
  const Plane& s2, const Transform3f& tf2,
- Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  FCL_REAL distance;
-  Vec3f p1, p2;
+  Vec3f p1, p2, n;
   bool res = details::conePlaneIntersect
-    (s1, tf1, s2, tf2, distance, p1, p2, *normal);
-  *contact_points = p1;
-  *penetration_depth = -distance;
+    (s1, tf1, s2, tf2, distance, p1, p2, n);
+  if (contact_points) *contact_points = p1;
+  if (normal) *normal = n;
   return res;
 }
 
 SHAPE_INTERSECT_INVERTED(Plane, Cone)
 
 template<>
-bool GJKSolver::shapeIntersect<Plane, Plane>(const Plane& s1, const Transform3f& tf1,
-                                                   const Plane& s2, const Transform3f& tf2,
-                                                   Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal) const
+bool GJKSolver::shapeIntersect<Plane, Plane>
+(const Plane& s1, const Transform3f& tf1,
+ const Plane& s2, const Transform3f& tf2,
+ FCL_REAL& distance, bool,
+ Vec3f* contact_points, Vec3f* normal) const
 {
-  return details::planeIntersect(s1, tf1, s2, tf2, contact_points, penetration_depth, normal);
+  return details::planeIntersect(s1, tf1, s2, tf2, contact_points, &distance, normal);
 }
 
 

--- a/src/traversal/traversal_recurse.cpp
+++ b/src/traversal/traversal_recurse.cpp
@@ -399,7 +399,7 @@ void propagateBVHFrontListCollisionRecurse
         }
       }
     }
-    result.distance_lower_bound = sqrt (sqrDistLowerBound);
+    result.updateDistanceLowerBound (sqrt (sqrDistLowerBound));
   }
 
 

--- a/test/box_box_distance.cpp
+++ b/test/box_box_distance.cpp
@@ -217,3 +217,42 @@ BOOST_AUTO_TEST_CASE(distance_box_box_3)
   BOOST_CHECK_CLOSE (p2 [2], p2Moved [2], 1e-4);
   
 }
+
+BOOST_AUTO_TEST_CASE(distance_box_box_4)
+{
+  hpp::fcl::Box s1 (1, 1, 1);
+  hpp::fcl::Box s2 (1, 1, 1);
+
+  // Enable computation of nearest points
+  DistanceRequest distanceRequest (true, 0, 0);
+  DistanceResult distanceResult;
+  double distance;
+
+  Transform3f tf1 (Vec3f (2, 0, 0));
+  Transform3f tf2;
+  hpp::fcl::distance (&s1, tf1, &s2, tf2, distanceRequest, distanceResult);
+
+  distance = 1.;
+  BOOST_CHECK_CLOSE(distanceResult.min_distance, distance, 1e-4);
+
+  tf1.setTranslation(Vec3f (1.01, 0, 0));
+  distanceResult.clear();
+  hpp::fcl::distance (&s1, tf1, &s2, tf2, distanceRequest, distanceResult);
+
+  distance = 0.01;
+  BOOST_CHECK_CLOSE(distanceResult.min_distance, distance, 2e-3);
+
+  tf1.setTranslation(Vec3f (0.99, 0, 0));
+  distanceResult.clear();
+  hpp::fcl::distance (&s1, tf1, &s2, tf2, distanceRequest, distanceResult);
+
+  distance = -0.01;
+  BOOST_CHECK_CLOSE(distanceResult.min_distance, distance, 2e-3);
+
+  tf1.setTranslation(Vec3f (0, 0, 0));
+  distanceResult.clear();
+  hpp::fcl::distance (&s1, tf1, &s2, tf2, distanceRequest, distanceResult);
+
+  distance = -1;
+  BOOST_CHECK_CLOSE(distanceResult.min_distance, distance, 2e-3);
+}

--- a/test/collision.cpp
+++ b/test/collision.cpp
@@ -104,8 +104,9 @@ BOOST_AUTO_TEST_CASE(OBB_Box_test)
 
     GJKSolver solver;
 
+    FCL_REAL distance;
     bool overlap_obb = obb1.overlap(obb2);
-    bool overlap_box = solver.shapeIntersect(box1, box1_tf, box2, box2_tf, NULL, NULL, NULL);
+    bool overlap_box = solver.shapeIntersect(box1, box1_tf, box2, box2_tf, distance, false, NULL, NULL);
     
     BOOST_CHECK(overlap_obb == overlap_box);
   }
@@ -138,13 +139,14 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
     FCL_REAL len = (aabb1.max_[0] - aabb1.min_[0]) * 0.5;
     OBB obb2;
     GJKSolver solver;
+    FCL_REAL distance;
  
     {  
       Sphere sphere(len);
       computeBV(sphere, transforms[i], obb2);
  
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_sphere = solver.shapeIntersect(box1, box1_tf, sphere, transforms[i], NULL, NULL, NULL);
+      bool overlap_sphere = solver.shapeIntersect(box1, box1_tf, sphere, transforms[i], distance, false, NULL, NULL);
       BOOST_CHECK(overlap_obb >= overlap_sphere);
     }
 
@@ -153,7 +155,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(capsule, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_capsule = solver.shapeIntersect(box1, box1_tf, capsule, transforms[i], NULL, NULL, NULL);
+      bool overlap_capsule = solver.shapeIntersect(box1, box1_tf, capsule, transforms[i], distance, false, NULL, NULL);
       BOOST_CHECK(overlap_obb >= overlap_capsule);
     }
 
@@ -162,7 +164,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(cone, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_cone = solver.shapeIntersect(box1, box1_tf, cone, transforms[i], NULL, NULL, NULL);
+      bool overlap_cone = solver.shapeIntersect(box1, box1_tf, cone, transforms[i], distance, false, NULL, NULL);
       BOOST_CHECK(overlap_obb >= overlap_cone);
     }
 
@@ -171,7 +173,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(cylinder, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_cylinder = solver.shapeIntersect(box1, box1_tf, cylinder, transforms[i], NULL, NULL, NULL);
+      bool overlap_cylinder = solver.shapeIntersect(box1, box1_tf, cylinder, transforms[i], distance, false, NULL, NULL);
       BOOST_CHECK(overlap_obb >= overlap_cylinder);
     }
   }

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -217,7 +217,7 @@ template <typename Sa, typename Sb> void compareShapeDistance (
 BOOST_AUTO_TEST_CASE(compare_convex_box)
 {
   FCL_REAL extents [6] = {0, 0, 0, 10, 10, 10};
-  FCL_REAL l = 1, w = 1, d = 1;
+  FCL_REAL l = 1, w = 1, d = 1, eps = 1e-4;
   Box box(l*2, w*2, d*2);
   Convex<Quadrilateral> convex_box (buildBox (l, w, d));
 
@@ -225,16 +225,16 @@ BOOST_AUTO_TEST_CASE(compare_convex_box)
   Transform3f tf2;
 
   tf2.setTranslation (Vec3f (3, 0, 0));
-  compareShapeIntersection(box, convex_box, tf1, tf2);
-  compareShapeDistance    (box, convex_box, tf1, tf2);
+  compareShapeIntersection(box, convex_box, tf1, tf2, eps);
+  compareShapeDistance    (box, convex_box, tf1, tf2, eps);
 
   tf2.setTranslation (Vec3f (0, 0, 0));
-  compareShapeIntersection(box, convex_box, tf1, tf2);
-  compareShapeDistance    (box, convex_box, tf1, tf2);
+  compareShapeIntersection(box, convex_box, tf1, tf2, eps);
+  compareShapeDistance    (box, convex_box, tf1, tf2, eps);
 
   for (int i = 0; i < 1000; ++i) {
     generateRandomTransform(extents, tf2);
-    compareShapeIntersection(box, convex_box, tf1, tf2);
-    compareShapeDistance    (box, convex_box, tf1, tf2);
+    compareShapeIntersection(box, convex_box, tf1, tf2, eps);
+    compareShapeDistance    (box, convex_box, tf1, tf2, eps);
   }
 }

--- a/test/general_test.cpp
+++ b/test/general_test.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
   boost::shared_ptr<Box> box1(new Box(1,1,1));
   GJKSolver_libccd solver;
   Vec3f contact_points;
-  FCL_REAL penetration_depth;
+  FCL_REAL distance;
   Vec3f normal;
 
   Transform3f tf0, tf1;
@@ -23,12 +23,10 @@ int main(int argc, char** argv)
   tf0.setQuatRotation(Quaternion3f(.6, .8, 0, 0));
   tf1.setIdentity();
 
-
-
-  bool res = solver.shapeIntersect(*box0, tf0, *box1, tf1, &contact_points, &penetration_depth, &normal);
+  bool res = solver.shapeIntersect(*box0, tf0, *box1, tf1, distance, true, &contact_points, &normal);
 
   cout << "contact points: " << contact_points << endl;
-  cout << "pen depth: " << penetration_depth << endl;
+  cout << "signed distance: " << distance << endl;
   cout << "normal: " << normal << endl;
   cout << "result: " << res << endl;
   

--- a/test/geometric_shapes.cpp
+++ b/test/geometric_shapes.cpp
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_boxbox)
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15, 0, 0));
   normal << 1, 0, 0;
-  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-8);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15.01, 0, 0));
@@ -3023,7 +3023,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_boxbox)
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15, 0, 0));
   normal << 1, 0, 0;
-  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-8);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(15.01, 0, 0));

--- a/test/geometric_shapes.cpp
+++ b/test/geometric_shapes.cpp
@@ -57,7 +57,27 @@ FCL_REAL tol_gjk = 0.01;
 GJKSolver solver1;
 GJKSolver solver2;
 
+int line;
+#define SET_LINE line = __LINE__
+#define FCL_CHECK(cond) BOOST_CHECK_MESSAGE(cond, "from line " << line << ": " #cond)
+#define FCL_CHECK_EQUAL(a,b)            \
+  BOOST_CHECK_MESSAGE((a) == (b),       \
+    "from line " << line << ": " #a "[" << (a) << "] != " #b "[" << (b) << "].")
 #define BOOST_CHECK_FALSE(p) BOOST_CHECK(!(p))
+
+namespace hpp {
+namespace fcl {
+std::ostream& operator<< (std::ostream& os, const ShapeBase&)
+{
+  return os << "a_shape";
+}
+
+std::ostream& operator<< (std::ostream& os, const Box& b)
+{
+  return os << "Box(" << 2*b.halfSide.transpose() << ')';
+}
+}
+}
 
 template <typename S1, typename S2>
 void printComparisonError(const std::string& comparison_type,
@@ -120,7 +140,7 @@ void compareContact(const S1& s1, const Transform3f& tf1,
   if (expected_point)
   {
     bool contact_equal = isEqual(contact, *expected_point, tol);
-    BOOST_CHECK(contact_equal);
+    FCL_CHECK(contact_equal);
     if (!contact_equal)
       printComparisonError("contact", s1, tf1, s2, tf2, contact, *expected_point, false, tol);
   }
@@ -128,7 +148,7 @@ void compareContact(const S1& s1, const Transform3f& tf1,
   if (expected_depth)
   {
     bool depth_equal = std::fabs(depth - *expected_depth) < tol;
-    BOOST_CHECK(depth_equal);
+    FCL_CHECK(depth_equal);
     if (!depth_equal)
       printComparisonError("depth", s1, tf1, s2, tf2, depth, *expected_depth, tol);
   }
@@ -140,7 +160,7 @@ void compareContact(const S1& s1, const Transform3f& tf1,
     if (!normal_equal && check_opposite_normal)
       normal_equal = isEqual(normal, -(*expected_normal), tol);
 
-    BOOST_CHECK(normal_equal);
+    FCL_CHECK(normal_equal);
     if (!normal_equal)
       printComparisonError("normal", s1, tf1, s2, tf2, normal, *expected_normal, check_opposite_normal, tol);
   }
@@ -149,7 +169,7 @@ void compareContact(const S1& s1, const Transform3f& tf1,
 template <typename S1, typename S2>
 void testShapeIntersection(const S1& s1, const Transform3f& tf1,
                            const S2& s2, const Transform3f& tf2,
-                           bool expected_res,
+                           bool expect_collision,
                            Vec3f* expected_point = NULL,
                            FCL_REAL* expected_depth = NULL,
                            Vec3f* expected_normal = NULL,
@@ -161,20 +181,29 @@ void testShapeIntersection(const S1& s1, const Transform3f& tf1,
 
   Vec3f contact;
   Vec3f normal;  // normal direction should be from object 1 to object 2
-  bool res;
+  bool collision;
+  bool check_failed = false;
 
   request.enable_contact = false;
   result.clear();
-  res = (collide(&s1, tf1, &s2, tf2, request, result) > 0);
-  BOOST_CHECK_EQUAL(res, expected_res);
+  collision = (collide(&s1, tf1, &s2, tf2, request, result) > 0);
+  FCL_CHECK_EQUAL(collision, expect_collision);
+  check_failed = check_failed || (collision != expect_collision);
 
   request.enable_contact = true;
   result.clear();
-  res = (collide(&s1, tf1, &s2, tf2, request, result) > 0);
-  BOOST_CHECK_EQUAL(res, expected_res);
-  if (expected_res)
+  collision = (collide(&s1, tf1, &s2, tf2, request, result) > 0);
+  FCL_CHECK_EQUAL(collision, expect_collision);
+  check_failed = check_failed || (collision != expect_collision);
+
+  if (check_failed) {
+    BOOST_TEST_MESSAGE("Failure occured between " << s1 << " and " << s2 << " at transformations\n"
+        << tf1 << '\n' << tf2);
+  }
+
+  if (expect_collision)
   {
-    BOOST_CHECK_EQUAL(result.numContacts(), 1);
+    FCL_CHECK_EQUAL(result.numContacts(), 1);
     if (result.numContacts() == 1)
     {
       Contact contact = result.getContact(0);
@@ -292,69 +321,69 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(40, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(40, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(30, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(30.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(30.01, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(29.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(29.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f();
   normal.setZero();  // If the centers of two sphere are at the same position, the normal is (0, 0, 0)
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform;
   normal.setZero();  // If the centers of two sphere are at the same position, the normal is (0, 0, 0)
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-29.9, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-29.9, 0, 0));
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-30.0, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-30.01, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-30.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 bool compareContactPoints(const Vec3f& c1,const Vec3f& c2)
@@ -387,12 +416,14 @@ void testBoxBoxContactPoints(const Matrix3f& R)
   Transform3f tf2 = Transform3f(R);
 
   Vec3f normal;
-  Vec3f point;
-  double penetration;
+  Vec3f point(0.,0.,0.);
+  double distance;
 
   // Make sure the two boxes are colliding
-  bool res = solver1.shapeIntersect(s1, tf1, s2, tf2, &point, &penetration, &normal);
-  BOOST_CHECK(res);
+  solver1.gjk_tolerance = 1e-5;
+  solver1.epa_tolerance = 1e-5;
+  bool res = solver1.shapeIntersect(s1, tf1, s2, tf2, distance, true, &point, &normal);
+  FCL_CHECK(res);
 
   // Compute global vertices
   for (int i = 0; i < 8; ++i)
@@ -402,7 +433,9 @@ void testBoxBoxContactPoints(const Matrix3f& R)
   std::sort(vertices.begin(), vertices.end(), compareContactPoints);
 
   // The lowest vertex along z-axis should be the contact point
-  BOOST_CHECK(isEqual(vertices[0], point));
+  FCL_CHECK(normal.isApprox(Vec3f(0,0,1), 1e-6));
+  FCL_CHECK(vertices[0].head<2>().isApprox(point.head<2>(), 1e-6));
+  FCL_CHECK(vertices[0][2] <= point[2] && point[2] < 0);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_boxbox)
@@ -427,39 +460,39 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_boxbox)
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position. The current result is (1, 0, 0).
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position. The current result is (1, 0, 0).
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(q);
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = transform;
   tf2 = transform * Transform3f(q);
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   FCL_UINT32 numTests = 1e+2;
   for (FCL_UINT32 i = 0; i < numTests; ++i)
   {
     Transform3f tf;
     generateRandomTransform(extents, tf);
-    testBoxBoxContactPoints(tf.getRotation());
+    SET_LINE; testBoxBoxContactPoints(tf.getRotation());
   }
 }
 
@@ -482,30 +515,30 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spherebox)
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position. The current result is (-1, 0, 0).
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(22.50001, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(22.501, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(22.4, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(22.4, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 }
 
 BOOST_AUTO_TEST_CASE(shapeDistance_spherebox)
@@ -551,42 +584,42 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spherecapsule)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(24.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(24.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(25, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(24.999999, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(25.1, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(25.1, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_cylindercylinder)
@@ -607,35 +640,35 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_cylindercylinder)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 9.9, 0));
   normal << 0, 1, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(9.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(9.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 /*
@@ -657,40 +690,40 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_conecone)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(9.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(9.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.001, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.001, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 9.9));
   normal << 0, 0, 1;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 9.9));
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 }
 */
 
@@ -713,48 +746,48 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_conecylinder)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(9.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 0.061);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 0.061);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(9.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 0.46);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 0.46);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 9.9));
   normal << 0, 0, 1;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 9.9));
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10.01));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.01));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 */
 
@@ -930,64 +963,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacesphere)
   contact << -5, 0, 0;
   depth = 10;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(-5, 0, 0));
   depth = 10;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5, 0, 0));
   contact << -2.5, 0, 0;
   depth = 15;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5, 0, 0));
   contact = transform.transform(Vec3f(-2.5, 0, 0));
   depth = 15;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5, 0, 0));
   contact << -7.5, 0, 0;
   depth = 5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5, 0, 0));
   contact = transform.transform(Vec3f(-7.5, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.1, 0, 0));
   contact << 0.05, 0, 0;
   depth = 20.1;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.1, 0, 0));
   contact = transform.transform(Vec3f(0.05, 0, 0));
   depth = 20.1;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_planesphere)
@@ -1010,58 +1043,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planesphere)
   contact.setZero();
   depth = 10;
   normal << 1, 0, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 10;
   normal = transform.getRotation() * Vec3f(1, 0, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5, 0, 0));
   contact << 5, 0, 0;
   depth = 5;
   normal << 1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5, 0, 0));
   contact = transform.transform(Vec3f(5, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5, 0, 0));
   contact << -5, 0, 0;
   depth = 5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5, 0, 0));
   contact = transform.transform(Vec3f(-5, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacebox)
@@ -1084,68 +1117,68 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacebox)
   contact << -1.25, 0, 0;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(-1.25, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(1.25, 0, 0));
   contact << -0.625, 0, 0;
   depth = 3.75;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(1.25, 0, 0));
   contact = transform.transform(Vec3f(-0.625, 0, 0));
   depth = 3.75;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-1.25, 0, 0));
   contact << -1.875, 0, 0;
   depth = 1.25;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-1.25, 0, 0));
   contact = transform.transform(Vec3f(-1.875, 0, 0));
   depth = 1.25;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.51, 0, 0));
   contact << 0.005, 0, 0;
   depth = 5.01;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.51, 0, 0));
   contact = transform.transform(Vec3f(0.005, 0, 0));
   depth = 5.01;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f(transform.getRotation());
   tf2 = Transform3f();
-  testShapeIntersection(s, tf1, hs, tf2, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_planebox)
@@ -1168,62 +1201,62 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planebox)
   contact << 0, 0, 0;
   depth = 2.5;
   normal << 1, 0, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(1.25, 0, 0));
   contact << 1.25, 0, 0;
   depth = 1.25;
   normal << 1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(1.25, 0, 0));
   contact = transform.transform(Vec3f(1.25, 0, 0));
   depth = 1.25;
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-1.25, 0, 0));
   contact << -1.25, 0, 0;
   depth = 1.25;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-1.25, 0, 0));
   contact = transform.transform(Vec3f(-1.25, 0, 0));
   depth = 1.25;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.51, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f(transform.getRotation());
   tf2 = Transform3f();
-  testShapeIntersection(s, tf1, hs, tf2, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
@@ -1246,64 +1279,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
   contact << -2.5, 0, 0;
   depth = 5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(-2.5, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << -1.25, 0, 0;
   depth = 7.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(-1.25, 0, 0));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -3.75, 0, 0;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-3.75, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
   contact << 0.05, 0, 0;
   depth = 10.1;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
   contact = transform.transform(Vec3f(0.05, 0, 0));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1315,64 +1348,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
   contact << 0, -2.5, 0;
   depth = 5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, -2.5, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 2.5, 0));
   contact << 0, -1.25, 0;
   depth = 7.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, -1.25, 0));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -3.75, 0;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -3.75, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
   contact << 0, 0.05, 0;
   depth = 10.1;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
   contact = transform.transform(Vec3f(0, 0.05, 0));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1384,64 +1417,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
   contact << 0, 0, -5;
   depth = 10;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, -5));
   depth = 10;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 2.5));
   contact << 0, 0, -3.75;
   depth = 12.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, -3.75));
   depth = 12.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -6.25;
   depth = 7.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -6.25));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10.1));
   contact << 0, 0, 0.05;
   depth = 20.1;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.1));
   contact = transform.transform(Vec3f(0, 0, 0.05));
   depth = 20.1;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
@@ -1464,58 +1497,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact << 0, 0, 0;
   depth = 5;
   normal << 1, 0, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << 2.5, 0, 0;
   depth = 2.5;
   normal << 1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(2.5, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -2.5, 0, 0;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-2.5, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1527,7 +1560,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact << 0, 0, 0;
   depth = 5;
   normal << 0, 1, 0;  // (0, 1, 0) or (0, -1, 0)
-  testShapeIntersection
+  SET_LINE; testShapeIntersection
     (s, tf1, hs, tf2, true, 0x0, &depth, 0x0, true);
 
   tf1 = transform;
@@ -1535,7 +1568,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);  // (0, 1, 0) or (0, -1, 0)
-  testShapeIntersection
+  SET_LINE; testShapeIntersection
     (s, tf1, hs, tf2, true, 0x0, &depth, &normal, true);
 
   tf1 = Transform3f();
@@ -1543,44 +1576,44 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact << 0, 2.5, 0;
   depth = 2.5;
   normal << 0, 1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, 2.5, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -2.5, 0;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -2.5, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1592,14 +1625,14 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact << 0, 0, 0;
   depth = 10;
   normal << 0, 0, 1;  // (0, 0, 1) or (0, 0, -1)
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, 0x0, 0x0, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 10;
   normal = transform.getRotation() * Vec3f(0, 0, 1);  // (0, 0, 1) or (0, 0, -1)
-  testShapeIntersection
+  SET_LINE; testShapeIntersection
     (s, tf1, hs, tf2, true, 0x0, &depth, 0x0, true);
 
   tf1 = Transform3f();
@@ -1607,45 +1640,45 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   contact << 0, 0, 2.5;
   depth = 7.5;
   normal << 0, 0, 1;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, 2.5));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -2.5;
   depth = 7.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -2.5));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection
+  SET_LINE; testShapeIntersection
     (s, tf1, hs, tf2, true, 0x0, &depth, 0x0);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
@@ -1668,64 +1701,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
   contact << -2.5, 0, 0;
   depth = 5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(-2.5, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << -1.25, 0, 0;
   depth = 7.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(-1.25, 0, 0));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -3.75, 0, 0;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-3.75, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
   contact << 0.05, 0, 0;
   depth = 10.1;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
   contact = transform.transform(Vec3f(0.05, 0, 0));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1737,64 +1770,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
   contact << 0, -2.5, 0;
   depth = 5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, -2.5, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 2.5, 0));
   contact << 0, -1.25, 0;
   depth = 7.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, -1.25, 0));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -3.75, 0;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -3.75, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
   contact << 0, 0.05, 0;
   depth = 10.1;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
   contact = transform.transform(Vec3f(0, 0.05, 0));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1806,64 +1839,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
   contact << 0, 0, -2.5;
   depth = 5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, -2.5));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 2.5));
   contact << 0, 0, -1.25;
   depth = 7.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, -1.25));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -3.75;
   depth = 2.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -3.75));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 5.1));
   contact << 0, 0, 0.05;
   depth = 10.1;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 5.1));
   contact = transform.transform(Vec3f(0, 0, 0.05));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -5.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -5.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
@@ -1886,58 +1919,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
   contact << 0, 0, 0;
   depth = 5;
   normal << 1, 0, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << 2.5, 0, 0;
   depth = 2.5;
   normal << 1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(2.5, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -2.5, 0, 0;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-2.5, 0, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -1949,58 +1982,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
   contact << 0, 0, 0;
   depth = 5;
   normal << 0, 1, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 2.5, 0));
   contact << 0, 2.5, 0;
   depth = 2.5;
   normal << 0, 1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, 2.5, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -2.5, 0;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -2.5, 0));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -2012,58 +2045,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
   contact << 0, 0, 0;
   depth = 5;
   normal << 0, 0, 1;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 0, 1);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 2.5));
   contact << 0, 0, 2.5;
   depth = 2.5;
   normal << 0, 0, 1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, 2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -2.5;
   depth = 2.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 
@@ -2087,64 +2120,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
   contact << -2.5, 0, -5;
   depth = 5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(-2.5, 0, -5));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << -1.25, 0, -5;
   depth = 7.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(-1.25, 0, -5));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -3.75, 0, -5;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-3.75, 0, -5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
   contact << 0.05, 0, -5;
   depth = 10.1;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
   contact = transform.transform(Vec3f(0.05, 0, -5));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -2156,64 +2189,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
   contact << 0, -2.5, -5;
   depth = 5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, -2.5, -5));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 2.5, 0));
   contact << 0, -1.25, -5;
   depth = 7.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, -1.25, -5));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -3.75, -5;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -3.75, -5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
   contact << 0, 0.05, -5;
   depth = 10.1;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
   contact = transform.transform(Vec3f(0, 0.05, -5));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -2225,64 +2258,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
   contact << 0, 0, -2.5;
   depth = 5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, -2.5));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 2.5));
   contact << 0, 0, -1.25;
   depth = 7.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, -1.25));
   depth = 7.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -3.75;
   depth = 2.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -3.75));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 5.1));
   contact << 0, 0, 0.05;
   depth = 10.1;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 5.1));
   contact = transform.transform(Vec3f(0, 0, 0.05));
   depth = 10.1;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -5.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -5.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
@@ -2305,58 +2338,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
   contact << 0, 0, 0;
   depth = 5;
   normal << 1, 0, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(2.5, 0, 0));
   contact << 2.5, 0, -2.5;
   depth = 2.5;
   normal << 1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(2.5, 0, 0));
   contact = transform.transform(Vec3f(2.5, 0, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-2.5, 0, 0));
   contact << -2.5, 0, -2.5;
   depth = 2.5;
   normal << -1, 0, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-2.5, 0, 0));
   contact = transform.transform(Vec3f(-2.5, 0, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-5.1, 0, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -2368,58 +2401,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
   contact << 0, 0, 0;
   depth = 5;
   normal << 0, 1, 0;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 2.5, 0));
   contact << 0, 2.5, -2.5;
   depth = 2.5;
   normal << 0, 1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 2.5, 0));
   contact = transform.transform(Vec3f(0, 2.5, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -2.5, 0));
   contact << 0, -2.5, -2.5;
   depth = 2.5;
   normal << 0, -1, 0;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -2.5, 0));
   contact = transform.transform(Vec3f(0, -2.5, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, -1, 0);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, -5.1, 0));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
 
 
@@ -2431,58 +2464,58 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
   contact << 0, 0, 0;
   depth = 5;
   normal << 0, 0, 1;  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = transform;
   tf2 = transform;
   contact = transform.transform(Vec3f(0, 0, 0));
   depth = 5;
   normal = transform.getRotation() * Vec3f(0, 0, 1);  // (1, 0, 0) or (-1, 0, 0)
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal, true);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 2.5));
   contact << 0, 0, 2.5;
   depth = 2.5;
   normal << 0, 0, 1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 2.5));
   contact = transform.transform(Vec3f(0, 0, 2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -2.5));
   contact << 0, 0, -2.5;
   depth = 2.5;
   normal << 0, 0, -1;
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -2.5));
   contact = transform.transform(Vec3f(0, 0, -2.5));
   depth = 2.5;
   normal = transform.getRotation() * Vec3f(0, 0, -1);
-  testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, true, &contact, &depth, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, -10.1));
-  testShapeIntersection(s, tf1, hs, tf2, false);
+  SET_LINE; testShapeIntersection(s, tf1, hs, tf2, false);
 }
 
 
@@ -2892,69 +2925,69 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(40, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(40, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(30, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(30.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(30.01, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(29.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(29.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f();
   normal.setZero();  // If the centers of two sphere are at the same position, the normal is (0, 0, 0)
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform;
   normal.setZero();  // If the centers of two sphere are at the same position, the normal is (0, 0, 0)
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-29.9, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-29.9, 0, 0));
   normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-30.0, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(-30.01, 0, 0));
   normal << -1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(-30.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_boxbox)
@@ -2979,32 +3012,32 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_boxbox)
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position. The current result is (1, 0, 0).
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position. The current result is (1, 0, 0).
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(15, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(15.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(q);
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 
   tf1 = transform;
   tf2 = transform * Transform3f(q);
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, 0x0);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spherebox)
@@ -3025,31 +3058,31 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spherebox)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(22.5, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-7);  // built-in GJK solver requires larger tolerance than libccd
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-7);  // built-in GJK solver requires larger tolerance than libccd
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(22.51, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(22.4, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-2);  // built-in GJK solver requires larger tolerance than libccd
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, 1e-2);  // built-in GJK solver requires larger tolerance than libccd
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(22.4, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
   // built-in GJK solver returns incorrect normal.
   // testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 }
@@ -3072,32 +3105,32 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spherecapsule)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(24.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(24.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(25, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(25.1, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_cylindercylinder)
@@ -3118,32 +3151,32 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_cylindercylinder)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(9.9, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(9.9, 0, 0));
   normal = transform.getRotation() * Vec3f(1, 0, 0);
-  testShapeIntersection(s1, tf1, s2, tf2, true);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10, 0, 0));
   normal << 1, 0, 0;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.01, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecone)
@@ -3164,41 +3197,41 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecone)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   // z=0 is a singular points. Two normals could be returned.
   tf2 = Transform3f(Vec3f(9.9, 0, 0.00001));
   normal = Vec3f(2*(s1.halfLength + s2.halfLength), 0, s1.radius+s2.radius).normalized();
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform * tf1;
   tf2 = transform * tf2;
   normal = transform.getRotation() * normal;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10.1, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10.1, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 9.9));
   normal << 0, 0, 1;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 9.9));
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecylinder)
@@ -3219,47 +3252,47 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecylinder)
   tf1 = Transform3f();
   tf2 = Transform3f();
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform;
   // TODO: Need convention for normal when the centers of two objects are at same position.
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(9.9, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(9.9, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(10, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(10, 0, 0));
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, NULL);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 9.9));
   normal << 0, 0, 1;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 9.9));
   normal = transform.getRotation() * Vec3f(0, 0, 1);
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = Transform3f();
   tf2 = Transform3f(Vec3f(0, 0, 10));
   normal << 0, 0, 1;
-  testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, true, NULL, NULL, &normal, false, tol_gjk);
 
   tf1 = transform;
   tf2 = transform * Transform3f(Vec3f(0, 0, 10.1));
-  testShapeIntersection(s1, tf1, s2, tf2, false);
+  SET_LINE; testShapeIntersection(s1, tf1, s2, tf2, false);
 }
 
 
@@ -3761,7 +3794,7 @@ BOOST_AUTO_TEST_CASE(reversibleShapeDistance_allshapes)
 //  testReversibleShapeDistance(box, plane, distance);
 //  testReversibleShapeDistance(box, halfspace, distance);
 
-  testReversibleShapeDistance(sphere, capsule, distance);
+  SET_LINE; testReversibleShapeDistance(sphere, capsule, distance);
 //  testReversibleShapeDistance(sphere, cone, distance);
 //  testReversibleShapeDistance(sphere, cylinder, distance);
 //  testReversibleShapeDistance(sphere, plane, distance);

--- a/test/obb.cpp
+++ b/test/obb.cpp
@@ -159,7 +159,7 @@ typedef boost::chrono::high_resolution_clock clock_type;
 typedef clock_type::duration duration_type;
 
 const char* sep = ",\t"; 
-const FCL_REAL eps = 1e-10;
+const FCL_REAL eps = 1.5e-7;
 
 const Eigen::IOFormat py_fmt(Eigen::FullPrecision,
     0,

--- a/test/sphere_capsule.cpp
+++ b/test/sphere_capsule.cpp
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (0., 0., 200));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+        FCL_REAL distance;
+	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, distance, false, NULL, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z_negative)
@@ -75,7 +76,8 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z_negative)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (0., 0., -200));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+        FCL_REAL distance;
+	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, distance, false, NULL, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_x)
@@ -89,7 +91,8 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_x)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (150., 0., 0.));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+        FCL_REAL distance;
+	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, distance, false, NULL, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_capsule_rotated)
@@ -106,7 +109,8 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_capsule_rotated)
         setEulerZYX(rotation, M_PI * 0.5, 0., 0.);
 	Transform3f capsule_transform (rotation, Vec3f (150., 0., 0.));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+        FCL_REAL distance;
+	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, distance, false, NULL, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_penetration_z)


### PR DESCRIPTION
This fixes the two points raised in #147: 
- EPA failure on a pair of boxes,
- the uninitialized values when EPA fails.

The other commits are related to other changes.

### EPA failures
There is one EPA failure which I was not able to fix. It is due to the addition of parallel faces in the envelop built by EPA. This case should be handled in EPA::expand function.

### API of GJKSolver::shapeIntersect

Currently, a collision query between two shapes ends up in calculating the signed distance between the shapes. For pairs which use GJK / EPA to compute the signed distance, this is very costly because : 
- it isn't possible to break GJK as soon as it proves non-collision (or that a certain safety margin is ensured). This is especially useful for continuous shape.
- EPA is run even when not necessary.

This PRs fixes the old FCL API of shapeIntersect so that a distance lower bound can be computed. I won't have time to complete it now so I prefer to submit it as is. What is left for later is:
- make GJKSolver able to set the distanceEarlyBreak in GJK according to the requested security margin and break distance,
- modify the ShapeShapeCollide so that they use the ShapeCollisionTraversalNode.
Both changes should not be hard but they need to be carefully tested.