### PR TITLE
Activate python3-pylatexenc dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  <!-- <build_depend>pylatexenc-pip</build_depend> -->
+  <build_depend>python3-pylatexenc</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-lxml</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-lxml</build_depend>
   <doc_depend>doxygen</doc_depend>


### PR DESCRIPTION
The key was merged, but won't be available during buildfarm builds - can be used for CI though :-)