### PR TITLE
Add CollisionResult::nearest_points

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -314,6 +314,18 @@ public:
       return contacts.back();
   }
 
+  /// @brief get the i-th contact calculated
+  void setContact(size_t i, const Contact& c)
+  {
+    if(contacts.size() == 0)
+      throw std::invalid_argument("The number of contacts is zero. No Contact can be returned.");
+    
+    if(i < contacts.size()) 
+      contacts[i] = c;
+    else
+      contacts.back() = c;
+  }
+
   /// @brief get all the contacts
   void getContacts(std::vector<Contact>& contacts_) const
   {

--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -259,6 +259,11 @@ public:
   /// overhead).
   FCL_REAL distance_lower_bound;
 
+  /// @brief nearest points
+  /// available only when distance_lower_bound is inferior to
+  /// CollisionRequest::break_distance.
+  Vec3f nearest_points[2];
+
 public:
   CollisionResult()
     : distance_lower_bound ((std::numeric_limits<FCL_REAL>::max)())

--- a/include/hpp/fcl/internal/traversal_node_base.h
+++ b/include/hpp/fcl/internal/traversal_node_base.h
@@ -171,6 +171,29 @@ public:
   DistanceResult* result;
 };
 
+namespace internal {
+inline void updateDistanceLowerBoundFromBV (const CollisionRequest& req,
+    CollisionResult& res, const FCL_REAL& sqrDistLowerBound)
+{
+  // BV cannot find negative distance.
+  if (res.distance_lower_bound <= 0) return;
+  FCL_REAL new_dlb = std::sqrt(sqrDistLowerBound) - req.security_margin;
+  if (new_dlb < res.distance_lower_bound)
+    res.distance_lower_bound = new_dlb;
+}
+
+inline void updateDistanceLowerBoundFromLeaf (const CollisionRequest&,
+    CollisionResult& res, const FCL_REAL& distance,
+    const Vec3f& p0, const Vec3f& p1)
+{
+  if (distance < res.distance_lower_bound) {
+    res.distance_lower_bound = distance;
+    res.nearest_points[0] = p0;
+    res.nearest_points[1] = p1;
+  }
+}
+} // namespace internal
+
 ///@}
 
 }

--- a/include/hpp/fcl/internal/traversal_node_bvh_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_bvh_shape.h
@@ -196,10 +196,8 @@ public:
       disjoint = !overlap(this->tf1.getRotation(), this->tf1.getTranslation(),
                       this->model2_bv, this->model1->getBV(b1).bv,
                       this->request, sqrDistLowerBound);
-    if (   disjoint
-        && this->result->distance_lower_bound > 0
-        && sqrDistLowerBound < this->result->distance_lower_bound * this->result->distance_lower_bound)
-      this->result->distance_lower_bound = sqrt(sqrDistLowerBound);
+    if (disjoint)
+      internal::updateDistanceLowerBoundFromBV(this->request, *this->result, sqrDistLowerBound);
     assert (!disjoint || sqrDistLowerBound > 0);
     return disjoint;
   }
@@ -255,11 +253,9 @@ public:
       }
     } else
       sqrDistLowerBound = distance * distance;
-    if (distToCollision < this->result->distance_lower_bound) {
-      this->result->distance_lower_bound = distToCollision;
-      this->result->nearest_points[0] = c1;
-      this->result->nearest_points[1] = c2;
-    }
+
+    internal::updateDistanceLowerBoundFromLeaf(this->request,
+        *this->result, distToCollision, c1, c2);
 
     assert (this->result->isCollision () || sqrDistLowerBound > 0);
   }
@@ -314,10 +310,8 @@ public:
       disjoint = !overlap(this->tf2.getRotation(), this->tf2.getTranslation(),
                      this->model1_bv, this->model2->getBV(b2).bv,
                      sqrDistLowerBound);
-    if (disjoint
-        && this->result->distance_lower_bound > 0
-        && sqrDistLowerBound < this->result->distance_lower_bound * this->result->distance_lower_bound)
-      this->result->distance_lower_bound = sqrt(sqrDistLowerBound);
+    if (disjoint)
+      internal::updateDistanceLowerBoundFromBV(this->request, *this->result, sqrDistLowerBound);
     assert (!disjoint || sqrDistLowerBound > 0);
     return disjoint;
   }
