### PR TITLE
Add DistanceFunctor

### DIFF
--- a/include/hpp/fcl/collision.h
+++ b/include/hpp/fcl/collision.h
@@ -109,7 +109,7 @@ public:
     std::size_t res;
     if (swap_geoms) {
       res = func(o2, tf2, o1, tf1, &solver, request, result);
-      invertResults(result);
+      result.swapObjects();
     } else {
       res = func (o1, tf1, o2, tf2, &solver, request, result);
     }

--- a/include/hpp/fcl/collision.h
+++ b/include/hpp/fcl/collision.h
@@ -42,6 +42,7 @@
 #include <hpp/fcl/data_types.h>
 #include <hpp/fcl/collision_object.h>
 #include <hpp/fcl/collision_data.h>
+#include <hpp/fcl/collision_func_matrix.h>
 
 namespace hpp
 {
@@ -83,8 +84,60 @@ inline std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   request.updateGuess (result);
   return res;
 }
-}
 
+/// This class reduces the cost of identifying the geometry pair.
+/// This is mostly useful for repeated shape-shape queries.
+///
+/// \code
+///   ComputeCollision calc_collision (o1, o2);
+///   std::size_t ncontacts = calc_collision(tf1, tf2, request, result);
+/// \endcode
+class HPP_FCL_DLLAPI ComputeCollision {
+public:
+  ComputeCollision(const CollisionGeometry* o1, const CollisionGeometry* o2);
+
+  std::size_t operator()(const Transform3f& tf1, const Transform3f& tf2,
+      const CollisionRequest& request, CollisionResult& result)
+  {
+    bool cached = request.enable_cached_gjk_guess;
+    solver.enable_cached_guess = cached;
+    if (cached) {
+      solver.cached_guess = request.cached_gjk_guess;
+      solver.support_func_cached_guess = request.cached_support_func_guess;
+    }
+
+    std::size_t res;
+    if (swap_geoms) {
+      res = func(o2, tf2, o1, tf1, &solver, request, result);
+      invertResults(result);
+    } else {
+      res = func (o1, tf1, o2, tf2, &solver, request, result);
+    }
+
+    if (cached) {
+      result.cached_gjk_guess = solver.cached_guess;
+      result.cached_support_func_guess = solver.support_func_cached_guess;
+    }
+    return res;
+  }
+
+  inline std::size_t operator()(const Transform3f& tf1, const Transform3f& tf2,
+      CollisionRequest& request, CollisionResult& result)
+  {
+    std::size_t res = operator()(tf1, tf2, (const CollisionRequest&) request, result);
+    request.updateGuess (result);
+    return res;
+  }
+
+private:
+  CollisionGeometry const *o1, *o2;
+  GJKSolver solver;
+
+  CollisionFunctionMatrix::CollisionFunc func;
+  bool swap_geoms;
+};
+
+} // namespace fcl
 } // namespace hpp
 
 #endif

--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -334,7 +334,7 @@ public:
 
   /// @brief reposition Contact objects when fcl inverts them
   /// during their construction.
-  friend void invertResults(CollisionResult& result);
+  void swapObjects();
 };
 
 struct DistanceResult;

--- a/python/collision.cc
+++ b/python/collision.cc
@@ -179,4 +179,12 @@ void exposeCollisionAPI ()
         const CollisionGeometry*, const Transform3f&,
         const CollisionGeometry*, const Transform3f&,
         CollisionRequest&, CollisionResult&) > (&collide));
+
+  class_<ComputeCollision> ("ComputeCollision",
+      doxygen::class_doc<ComputeCollision>(), no_init)
+    .def (dv::init<ComputeCollision, const CollisionGeometry*, const CollisionGeometry*>())
+    .def ("__call__", static_cast< std::size_t (ComputeCollision::*)(
+        const Transform3f&, const Transform3f&,
+        CollisionRequest&, CollisionResult&) > (&ComputeCollision::operator()));
+
 }

