### PR TITLE
[Tests] add missing include

### DIFF
--- a/test/collision.cpp
+++ b/test/collision.cpp
@@ -38,6 +38,7 @@
 #define BOOST_CHRONO_VERSION 2
 #include <boost/chrono/chrono.hpp>
 #include <boost/chrono/chrono_io.hpp>
+#include <boost/mpl/vector.hpp>
 
 #define BOOST_TEST_MODULE FCL_COLLISION
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
fix for Boost 1.76.0:

```
/src/hpp-fcl/test/collision.cpp:228:9: error: no template named 'vector' in namespace 'boost::mpl'; did you mean 'boost::container::vector'?
typedef boost::mpl::vector<OBB, RSS, KDOP<24>, KDOP<18>, KDOP<16>, kIOS, OBBRSS> BVs_t;
        ^~~~~~~~~~~~~~~~~~
        boost::container::vector
/usr/local/include/boost/container/container_fwd.hpp:104:7: note: 'boost::container::vector' declared here
class vector;
      ^
/src/hpp-fcl/test/collision.cpp:228:21: error: too many template arguments for class template 'vector'
typedef boost::mpl::vector<OBB, RSS, KDOP<24>, KDOP<18>, KDOP<16>, kIOS, OBBRSS> BVs_t;
                    ^                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/container/container_fwd.hpp:104:7: note: template is declared here
class vector;
      ^
   ```