@@ -352,17 +346,6 @@ public:
                                           this->tf2, c1, c2, distance, normal);
     }
 
-    if (collision) {
-      if(this->request.num_max_contacts > this->result->numContacts())
-      {  
-        this->result->addContact (Contact(this->model1 , this->model2,
-                                          Contact::NONE, primitive_id,
-                                          c1, normal, -distance));
-        assert (this->result->isCollision ());
-        return;
-      }
-    }
-
     FCL_REAL distToCollision = distance - this->request.security_margin;
     if(collision) {
       sqrDistLowerBound = 0;
@@ -384,11 +367,9 @@ public:
       }
     } else
       sqrDistLowerBound = distToCollision * distToCollision;
-    if (distToCollision < this->result->distance_lower_bound) {
-      this->result->distance_lower_bound = distToCollision;
-      this->result->nearest_points[0] = c1;
-      this->result->nearest_points[1] = c2;
-    }
+
+    internal::updateDistanceLowerBoundFromLeaf(this->request,
+        *this->result, distToCollision, c1, c2);
 
     assert (this->result->isCollision () || sqrDistLowerBound > 0);
   }

--- a/include/hpp/fcl/internal/traversal_node_bvhs.h
+++ b/include/hpp/fcl/internal/traversal_node_bvhs.h
@@ -188,10 +188,8 @@ public:
           this->request, sqrDistLowerBound);
       assert (!disjoint || sqrDistLowerBound > 0);
     }
-    if (   disjoint
-        && this->result->distance_lower_bound > 0
-        && sqrDistLowerBound < this->result->distance_lower_bound * this->result->distance_lower_bound)
-      this->result->distance_lower_bound = sqrt(sqrDistLowerBound);
+    if (disjoint)
+      internal::updateDistanceLowerBoundFromBV(this->request, *this->result, sqrDistLowerBound);
     return disjoint;
   }
 
@@ -257,11 +255,9 @@ public:
       }
     } else 
       sqrDistLowerBound = distToCollision * distToCollision;
-    if (distToCollision < this->result->distance_lower_bound) {
-      this->result->distance_lower_bound = distToCollision;
-      this->result->nearest_points[0] = p1;
-      this->result->nearest_points[1] = p2;
-    }
+
+    internal::updateDistanceLowerBoundFromLeaf(this->request,
+        *this->result, distToCollision, p1, p2);
   }
 
   Vec3f* vertices1;

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -46,6 +46,7 @@
 #include <hpp/fcl/octree.h>
 #include <hpp/fcl/BVH/BVH_model.h>
 #include <hpp/fcl/shape/geometric_shapes_utility.h>
+#include <hpp/fcl/internal/shape_shape_func.h>
 
 namespace hpp
 {
@@ -294,69 +295,8 @@ private:
                                    const S& s, const OBB& obb2,
                                    const Transform3f& tf1, const Transform3f& tf2) const
   {
-    if(!root1)
-    {
-      OBB obb1;
-      convertBV(bv1, tf1, obb1);
-      if(obb1.overlap(obb2))
-      {
-        Box box;
-        Transform3f box_tf;
-        constructBox(bv1, tf1, box, box_tf);
-
-        FCL_REAL distance;
-        if(solver->shapeIntersect(box, box_tf, s, tf2, distance, false, NULL, NULL))
-        {
-          AABB overlap_part;
-          AABB aabb1, aabb2;
-          computeBV<AABB, Box>(box, box_tf, aabb1);
-          computeBV<AABB, S>(s, tf2, aabb2);
-          aabb1.overlap(aabb2, overlap_part);
-        }
-      }
-
-      return false;
-    }
-    else if(!tree1->nodeHasChildren(root1))
-    {
-      if(tree1->isNodeOccupied(root1)) // occupied area
-      {
-        OBB obb1;
-        convertBV(bv1, tf1, obb1);
-        if(obb1.overlap(obb2))
-        {
-          Box box;
-          Transform3f box_tf;
-          constructBox(bv1, tf1, box, box_tf);
-
-          FCL_REAL distance;
-          if(!crequest->enable_contact)
-          {
-            if(solver->shapeIntersect(box, box_tf, s, tf2, distance, false, NULL, NULL))
-            {
-              if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, &s, static_cast<int>(root1 - tree1->getRoot()), Contact::NONE));
-            }
-          }
-          else
-          {
-            Vec3f contact;
-            Vec3f normal;
-
-            if(solver->shapeIntersect(box, box_tf, s, tf2, distance, true, &contact, &normal))
-            {
-              if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, &s, static_cast<int>(root1 - tree1->getRoot()), Contact::NONE, contact, normal, distance));
-            }
-          }
-
-          return crequest->isSatisfied(*cresult);
-        }
-        else return false;
-      }
-      else // free area
-        return false;
-    }
+    // Empty OcTree is considered free.
+    if(!root1) return false;
 
     /// stop when 1) bounding boxes of two objects not overlap; OR
     ///           2) at least of one the nodes is free; OR
