### PR TITLE
[TraversalNodeBase] Remove duplicate member in derived class.

### DIFF
--- a/include/hpp/fcl/internal/traversal_node_base.h
+++ b/include/hpp/fcl/internal/traversal_node_base.h
@@ -133,8 +133,6 @@ public:
   /// @brief collision result kept during the traversal iteration
   CollisionResult* result;
 
-  /// @brief Whether stores statistics 
-  bool enable_statistics;
 };
 
 /// @}


### PR DESCRIPTION
enable_statistics was duplicated in derived class CollisionTraversalNodeBase.