### PR TITLE
Fix Python 3 doc generation

### DIFF
--- a/doc/python/xml_docstring.py
+++ b/doc/python/xml_docstring.py
@@ -69,10 +69,13 @@ class XmlDocString (object):
         if detailled is not None and len(detailled.getchildren()) > 0:
             if brief is not None: self._newline ()
             self.visit (detailled)
-        from sys import stdout, stderr
+        from sys import stdout, stderr, version_info
         self.writeErrors(output)
         self._clean()
-        return self._linesep.join(self.lines).encode("utf-8")
+        if version_info[0] == 2:
+            return self._linesep.join(self.lines).encode("utf-8")
+        else:
+            return self._linesep.join(self.lines)
 
     def visit (self, node):
         assert isinstance(node.tag, str)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>hpp-fcl</name>
-  <version>1.4.3</version>
+  <version>1.4.5</version>
   <description>An extension of the Flexible Collision Library.</description>
   <!-- The maintainer listed here is for the ROS release to receive emails for the buildfarm. 
   Please check the repository URL for full list of authors and maintainers. -->


### PR DESCRIPTION
This also bump the version in the package.xml.

I set it to the next release number because I think the devel branch should have a version number higher that the last release (except when they match, if course). On the practical aspect, this allows you to use stuff like `#ifdef HPP_FCL_VERSION_AT_LEAST(current devel version)` which will work with the next release.
Of course, we don't know yet whether next release will be 1.4.5 or 1.5 of 2.0 and we can adjust it upon release.