@@ -367,7 +307,35 @@ private:
     {
       OBB obb1;
       convertBV(bv1, tf1, obb1);
-      if(!obb1.overlap(obb2)) return false;
+      FCL_REAL sqrDistLowerBound;
+      if(!obb1.overlap(obb2, *crequest, sqrDistLowerBound)) {
+        internal::updateDistanceLowerBoundFromBV(*crequest, *cresult, sqrDistLowerBound);
+        return false;
+      }
+    }
+
+    if(!tree1->nodeHasChildren(root1))
+    {
+      assert(tree1->isNodeOccupied(root1)); // it isn't free nor uncertain.
+
+      Box box;
+      Transform3f box_tf;
+      constructBox(bv1, tf1, box, box_tf);
+
+      bool contactNotAdded = (cresult->numContacts() >= crequest->num_max_contacts);
+      std::size_t ncontact = ShapeShapeCollide<Box, S>(&box, box_tf,
+          &s, tf2, solver, *crequest, *cresult);
+      assert(ncontact == 0 || ncontact == 1);
+      if (!contactNotAdded && ncontact == 1) {
+        // Update contact information.
+        const Contact& c = cresult->getContact(cresult->numContacts()-1);
+        cresult->setContact(cresult->numContacts()-1, Contact(
+              tree1, c.o2,
+              static_cast<int>(root1 - tree1->getRoot()), c.b2,
+              c.pos, c.normal, c.penetration_depth));
+      }
+
+      return crequest->isSatisfied(*cresult);
     }
 
     for(unsigned int i = 0; i < 8; ++i)
@@ -475,112 +443,19 @@ private:
   }
 
 