--- a/python/distance.cc
+++ b/python/distance.cc
@@ -132,4 +132,12 @@ void exposeDistanceAPI ()
         const CollisionGeometry*, const Transform3f&,
         const CollisionGeometry*, const Transform3f&,
         DistanceRequest&, DistanceResult&) > (&distance));
+
+  class_<ComputeDistance> ("ComputeDistance",
+      doxygen::class_doc<ComputeDistance>(), no_init)
+    .def (dv::init<ComputeDistance, const CollisionGeometry*, const CollisionGeometry*>())
+    .def ("__call__", static_cast< FCL_REAL (ComputeDistance::*)(
+        const Transform3f&, const Transform3f&,
+        DistanceRequest&, DistanceResult&) > (&ComputeDistance::operator()));
+
 }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -54,14 +54,14 @@ CollisionFunctionMatrix& getCollisionFunctionLookTable()
 }
 
 // reorder collision results in the order the call has been made.
-void invertResults(CollisionResult& result)
+void CollisionResult::swapObjects()
 {
-    for(std::vector<Contact>::iterator it = result.contacts.begin();
-        it != result.contacts.end(); ++it)
-    {
-        std::swap(it->o1, it->o2);
-        std::swap(it->b1, it->b2);
-    }
+  for(std::vector<Contact>::iterator it = contacts.begin();
+      it != contacts.end(); ++it)
+  {
+    std::swap(it->o1, it->o2);
+    std::swap(it->b1, it->b2);
+  }
 }
 
 std::size_t collide(const CollisionObject* o1, const CollisionObject* o2,
@@ -108,7 +108,7 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
       else
       {
         res = looktable.collision_matrix[node_type2][node_type1](o2, tf2, o1, tf1, &solver, request, result);
-        invertResults(result);
+        result.swapObjects();
       }
     }
     else

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -56,17 +56,11 @@ CollisionFunctionMatrix& getCollisionFunctionLookTable()
 // reorder collision results in the order the call has been made.
 void invertResults(CollisionResult& result)
 {
-    const CollisionGeometry* otmp;
-    int btmp;
     for(std::vector<Contact>::iterator it = result.contacts.begin();
         it != result.contacts.end(); ++it)
     {
-        otmp = it->o1;
-        it->o1 = it->o2;
-        it->o2 = otmp;
-        btmp = it->b1;
-        it->b1 = it->b2;
-        it->b2 = btmp;
+        std::swap(it->o1, it->o2);
+        std::swap(it->b1, it->b2);
     }
 }
 
@@ -136,7 +130,32 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   return res;
 }
 
+ComputeCollision::ComputeCollision(const CollisionGeometry* o1,
+    const CollisionGeometry* o2)
+  : o1(o1), o2(o2)
+{
+  const CollisionFunctionMatrix& looktable = getCollisionFunctionLookTable();
+
+  OBJECT_TYPE object_type1 = o1->getObjectType();
+  NODE_TYPE node_type1 = o1->getNodeType();
+  OBJECT_TYPE object_type2 = o2->getObjectType();
+  NODE_TYPE node_type2 = o2->getNodeType();
+
+  swap_geoms = object_type1 == OT_GEOM && object_type2 == OT_BVH;
+
+  if(   ( swap_geoms && !looktable.collision_matrix[node_type2][node_type1])
+     || (!swap_geoms && !looktable.collision_matrix[node_type1][node_type2]))
+  {
+    std::ostringstream oss;
+    oss << "Warning: collision function between node type " << node_type1 <<
+      " and node type " << node_type2 << " is not supported";
+    throw std::invalid_argument(oss.str());
+  }
+  if (swap_geoms)
+    func = looktable.collision_matrix[node_type2][node_type1];
+  else
+    func = looktable.collision_matrix[node_type1][node_type2];
 }
 
-
+} // namespace fcl
 } // namespace hpp

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -119,7 +119,32 @@ FCL_REAL distance(const CollisionGeometry* o1, const Transform3f& tf1,
   return res;
 }
 
