### PR TITLE
Zero warnings

### DIFF
--- a/include/hpp/fcl/broadphase/detail/simple_hash_table-inl.h
+++ b/include/hpp/fcl/broadphase/detail/simple_hash_table-inl.h
@@ -79,7 +79,7 @@ std::vector<Data> SimpleHashTable<Key, Data, HashFnc>::query(Key key) const {
   std::vector<unsigned int> indices = h_(key);
   std::set<Data> result;
   for (size_t i = 0; i < indices.size(); ++i) {
-    unsigned int index = indices[i] % range;
+    size_t index = indices[i] % range;
     std::copy(table_[index].begin(), table_[index].end(),
               std::inserter(result, result.end()));
   }
@@ -93,7 +93,7 @@ void SimpleHashTable<Key, Data, HashFnc>::remove(Key key, Data value) {
   size_t range = table_.size();
   std::vector<unsigned int> indices = h_(key);
   for (size_t i = 0; i < indices.size(); ++i) {
-    unsigned int index = indices[i] % range;
+    size_t index = indices[i] % range;
     table_[index].remove(value);
   }
 }

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -55,6 +55,11 @@ class HPP_FCL_DLLAPI ShapeBase : public CollisionGeometry {
   /// \brief Copy constructor
   ShapeBase(const ShapeBase& other) : CollisionGeometry(other) {}
 
+  ShapeBase& operator=(const ShapeBase& other) {
+    if (this == &other) return *this;
+    return *this;
+  }
+
   virtual ~ShapeBase(){};
 
   /// @brief Get object type: a geometric shape

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -56,7 +56,6 @@ class HPP_FCL_DLLAPI ShapeBase : public CollisionGeometry {
   ShapeBase(const ShapeBase& other) : CollisionGeometry(other) {}
 
   ShapeBase& operator=(const ShapeBase& other) {
-    if (this == &other) return *this;
     return *this;
   }
 

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -55,7 +55,7 @@ class HPP_FCL_DLLAPI ShapeBase : public CollisionGeometry {
   /// \brief Copy constructor
   ShapeBase(const ShapeBase& other) : CollisionGeometry(other) {}
 
-  ShapeBase& operator=(const ShapeBase& other) { return *this; }
+  ShapeBase& operator=(const ShapeBase& /*other*/) { return *this; }
 
   virtual ~ShapeBase(){};
 

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -55,9 +55,7 @@ class HPP_FCL_DLLAPI ShapeBase : public CollisionGeometry {
   /// \brief Copy constructor
   ShapeBase(const ShapeBase& other) : CollisionGeometry(other) {}
 
-  ShapeBase& operator=(const ShapeBase& other) {
-    return *this;
-  }
+  ShapeBase& operator=(const ShapeBase& other) { return *this; }
 
   virtual ~ShapeBase(){};
 

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
+  <!-- <build_depend>pylatexenc-pip</build_depend> -->
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-lxml</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-lxml</build_depend>
   <doc_depend>doxygen</doc_depend>

--- a/python/broadphase/broadphase_callbacks.hh
+++ b/python/broadphase/broadphase_callbacks.hh
@@ -1,7 +1,7 @@
 //
 // Software License Agreement (BSD License)
 //
-//  Copyright (c) 2022 NRIA
+//  Copyright (c) 2022 INRIA
 //  Author: Justin Carpentier
 //  All rights reserved.
 //
@@ -15,7 +15,7 @@
 //     copyright notice, this list of conditions and the following
 //     disclaimer in the documentation and/or other materials provided
 //     with the distribution.
-//   * Neither the name of CNRS-LAAS. nor the names of its
+//   * Neither the name of INRIA nor the names of its
 //     contributors may be used to endorse or promote products derived
 //     from this software without specific prior written permission.
 //

--- a/python/broadphase/broadphase_callbacks.hh
+++ b/python/broadphase/broadphase_callbacks.hh
@@ -56,7 +56,10 @@ struct CollisionCallBackBaseWrapper : CollisionCallBackBase,
 
   void init() { this->get_override("init")(); }
   bool collide(CollisionObject* o1, CollisionObject* o2) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
     return this->get_override("collide")(o1, o2);
+#pragma GCC diagnostic pop
   }
 
   static void expose() {
@@ -83,7 +86,10 @@ struct DistanceCallBackBaseWrapper : DistanceCallBackBase,
   }
 
   bool distance(CollisionObject* o1, CollisionObject* o2, FCL_REAL& dist) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
     return this->get_override("distance")(o1, o2, dist);
+#pragma GCC diagnostic pop
   }
 
   static void expose() {

--- a/python/broadphase/broadphase_collision_manager.hh
+++ b/python/broadphase/broadphase_collision_manager.hh
@@ -1,7 +1,7 @@
 //
 // Software License Agreement (BSD License)
 //
-//  Copyright (c) 2022 NRIA
+//  Copyright (c) 2022 INRIA
 //  Author: Justin Carpentier
 //  All rights reserved.
 //
@@ -15,7 +15,7 @@
 //     copyright notice, this list of conditions and the following
 //     disclaimer in the documentation and/or other materials provided
 //     with the distribution.
-//   * Neither the name of CNRS-LAAS. nor the names of its
+//   * Neither the name of INRIA nor the names of its
 //     contributors may be used to endorse or promote products derived
 //     from this software without specific prior written permission.
 //

--- a/python/broadphase/broadphase_collision_manager.hh
+++ b/python/broadphase/broadphase_collision_manager.hh
@@ -78,7 +78,10 @@ struct BroadPhaseCollisionManagerWrapper
   void clear() { this->get_override("clear")(); }
 
   std::vector<CollisionObject *> getObjects() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
     return this->get_override("getObjects")();
+#pragma GCC diagnostic pop
   }
 
   void collide(CollisionCallBackBase *callback) const {
@@ -103,8 +106,18 @@ struct BroadPhaseCollisionManagerWrapper
     this->get_override("collide")(other_manager, callback);
   }
 
-  bool empty() const { return this->get_override("empty")(); }
-  size_t size() const { return this->get_override("size")(); }
+  bool empty() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+    return this->get_override("empty")();
+#pragma GCC diagnostic pop
+  }
+  size_t size() const {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+    return this->get_override("size")();
+#pragma GCC diagnostic pop
+  }
 
   static void expose() {
     bp::class_<BroadPhaseCollisionManagerWrapper, boost::noncopyable>(


### PR DESCRIPTION
This PR should get us to zero warnings with gcc and clang.

Once https://github.com/ros/rosdistro/pull/32683 is merged, we can uncomment the new dependency on pylatexenc in the package.xml and fix the unstable builds on the buildfarm (to remove the multi-line comment warnings and get nicer Python documentation strings in the bindings).