+  /// \return True if the request is satisfied.
   template<typename BV>
   bool OcTreeMeshIntersectRecurse(const OcTree* tree1, const OcTree::OcTreeNode* root1, const AABB& bv1,
                                   const BVHModel<BV>* tree2, int root2,
                                   const Transform3f& tf1, const Transform3f& tf2) const
   {
-    if(!root1)
-    {
-      if(tree2->getBV(root2).isLeaf())
-      {
-        OBB obb1, obb2;
-        convertBV(bv1, tf1, obb1);
-        convertBV(tree2->getBV(root2).bv, tf2, obb2);
-        if(obb1.overlap(obb2))
-        {
-          Box box;
-          Transform3f box_tf;
-          constructBox(bv1, tf1, box, box_tf);
+    // FIXME I do not understand why the BVHModel was traversed. The code in this
+    // if(!root1) did not output anything so the empty OcTree is considered free.
+    // Should an empty OcTree be considered free ?
 
-          int primitive_id = tree2->getBV(root2).primitiveId();
-          const Triangle& tri_id = tree2->tri_indices[primitive_id];
-          const Vec3f& p1 = tree2->vertices[tri_id[0]];
-          const Vec3f& p2 = tree2->vertices[tri_id[1]];
-          const Vec3f& p3 = tree2->vertices[tri_id[2]];
-          Vec3f c1, c2, normal;
-          FCL_REAL distance;
-          if(solver->shapeTriangleInteraction
-             (box, box_tf, p1, p2, p3, tf2, distance, c1, c2, normal))
-          {
-            AABB overlap_part;
-            AABB aabb1;
-            computeBV<AABB, Box>(box, box_tf, aabb1);
-            AABB aabb2(tf2.transform(p1), tf2.transform(p2), tf2.transform(p3));
-            aabb1.overlap(aabb2, overlap_part);
-          }
-        }
-
-        return false;
-      }
-      else
-      {
-        if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, tree2->getBV(root2).leftChild(), tf1, tf2))
-          return true;
-
-        if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, tree2->getBV(root2).rightChild(), tf1, tf2))
-          return true;
-
-        return false;
-      }
-    }
-    else if(!tree1->nodeHasChildren(root1) && tree2->getBV(root2).isLeaf())
-    {
-      if(tree1->isNodeOccupied(root1))
-      {
-        OBB obb1, obb2;
-        convertBV(bv1, tf1, obb1);
-        convertBV(tree2->getBV(root2).bv, tf2, obb2);
-        if(obb1.overlap(obb2))
-        {
-          Box box;
-          Transform3f box_tf;
-          constructBox(bv1, tf1, box, box_tf);
-
-          int primitive_id = tree2->getBV(root2).primitiveId();
-          const Triangle& tri_id = tree2->tri_indices[primitive_id];
-          const Vec3f& p1 = tree2->vertices[tri_id[0]];
-          const Vec3f& p2 = tree2->vertices[tri_id[1]];
-          const Vec3f& p3 = tree2->vertices[tri_id[2]];
-        
-          if(!crequest->enable_contact)
-          {
-            Vec3f c1, c2, normal;
-            FCL_REAL distance;
-            if(solver->shapeTriangleInteraction
-               (box, box_tf, p1, p2, p3, tf2, distance, c1, c2, normal))
-            {
-              if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, tree2,
-                                            (int)(root1 - tree1->getRoot()),
-                                            primitive_id));
-            }
-          }
-          else
-          {
-            Vec3f c1, c2;
-            FCL_REAL distance;
-            Vec3f normal;
-
-            if(solver->shapeTriangleInteraction(box, box_tf, p1, p2, p3, tf2,
-                                                distance, c1, c2, normal))
-            {
-              assert (crequest->security_margin == 0);
-              if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact
-                  (Contact(tree1, tree2, (int) (root1 - tree1->getRoot()),
-                           primitive_id, c1, normal, -distance));
-            }
-          }
-
-          return crequest->isSatisfied(*cresult);
-        }
-        else
-          return false;
-      }
-      else // free area
-        return false;
-    }
+    // Empty OcTree is considered free.
+    if(!root1) return false;
+    BVNode<BV> const& bvn2 = tree2->getBV(root2);
 
     /// stop when 1) bounding boxes of two objects not overlap; OR
     ///           2) at least one of the nodes is free; OR
@@ -592,11 +467,55 @@ private:
     {
       OBB obb1, obb2;
       convertBV(bv1, tf1, obb1);
-      convertBV(tree2->getBV(root2).bv, tf2, obb2);
-      if(!obb1.overlap(obb2)) return false;      
+      convertBV(bvn2.bv, tf2, obb2);
+      FCL_REAL sqrDistLowerBound;
+      if(!obb1.overlap(obb2, *crequest, sqrDistLowerBound)) {
+        internal::updateDistanceLowerBoundFromBV(*crequest, *cresult, sqrDistLowerBound);
+        return false;
+      }
     }