+ComputeDistance::ComputeDistance(const CollisionGeometry* o1,
+    const CollisionGeometry* o2)
+  : o1(o1), o2(o2)
+{
+  const DistanceFunctionMatrix& looktable = getDistanceFunctionLookTable();
 
+  OBJECT_TYPE object_type1 = o1->getObjectType();
+  NODE_TYPE node_type1 = o1->getNodeType();
+  OBJECT_TYPE object_type2 = o2->getObjectType();
+  NODE_TYPE node_type2 = o2->getNodeType();
+
+  swap_geoms = object_type1 == OT_GEOM && object_type2 == OT_BVH;
+
+  if(   ( swap_geoms && !looktable.distance_matrix[node_type2][node_type1])
+     || (!swap_geoms && !looktable.distance_matrix[node_type1][node_type2]))
+  {
+    std::ostringstream oss;
+    oss << "Warning: distance function between node type " << node_type1 <<
+      " and node type " << node_type2 << " is not supported";
+    throw std::invalid_argument(oss.str());
+  }
+  if (swap_geoms)
+    func = looktable.distance_matrix[node_type2][node_type1];
+  else
+    func = looktable.distance_matrix[node_type1][node_type2];
 }
 
+} // namespace fcl
 } // namespace hpp


### PR DESCRIPTION
This is a draft to open discussions on removing the overhead introduced by hpp-fcl design.

The following benchmark for capsule-capsule distance shows that a hpp-fcl design introduces about 12ns per call, which is about 23% of the current cost. The attempt to remove this cost proposed here makes the overhead drop to 2ns, so less than 5%.

**NOTE** this figures should be taken with care.

```c++
#include <hpp/fcl/shape/geometric_shapes.h>
#include <hpp/fcl/distance.h>
#include "../src/distance_func_matrix.h"
#include "utility.h"

#include <iostream>
#include <chrono>

template<typename TimeT = std::chrono::milliseconds>
struct measure
{
    template<typename F, typename ...Args>
    static typename TimeT::rep execution(F&& func, Args&&... args)
    {
        auto start = std::chrono::steady_clock::now();
        std::forward<decltype(func)>(func)(std::forward<Args>(args)...);
        auto duration = std::chrono::duration_cast< TimeT>
                            (std::chrono::steady_clock::now() - start);
        return duration.count();
    }
};

using namespace hpp::fcl;

std::vector<Transform3f> transforms;
Transform3f Id;

Capsule c1 (0.2, 1.),
        c2 (0.12, 0.7);

DistanceRequest request (true);

void with_hpp_fcl_overhead ()
{
  for (auto M : transforms) {
    DistanceResult result;
    distance(&c1, Id, &c2, M, request, result);
  }
}

void with_minimal_hpp_fcl_overhead ()
{
  DistanceFunctor func (&c1, &c2);
  for (auto M : transforms) {
    DistanceResult result;
    func.distance(Id, M, request, result);
  }
}

void without_hpp_fcl_overhead ()
{
  for (auto M : transforms) {
    DistanceResult result;
    ShapeShapeDistance<Capsule, Capsule>(&c1, Id, &c2, M, NULL, request, result);
  }
}

int main ()
{
  FCL_REAL extends[] = { 2, 2, 2, 2, 2, 2 };
  int n = 1e7;
  generateRandomTransforms(extends, transforms, n);

  using std::chrono::nanoseconds;
  std::cout << "current  : " << measure<nanoseconds>::execution(with_hpp_fcl_overhead            ) / n << std::endl;
  std::cout << "new      : " << measure<nanoseconds>::execution(with_minimal_hpp_fcl_overhead    ) / n << std::endl;
  std::cout << "smallest : " << measure<nanoseconds>::execution(without_hpp_fcl_overhead         ) / n << std::endl;

  return 0;
}
```
gives something like
```
current  : 60
new      : 48
smallest : 46
```