### PR TITLE
Comment pylatexenc again since it's not available on the buildfarm

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,8 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  <build_depend>python3-pylatexenc</build_depend>
+  <!-- pylatexenc dependency commented since pip packages are not available on the buildfarm -->
+  <!--<build_depend>python3-pylatexenc</build_depend>-->
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-lxml</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-lxml</build_depend>
   <doc_depend>doxygen</doc_depend>


### PR DESCRIPTION
Builds are failing. Turns out these keys are available for developer machines but not for CI/buildfarm