### PR TITLE
tests: remove link to boost unit test framework

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,6 @@ macro(add_fcl_test test_name source)
   target_link_libraries(${test_name}
     PUBLIC
     hpp-fcl
-    Boost::unit_test_framework
     Boost::chrono
     Boost::filesystem
     Boost::timer


### PR DESCRIPTION
Hi,

This fix a very long standing bug, where unit tests would randomly segfault on exit, eg. [in CI](https://gitlab.laas.fr/humanoid-path-planner/hpp-fcl/-/jobs/141152):
```
14/19 Test #17: gjk ..............................Child aborted***Exception:   0.16 sec
Running 3 test cases...
nCol / nTotal = 2840 / 10000
nDiff = 0
Total / average time gjk: 6652, 6.652e-07s
-- Collisions -------------------------
Total / average time gjk: 1950, 6.8662e-07s
-- No collisions -------------------------
Total / average time gjk: 4702, 6.56704e-07s
*** No errors detected
malloc_consolidate(): invalid chunk size
```

This hit in many of our projects, but only on Debian, so we have just been ignoring most Debian CI job failures until now.

But this time, I noticed exactly the same issue on Arch, where 19 tests failed out of 25, always with: 
```
*** No errors detected
double free or corruption (fasttop)
```

for reference:
```
╰─>$ gdb ./build/test/gjk 
GNU gdb (GDB) 11.2
[…]
Reading symbols from ./build/test/gjk...
(gdb) r
Starting program: hpp-fcl/build/test/gjk 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
Running 3 test cases...
nCol / nTotal = 2840 / 10000
nDiff = 0
Total / average time gjk: 900612, 9.00612e-05s
-- Collisions -------------------------
Total / average time gjk: 269339, 9.48377e-05s
-- No collisions -------------------------
Total / average time gjk: 631273, 8.81666e-05s

*** No errors detected
double free or corruption (fasttop)

Program received signal SIGABRT, Aborted.
0x00007ffff6e2534c in __pthread_kill_implementation () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff6e2534c in __pthread_kill_implementation () from /usr/lib/libc.so.6
#1  0x00007ffff6dd84b8 in raise () from /usr/lib/libc.so.6
#2  0x00007ffff6dc2534 in abort () from /usr/lib/libc.so.6
#3  0x00007ffff6e19397 in __libc_message () from /usr/lib/libc.so.6
#4  0x00007ffff6e2f33c in malloc_printerr () from /usr/lib/libc.so.6
#5  0x00007ffff6e30f7a in _int_free () from /usr/lib/libc.so.6
#6  0x00007ffff6e33be3 in free () from /usr/lib/libc.so.6
#7  0x00007ffff6ddb0f7 in __cxa_finalize () from /usr/lib/libc.so.6
#8  0x00007ffff7ee2a08 in ?? () from /usr/lib/libboost_unit_test_framework.so.1.78.0
#9  0x00007fffffffd580 in ?? ()
#10 0x00007ffff7fcbc8e in _dl_fini () from /lib64/ld-linux-x86-64.so.2
Backtrace stopped: frame did not save the PC
```

and:
```
╰─>$ valgrind ./build/test/gjk
==1398455== Memcheck, a memory error detector
==1398455== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1398455== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==1398455== Command: ./build/test/gjk
==1398455== 
Running 3 test cases...
nCol / nTotal = 2840 / 10000
nDiff = 0
Total / average time gjk: 37746335, 0.00377463s
-- Collisions -------------------------
Total / average time gjk: 11489265, 0.00404552s
-- No collisions -------------------------
Total / average time gjk: 26257070, 0.00366719s

*** No errors detected
==1398455== Invalid free() / delete / delete[] / realloc()
==1398455==    at 0x48488AF: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1398455==    by 0x58BB0F6: __cxa_finalize (in /usr/lib/libc.so.6)
==1398455==    by 0x48C5A07: ??? (in /usr/lib/libboost_unit_test_framework.so.1.78.0)
==1398455==    by 0x4005C8D: _dl_fini (in /usr/lib/ld-linux-x86-64.so.2)
==1398455==    by 0x58BAC04: __run_exit_handlers (in /usr/lib/libc.so.6)
==1398455==    by 0x58BAD7F: exit (in /usr/lib/libc.so.6)
==1398455==    by 0x58A3316: (below main) (in /usr/lib/libc.so.6)
==1398455==  Address 0x6501d40 is 0 bytes inside a block of size 18 free'd
==1398455==    at 0x48488AF: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1398455==    by 0x58BAC04: __run_exit_handlers (in /usr/lib/libc.so.6)
==1398455==    by 0x58BAD7F: exit (in /usr/lib/libc.so.6)
==1398455==    by 0x58A3316: (below main) (in /usr/lib/libc.so.6)
==1398455==  Block was alloc'd at
==1398455==    at 0x4846013: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1398455==    by 0x445E97: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (basic_string.tcc:219)
==1398455==    by 0x42EE8C: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) (basic_string.h:539)
==1398455==    by 0x41509C: __static_initialization_and_destruction_0(int, int) (unit_test_parameters.ipp:97)
==1398455==    by 0x4159D1: _GLOBAL__sub_I__ZN5boost9unit_test6output22compiler_log_formatter9log_startERSom (gjk.cpp:406)
==1398455==    by 0x58A343A: __libc_start_main@@GLIBC_2.34 (in /usr/lib/libc.so.6)
==1398455==    by 0x3DCD74: (below main) (in hpp-fcl/build/test/gjk)
==1398455== 
==1398455== 
==1398455== HEAP SUMMARY:
==1398455==     in use at exit: 2,942 bytes in 25 blocks
==1398455==   total heap usage: 166,480 allocs, 166,460 frees, 11,146,341 bytes allocated
==1398455== 
==1398455== LEAK SUMMARY:
==1398455==    definitely lost: 102 bytes in 5 blocks
==1398455==    indirectly lost: 0 bytes in 0 blocks
==1398455==      possibly lost: 0 bytes in 0 blocks
==1398455==    still reachable: 2,840 bytes in 20 blocks
==1398455==         suppressed: 0 bytes in 0 blocks
==1398455== Rerun with --leak-check=full to see details of leaked memory
==1398455== 
==1398455== For lists of detected and suppressed errors, rerun with: -s
==1398455== ERROR SUMMARY: 5 errors from 1 contexts (suppressed: 0 from 0)
```

and:
```
╰─>$ ldd build/test/gjk
	linux-vdso.so.1 (0x00007fffc1b49000)
	libboost_unit_test_framework.so.1.78.0 => /usr/lib/libboost_unit_test_framework.so.1.78.0 (0x00007f2538407000)
	libboost_chrono.so.1.78.0 => /usr/lib/libboost_chrono.so.1.78.0 (0x00007f25383fc000)
	libboost_filesystem.so.1.78.0 => /usr/lib/libboost_filesystem.so.1.78.0 (0x00007f25383d7000)
	libboost_timer.so.1.78.0 => /usr/lib/libboost_timer.so.1.78.0 (0x00007f25383cd000)
	libhpp-fcl.so => hpp-fcl/build/src/libhpp-fcl.so (0x00007f25378ca000)
	libboost_serialization.so.1.78.0 => /usr/lib/libboost_serialization.so.1.78.0 (0x00007f2537882000)
	liboctomap.so.1.9 => /usr/lib/liboctomap.so.1.9 (0x00007f253781d000)
	liboctomath.so.1.9 => /usr/lib/liboctomath.so.1.9 (0x00007f2537815000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f25375ef000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f2537507000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f25374ec000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f25372e0000)
	librt.so.1 => /usr/lib/librt.so.1 (0x00007f25372db000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f25372d6000)
	libboost_atomic.so.1.78.0 => /usr/lib/libboost_atomic.so.1.78.0 (0x00007f25372cc000)
	libassimp.so.5 => /usr/lib/libassimp.so.5 (0x00007f2536ae4000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f25389d8000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f2536ac8000)
```

And the thing is that building Arch package still work, so the difference must be in the compilation flags for packages. And it make sense as default flags for Debian and Ubuntu are probably different on this point.

And with `export LDFLAGS=-Wl,--as-needed`, all test are passing fine. Also:
```
╰─>$ ldd build/test/gjk
	linux-vdso.so.1 (0x00007ffd0d88a000)
	libhpp-fcl.so => hpp-fcl/build/src/libhpp-fcl.so (0x00007f907f52e000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f907f2c0000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007f907f1d8000)
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f907f1bd000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f907efb3000)
	libassimp.so.5 => /usr/lib/libassimp.so.5 (0x00007f907e7c9000)
	liboctomap.so.1.9 => /usr/lib/liboctomap.so.1.9 (0x00007f907e764000)
	liboctomath.so.1.9 => /usr/lib/liboctomath.so.1.9 (0x00007f907e75c000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f907f8cf000)
	libz.so.1 => /usr/lib/libz.so.1 (0x00007f907e742000)
```

And for the sake of completeness:
```
╰─>$ valgrind ./build/test/gjk
==1410978== Memcheck, a memory error detector
==1410978== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1410978== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==1410978== Command: ./build/test/gjk
==1410978== 
Running 3 test cases...
nCol / nTotal = 2840 / 10000
nDiff = 0
Total / average time gjk: 37787794, 0.00377878s
-- Collisions -------------------------
Total / average time gjk: 11483341, 0.00404343s
-- No collisions -------------------------
Total / average time gjk: 26304453, 0.00367381s

*** No errors detected
==1410978== 
==1410978== HEAP SUMMARY:
==1410978==     in use at exit: 2,840 bytes in 20 blocks
==1410978==   total heap usage: 166,462 allocs, 166,442 frees, 11,143,195 bytes allocated
==1410978== 
==1410978== LEAK SUMMARY:
==1410978==    definitely lost: 0 bytes in 0 blocks
==1410978==    indirectly lost: 0 bytes in 0 blocks
==1410978==      possibly lost: 0 bytes in 0 blocks
==1410978==    still reachable: 2,840 bytes in 20 blocks
==1410978==         suppressed: 0 bytes in 0 blocks
==1410978== Rerun with --leak-check=full to see details of leaked memory
==1410978== 
==1410978== For lists of detected and suppressed errors, rerun with: -s
==1410978== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

So, clearly the links to Boost are not required, as `--as-needed` drop them, and moreover at least one of them introduce a memory issue.

This PR shows that removing `Boost::unit_test_framework` links workaround the issue (and valgrind is also happy in that case, even without `$LDFLAGS`), but this might not be the best way, and/or introduce other issues (eg. about Boost unit test framework include dirs)

cc @MaximilienNaveau & @cmastalli : I think you also got this issue on crocoddyl / debian, and I checked it there too: [before](https://gitlab.laas.fr/loco-3d/crocoddyl/-/jobs/140785) / [after](https://gitlab.laas.fr/gsaurel/crocoddyl/-/jobs/141163)