### PR TITLE
Remove register keyword to fix #220

### DIFF
--- a/src/BV/OBB.cpp
+++ b/src/BV/OBB.cpp
@@ -163,7 +163,7 @@ inline OBB merge_smalldist(const OBB& b1, const OBB& b2)
 
 bool obbDisjoint(const Matrix3f& B, const Vec3f& T, const Vec3f& a, const Vec3f& b)
 {
-  register FCL_REAL t, s;
+  FCL_REAL t, s;
   const FCL_REAL reps = 1e-6;
 
   Matrix3f Bf (B.array().abs() + reps);
@@ -313,7 +313,7 @@ namespace internal
   {
     // Bf = |B|
     // | B^T T| - Bf^T * a - b
-    register FCL_REAL s, t = 0;
+    FCL_REAL s, t = 0;
     s = std::abs(B.col(0).dot(T)) - Bf.col(0).dot(a) - b[0];
     if (s > 0) t += s*s;
     s = std::abs(B.col(1).dot(T)) - Bf.col(1).dot(a) - b[1];

--- a/test/obb.cpp
+++ b/test/obb.cpp
@@ -213,7 +213,7 @@ namespace obbDisjoint_impls
     return AABB_corner.array().max(0).matrix().squaredNorm ();
     /*/
 #if MANUAL_PRODUCT
-    register FCL_REAL s, t = 0;
+    FCL_REAL s, t = 0;
     s = std::abs(B.col(0).dot(T)) - Bf.col(0).dot(a) - b[0];
     if (s > 0) t += s*s;
     s = std::abs(B.col(1).dot(T)) - Bf.col(1).dot(a) - b[1];
@@ -816,7 +816,7 @@ namespace obbDisjoint_impls
   // ------------------------ 5 --------------------------------------
   bool originalWithLowerBound (const Matrix3f& B, const Vec3f& T, const Vec3f& a, const Vec3f& b, const FCL_REAL& breakDistance2, FCL_REAL& squaredLowerBoundDistance)
   {
-    register FCL_REAL t, s;
+    FCL_REAL t, s;
     FCL_REAL diff;
 
     Matrix3f Bf (B.cwiseAbs());
@@ -1039,7 +1039,7 @@ namespace obbDisjoint_impls
   // ------------------------ 6 --------------------------------------
   bool originalWithNoLowerBound (const Matrix3f& B, const Vec3f& T, const Vec3f& a, const Vec3f& b, const FCL_REAL& , FCL_REAL& squaredLowerBoundDistance)
   {
-    register FCL_REAL t, s;
+    FCL_REAL t, s;
     const FCL_REAL reps = 1e-6;
 
     squaredLowerBoundDistance = 0;


### PR DESCRIPTION
The register keyword leads to a compile error for C++ standards newer
than or equal to C++17.