-   
-    if(tree2->getBV(root2).isLeaf() || (tree1->nodeHasChildren(root1) && (bv1.size() > tree2->getBV(root2).bv.size())))
+
+    // Check if leaf collides.
+    if(!tree1->nodeHasChildren(root1) && bvn2.isLeaf())
+    {
+      assert(tree1->isNodeOccupied(root1)); // it isn't free nor uncertain.
+      Box box;
+      Transform3f box_tf;
+      constructBox(bv1, tf1, box, box_tf);
+
+      int primitive_id = bvn2.primitiveId();
+      const Triangle& tri_id = tree2->tri_indices[primitive_id];
+      const Vec3f& p1 = tree2->vertices[tri_id[0]];
+      const Vec3f& p2 = tree2->vertices[tri_id[1]];
+      const Vec3f& p3 = tree2->vertices[tri_id[2]];
+
+      Vec3f c1, c2, normal;
+      FCL_REAL distance;
+
+      bool collision = solver->shapeTriangleInteraction
+         (box, box_tf, p1, p2, p3, tf2, distance, c1, c2, normal);
+      FCL_REAL distToCollision = distance - crequest->security_margin;
+
+      if(cresult->numContacts() < crequest->num_max_contacts) {
+        if(collision) {
+          cresult->addContact (Contact(
+                tree1, tree2,
+                (int) (root1 - tree1->getRoot()), primitive_id,
+                c1, normal, -distance));
+        } else if (distToCollision < 0) {
+          cresult->addContact (Contact(
+                tree1, tree2,
+                (int) (root1 - tree1->getRoot()), primitive_id,
+                .5 * (c1+c2), (c2-c1).normalized (), -distance));
+        }
+      }
+      internal::updateDistanceLowerBoundFromLeaf(*crequest, *cresult, distToCollision, c1, c2);
+
+      return crequest->isSatisfied(*cresult);
+    }
+
+    // Determine which tree to traverse first.
+    if(bvn2.isLeaf() || (tree1->nodeHasChildren(root1) && (bv1.size() > bvn2.bv.size())))
     {
       for(unsigned int i = 0; i < 8; ++i)
       {
@@ -613,10 +532,10 @@ private:
     }
     else
     {
-      if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, tree2->getBV(root2).leftChild(), tf1, tf2))
+      if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, bvn2.leftChild(), tf1, tf2))
         return true;
 
-      if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, tree2->getBV(root2).rightChild(), tf1, tf2))
+      if(OcTreeMeshIntersectRecurse(tree1, root1, bv1, tree2, bvn2.rightChild(), tf1, tf2))
         return true;      
 
     }
