### PR TITLE
[CMake] use system Qhull if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,20 +108,29 @@ if(HPP_FCL_HAS_QHULL)
   if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD EQUAL 98)
     message(FATAL_ERROR "Cannot use qhull library with C++ < 11.\nYou may add -DCMAKE_CXX_STANDARD=11")
   endif()
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third-parties)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_SOURCE_DIR}/third-parties/qhull/src/libqhullcpp
-    ${CMAKE_CURRENT_BINARY_DIR}/third-parties/libqhullcpp
-    )
-  set(Qhullcpp_PREFIX ${CMAKE_BINARY_DIR}/third-parties)
-  find_path(Qhull_r_INCLUDE_DIR
-    NAMES libqhull_r/libqhull_r.h
-    PATHS ${Qhull_PREFIX}
-    )
-  find_library(Qhull_r_LIBRARY
-    NAMES libqhull_r.so
-    PATHS ${Qhull_PREFIX}
-    )
+  find_package(Qhull COMPONENTS qhull_r qhullcpp)
+  if(Qhull_FOUND)
+    set(HPP_FCL_USE_SYSTEM_QHULL TRUE)
+  else()
+    message(STATUS "Qhullcpp not found: it will be build from sources, if Qhull_r is found")
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third-parties)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+      ${CMAKE_SOURCE_DIR}/third-parties/qhull/src/libqhullcpp
+      ${CMAKE_CURRENT_BINARY_DIR}/third-parties/libqhullcpp
+      )
+    set(Qhullcpp_PREFIX ${CMAKE_BINARY_DIR}/third-parties)
+    find_path(Qhull_r_INCLUDE_DIR
+      NAMES libqhull_r/libqhull_r.h
+      PATHS ${Qhull_PREFIX}
+      )
+    find_library(Qhull_r_LIBRARY
+      NAMES libqhull_r.so
+      PATHS ${Qhull_PREFIX}
+      )
+    if(NOT Qhull_r_LIBRARY)
+      message(FATAL_ERROR "Qhull_r not found, please install it or turn HPP_FCL_HAS_QHULL OFF")
+    endif()
+  endif()
 endif()
 
 FIND_PACKAGE(assimp REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ if(HPP_FCL_HAS_OCTOMAP)
   list(APPEND ${LIBRARY_NAME}_SOURCES octree.cpp)
 endif(HPP_FCL_HAS_OCTOMAP)
 
-if(HPP_FCL_HAS_QHULL)
+if(HPP_FCL_HAS_QHULL AND NOT HPP_FCL_USE_SYSTEM_QHULL)
   set(
     libqhullcpp_HEADERS
     ${Qhullcpp_PREFIX}/libqhullcpp/Coordinates.h
@@ -188,9 +188,13 @@ ENDIF(WIN32)
 
 if(HPP_FCL_HAS_QHULL)
   target_compile_definitions(${LIBRARY_NAME} PRIVATE -DHPP_FCL_HAS_QHULL)
-  target_include_directories(${LIBRARY_NAME} SYSTEM PRIVATE
-    ${Qhull_r_INCLUDE_DIR} ${Qhullcpp_PREFIX})
-  target_link_libraries(${LIBRARY_NAME} PRIVATE "${Qhull_r_LIBRARY}")
+  if (HPP_FCL_USE_SYSTEM_QHULL)
+    target_link_libraries(${LIBRARY_NAME} PRIVATE Qhull::qhull_r Qhull::qhullcpp)
+  else()
+    target_include_directories(${LIBRARY_NAME} SYSTEM PRIVATE
+      ${Qhull_r_INCLUDE_DIR} ${Qhullcpp_PREFIX})
+    target_link_libraries(${LIBRARY_NAME} PRIVATE "${Qhull_r_LIBRARY}")
+  endif()
 endif()
 
 target_include_directories(${LIBRARY_NAME}


### PR DESCRIPTION
Hi,

As discussed in #201, I'm activating Qhull on robotpkg. 

Doing so, I noticed that some distributions are already providing qhullcpp, so in that case there is no need to build it. This PR implement this case.

I also checked in other cases, where Qhull is installed but without qhullcpp, that the configuration provided by @jmirabel works well.