### PR TITLE
[ComputeCollision] Return no collision if security_margin is set to -inf

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -219,6 +219,9 @@ struct HPP_FCL_DLLAPI CollisionRequest : QueryRequest
   
   /// @brief Distance below which objects are considered in collision.
   /// See \ref hpp_fcl_collision_and_distance_lower_bound_computation
+  /// @note If set to -inf, the objects tested for collision are considered
+  ///       as collision free and no test is actually performed by functions
+  ///       hpp::fcl::collide of class hpp::fcl::ComputeCollision.
   FCL_REAL security_margin;
 
   /// @brief Distance below which bounding volumes are broken down.

--- a/include/hpp/fcl/doc.hh
+++ b/include/hpp/fcl/doc.hh
@@ -70,6 +70,10 @@ namespace fcl
 /// \note In the green hatched area, the distance lower bound is not known. It
 /// is only guaranted that it will be inferior to
 /// <em>distance - security_margin</em> and superior to \em break_distance.
+/// \note If CollisionRequest::security_margin is set to -inf, no collision test
+/// is performed by function hpp::fcl::collide or class
+/// hpp::fcl::ComputeCollision and the objects are considered as not
+/// colliding.
 
 } // namespace fcl
 } // namespace hpp

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -78,6 +78,11 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
                     const CollisionGeometry* o2, const Transform3f& tf2,
                     const CollisionRequest& request, CollisionResult& result)
 {
+  // If securit margin is set to -infinity, return that there is no collision
+  if (request.security_margin == -std::numeric_limits<FCL_REAL>::infinity()) {
+    result.clear();
+    return false;
+  }
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
   if (solver.enable_cached_guess) {
@@ -163,6 +168,11 @@ ComputeCollision::ComputeCollision(const CollisionGeometry* o1,
 std::size_t ComputeCollision::run(const Transform3f& tf1, const Transform3f& tf2,
        const CollisionRequest& request, CollisionResult& result) const
 {
+  // If securit margin is set to -infinity, return that there is no collision
+  if (request.security_margin == -std::numeric_limits<FCL_REAL>::infinity()) {
+    result.clear();
+    return false;
+  }
   std::size_t res;
   if (swap_geoms) {
     res = func(o2, tf2, o1, tf1, &solver, request, result);


### PR DESCRIPTION
This implements https://github.com/humanoid-path-planner/hpp-fcl/issues/269.