@@ -712,128 +631,9 @@ private:
                               const OcTree* tree2, const OcTree::OcTreeNode* root2, const AABB& bv2,
                               const Transform3f& tf1, const Transform3f& tf2) const
   {
-    if(!root1 && !root2)
-    {
-      OBB obb1, obb2;
-      convertBV(bv1, tf1, obb1);
-      convertBV(bv2, tf2, obb2);
-
-      if(obb1.overlap(obb2))
-      {
-        Box box1, box2;
-        Transform3f box1_tf, box2_tf;
-        constructBox(bv1, tf1, box1, box1_tf);
-        constructBox(bv2, tf2, box2, box2_tf);
-        
-        AABB overlap_part;
-        AABB aabb1, aabb2;
-        computeBV<AABB, Box>(box1, box1_tf, aabb1);
-        computeBV<AABB, Box>(box2, box2_tf, aabb2);
-        aabb1.overlap(aabb2, overlap_part);
-      }
-
-      return false;
-    }
-    else if(!root1 && root2)
-    {
-      if(tree2->nodeHasChildren(root2))
-      {
-        for(unsigned int i = 0; i < 8; ++i)
-        {
-          if(tree2->nodeChildExists(root2, i))
-          {
-            const OcTree::OcTreeNode* child = tree2->getNodeChild(root2, i);
-            AABB child_bv;
-            computeChildBV(bv2, i, child_bv);
-            if(OcTreeIntersectRecurse(tree1, NULL, bv1, tree2, child, child_bv, tf1, tf2))
-              return true;
-          }
-          else 
-          {
-            AABB child_bv;
-            computeChildBV(bv2, i, child_bv);
-            if(OcTreeIntersectRecurse(tree1, NULL, bv1, tree2, NULL, child_bv, tf1, tf2))
-              return true;
-          }
-        }
-      }
-      else
-      {
-        if(OcTreeIntersectRecurse(tree1, NULL, bv1, tree2, NULL, bv2, tf1, tf2))
-          return true;
-      }
-      
-      return false;
-    }
-    else if(root1 && !root2)
-    {
-      if(tree1->nodeHasChildren(root1))
-      {
-        for(unsigned int i = 0; i < 8; ++i)
-        {
-          if(tree1->nodeChildExists(root1, i))
-          {
-            const OcTree::OcTreeNode* child = tree1->getNodeChild(root1, i);
-            AABB child_bv;
-            computeChildBV(bv1, i,  child_bv);
-            if(OcTreeIntersectRecurse(tree1, child, child_bv, tree2, NULL, bv2, tf1, tf2))
-              return true;
-          }
-          else
-          {
-            AABB child_bv;
-            computeChildBV(bv1, i, child_bv);
-            if(OcTreeIntersectRecurse(tree1, NULL, child_bv, tree2, NULL, bv2, tf1, tf2))
-              return true;
-          }
-        }
-      }
-      else
-      {
-        if(OcTreeIntersectRecurse(tree1, NULL, bv1, tree2, NULL, bv2, tf1, tf2))
-          return true;
-      }
-      
-      return false;
-    }
-    else if(!tree1->nodeHasChildren(root1) && !tree2->nodeHasChildren(root2))
-    {
-      if(tree1->isNodeOccupied(root1) && tree2->isNodeOccupied(root2)) // occupied area
-      {
-        if(!crequest->enable_contact)
-        {
-          OBB obb1, obb2;
-          convertBV(bv1, tf1, obb1);
-          convertBV(bv2, tf2, obb2);
-          
-          if(obb1.overlap(obb2))
-          {
-            if(cresult->numContacts() < crequest->num_max_contacts)
-              cresult->addContact(Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot())));
-          }
-        }
-        else
-        {
-          Box box1, box2;
-          Transform3f box1_tf, box2_tf;
-          constructBox(bv1, tf1, box1, box1_tf);
-          constructBox(bv2, tf2, box2, box2_tf);
-
-          Vec3f contact;
-          FCL_REAL distance;
-          Vec3f normal;
-          if(solver->shapeIntersect(box1, box1_tf, box2, box2_tf, distance, true, &contact, &normal))
-          {
-            if(cresult->numContacts() < crequest->num_max_contacts)
-              cresult->addContact(Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot()), contact, normal, distance));
-          }
-        }
-
-        return crequest->isSatisfied(*cresult);
-      }
-      else // free area (at least one node is free)
-        return false;
-    }
+    // Empty OcTree is considered free.
+    if(!root1) return false;
+    if(!root2) return false;
 
     /// stop when 1) bounding boxes of two objects not overlap; OR
     ///           2) at least one of the nodes is free; OR
@@ -841,14 +641,59 @@ private:
     if(tree1->isNodeFree(root1) || tree2->isNodeFree(root2)) return false;
     else if((tree1->isNodeUncertain(root1) || tree2->isNodeUncertain(root2)))
       return false;
-    else 
+
+    bool bothAreLeaves = (!tree1->nodeHasChildren(root1) && !tree2->nodeHasChildren(root2));
+    if(!bothAreLeaves || !crequest->enable_contact)
     {
       OBB obb1, obb2;
       convertBV(bv1, tf1, obb1);
       convertBV(bv2, tf2, obb2);
-      if(!obb1.overlap(obb2)) return false;
+      FCL_REAL sqrDistLowerBound;
+      if(!obb1.overlap(obb2, *crequest, sqrDistLowerBound)) {
+        if (   cresult->distance_lower_bound > 0
+            && sqrDistLowerBound < cresult->distance_lower_bound * cresult->distance_lower_bound)
+          cresult->distance_lower_bound = sqrt(sqrDistLowerBound) - crequest->security_margin;
+        return false;
+      }
+      if(!crequest->enable_contact) { // Overlap
+        if(cresult->numContacts() < crequest->num_max_contacts)
+          cresult->addContact(Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot())));
+        return crequest->isSatisfied(*cresult);
+      }
     }
 
+    // Both node are leaves
+    if(bothAreLeaves)
+    {
+      assert(tree1->isNodeOccupied(root1) && tree2->isNodeOccupied(root2));
+
+      Box box1, box2;
+      Transform3f box1_tf, box2_tf;
+      constructBox(bv1, tf1, box1, box1_tf);
+      constructBox(bv2, tf2, box2, box2_tf);
+
+      FCL_REAL distance;
+      Vec3f c1, c2, normal;
+      bool collision = solver->shapeDistance(box1, box1_tf, box2, box2_tf, distance, c1, c2, normal);
+      FCL_REAL distToCollision = distance - crequest->security_margin;
+
+      if(cresult->numContacts() < crequest->num_max_contacts) {
+        if(collision)
+          cresult->addContact(Contact(tree1, tree2,
+                static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot()),
+                c1, normal, -distance));
+        else if (distToCollision <= 0)
+          cresult->addContact(Contact(tree1, tree2,
+                static_cast<int>(root1 - tree1->getRoot()), static_cast<int>(root2 - tree2->getRoot()),
+                .5 * (c1+c2), (c2-c1).normalized (),
+                -distance));
+      }
+      internal::updateDistanceLowerBoundFromLeaf(*crequest, *cresult, distToCollision, c1, c2);
+
+      return crequest->isSatisfied(*cresult);
+    }
+
+    // Determine which tree to traverse first.
     if(!tree2->nodeHasChildren(root2) || (tree1->nodeHasChildren(root1) && (bv1.size() > bv2.size())))
     {
       for(unsigned int i = 0; i < 8; ++i)
@@ -1026,9 +871,11 @@ public:
     return false;
   }
 
-  void leafCollides(int, int, FCL_REAL&) const
+  void leafCollides(int, int, FCL_REAL& sqrDistLowerBound) const
   {
     otsolver->OcTreeMeshIntersect(model2, model1, tf2, tf1, request, *result);
+    sqrDistLowerBound = std::max((FCL_REAL)0, result->distance_lower_bound);
+    sqrDistLowerBound *= sqrDistLowerBound;
   }
 
   const BVHModel<BV>* model1;

--- a/src/collision_node.cpp
+++ b/src/collision_node.cpp
@@ -60,7 +60,13 @@ void collide(CollisionTraversalNodeBase* node,
       collisionRecurse(node, 0, 0, front_list, sqrDistLowerBound);
     else
       collisionNonRecurse(node, front_list, sqrDistLowerBound);
-    result.updateDistanceLowerBound (sqrt (sqrDistLowerBound));
+    if (!std::isnan(sqrDistLowerBound)) {
+      if (sqrDistLowerBound == 0) {
+        assert(result.distance_lower_bound <= 0);
+      } else {
+        assert(fabs(sqrDistLowerBound-result.distance_lower_bound*result.distance_lower_bound) < 1e-8);
+      }
+    }
   }
 }
 

--- a/src/distance/sphere_sphere.cpp
+++ b/src/distance/sphere_sphere.cpp
@@ -38,6 +38,7 @@
 #include <hpp/fcl/math/transform.h>
 #include <hpp/fcl/shape/geometric_shapes.h>
 #include <hpp/fcl/internal/shape_shape_func.h>
+#include <hpp/fcl/internal/traversal_node_base.h>
 
 // Note that partial specialization of template functions is not allowed.
 // Therefore, two implementations with the default narrow phase solvers are
@@ -122,8 +123,10 @@ namespace fcl {
     FCL_REAL penetrationDepth;
     // Unlike in distance computation, we consider the security margin.
     penetrationDepth = r1 + r2 + margin - dist;
-    bool collision = (penetrationDepth >= 0);
-    if (collision) {
+
+    internal::updateDistanceLowerBoundFromLeaf (request, result, -penetrationDepth,
+        center1 + unit * r1, center2 - unit * r2);
+    if (penetrationDepth >= 0) {
       // Take contact point at the middle of intersection between each sphere
       // and segment [c1 c2].
       FCL_REAL abscissa = .5 * r1 + .5 * (dist - r2);
@@ -132,7 +135,6 @@ namespace fcl {
       result.addContact (contact);
       return 1;
     }
-    result.updateDistanceLowerBound (-penetrationDepth);
     return 0;
   }
 } // namespace fcl


### PR DESCRIPTION
This supersedes #198 .

Work left to be done:
- [ ] agree on the API
- [x] handle shape-shape collision
- [ ] add some unit test
- [x] revise the distance lower bound (does not take the security margin).

Class ShapeCollisionTraversal should be removed.

As a bonus, this also solves #199.