### PR TITLE
Feature: Nesterov acceleration for GJK

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -120,6 +120,9 @@ struct HPP_FCL_DLLAPI QueryRequest {
   /// @brief whether enable gjk initial guess
   bool enable_cached_gjk_guess;
 
+  /// @brief whether to enable the Nesterov accleration of GJK
+  bool enable_gjk_nesterov_acceleration;
+
   /// @brief the gjk initial guess set by user
   Vec3f cached_gjk_guess;
 
@@ -131,6 +134,7 @@ struct HPP_FCL_DLLAPI QueryRequest {
 
   QueryRequest()
       : enable_cached_gjk_guess(false),
+        enable_gjk_nesterov_acceleration(false),
         cached_gjk_guess(1, 0, 0),
         cached_support_func_guess(support_func_guess_t::Zero()),
         enable_timings(false) {}

--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -121,7 +121,7 @@ struct HPP_FCL_DLLAPI QueryRequest {
   bool enable_cached_gjk_guess;
 
   /// @brief whether to enable the Nesterov accleration of GJK
-  bool enable_gjk_nesterov_acceleration;
+  GJKVariant gjk_variant;
 
   /// @brief the gjk initial guess set by user
   Vec3f cached_gjk_guess;
@@ -134,7 +134,7 @@ struct HPP_FCL_DLLAPI QueryRequest {
 
   QueryRequest()
       : enable_cached_gjk_guess(false),
-        enable_gjk_nesterov_acceleration(false),
+        gjk_variant(GJKVariant::DefaultGJK),
         cached_gjk_guess(1, 0, 0),
         cached_support_func_guess(support_func_guess_t::Zero()),
         enable_timings(false) {}

--- a/include/hpp/fcl/data_types.h
+++ b/include/hpp/fcl/data_types.h
@@ -71,6 +71,9 @@ typedef Eigen::Matrix<Eigen::DenseIndex, Eigen::Dynamic, 3> Matrixx3i;
 typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, Eigen::Dynamic> MatrixXf;
 typedef Eigen::Vector2i support_func_guess_t;
 
+/// @brief Variant to use for the GJK algorithm
+enum GJKVariant { DefaultGJK, NesterovAcceleration };
+
 /// @brief Triangle with 3 indices for points
 class HPP_FCL_DLLAPI Triangle {
  public:

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -148,6 +148,8 @@ struct HPP_FCL_DLLAPI GJK {
   };
 
   enum Status { Valid, Inside, Failed };
+  /// @brief Version used for GJK. Vanilla is default.
+  enum GJKVariant { Vanilla, Nesterov };
 
   MinkowskiDiff const* shape;
   Vec3f ray;
@@ -228,6 +230,14 @@ struct HPP_FCL_DLLAPI GJK {
     distance_upper_bound = dup;
   }
 
+  /// @brief Set which GJK version to use. Default is Vanilla.
+  inline void setGJKVariant(GJKVariant variant) { gjk_variant = variant; }
+
+  /// @brief Set wether or not to use the normalization heuristic when computing a support point.
+  /// Only effective if acceleration version of GJK is used.
+  /// Default is false.
+  inline void setNormalizeSupportDirection(bool normalize) { normalize_support_direction = normalize; }
+
  private:
   SimplexV store_v[4];
   SimplexV* free_v[4];
@@ -239,6 +249,8 @@ struct HPP_FCL_DLLAPI GJK {
   unsigned int max_iterations;
   FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
+  GJKVariant gjk_variant;
+  bool normalize_support_direction;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -149,7 +149,7 @@ struct HPP_FCL_DLLAPI GJK {
 
   enum Status { Valid, Inside, Failed };
   /// @brief Version used for GJK. Vanilla is default.
-  enum GJKVariant { Vanilla, Nesterov };
+  enum GJKVariant { Default, NesterovAcceleration };
 
   MinkowskiDiff const* shape;
   Vec3f ray;

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -238,6 +238,9 @@ struct HPP_FCL_DLLAPI GJK {
   /// Default is false.
   inline void setNormalizeSupportDirection(bool normalize) { normalize_support_direction = normalize; }
 
+  /// @brief Get GJK number of iterations.
+  inline size_t getIterations() { return iterations; }
+
  private:
   SimplexV store_v[4];
   SimplexV* free_v[4];
@@ -251,6 +254,7 @@ struct HPP_FCL_DLLAPI GJK {
   FCL_REAL distance_upper_bound;
   GJKVariant gjk_variant;
   bool normalize_support_direction;
+  size_t iterations;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -86,6 +86,11 @@ struct HPP_FCL_DLLAPI MinkowskiDiff {
   /// \note It must set before the call to \ref set.
   int linear_log_convex_threshold;
 
+  /// @brief Wether or not to use the normalize heuristic in the GJK Nesterov
+  /// acceleration. This setting is only applied if the Nesterov acceleration in
+  /// the GJK class is active.
+  bool normalize_support_direction;
+
   typedef void (*GetSupportFunction)(const MinkowskiDiff& minkowskiDiff,
                                      const Vec3f& dir, bool dirIsNormalized,
                                      Vec3f& support0, Vec3f& support1,
@@ -121,6 +126,15 @@ struct HPP_FCL_DLLAPI MinkowskiDiff {
     assert(getSupportFunc != NULL);
     getSupportFunc(*this, d, dIsNormalized, supp0, supp1, hint,
                    const_cast<ShapeData*>(data));
+  }
+
+  /// @brief Set wether or not to use the normalization heuristic when computing
+  /// a support point. Only effective if acceleration version of GJK is used.
+  /// By default, when MinkowskiDiff::set is called, the normalization heuristic
+  /// is deduced from the shapes. The user can override this behavior with this
+  /// function.
+  inline void setNormalizeSupportDirection(bool normalize) {
+    normalize_support_direction = normalize;
   }
 };
 
@@ -231,13 +245,6 @@ struct HPP_FCL_DLLAPI GJK {
   /// @brief Set which GJK version to use. Default is Vanilla.
   inline void setGJKVariant(GJKVariant variant) { gjk_variant = variant; }
 
-  /// @brief Set wether or not to use the normalization heuristic when computing
-  /// a support point. Only effective if acceleration version of GJK is used.
-  /// Default is false.
-  inline void setNormalizeSupportDirection(bool normalize) {
-    normalize_support_direction = normalize;
-  }
-
   /// @brief Get GJK number of iterations.
   inline size_t getIterations() { return iterations; }
 
@@ -253,7 +260,6 @@ struct HPP_FCL_DLLAPI GJK {
   FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
   GJKVariant gjk_variant;
-  bool normalize_support_direction;
   size_t iterations;
 
   /// @brief discard one vertex from the simplex

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -149,7 +149,7 @@ struct HPP_FCL_DLLAPI GJK {
 
   enum Status { Valid, Inside, Failed };
   /// @brief Version used for GJK. Vanilla is default.
-  enum GJKVariant { Default, NesterovAcceleration };
+  enum GJKVariant { DefaultGJK, NesterovAcceleration };
 
   MinkowskiDiff const* shape;
   Vec3f ray;

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -148,8 +148,6 @@ struct HPP_FCL_DLLAPI GJK {
   };
 
   enum Status { Valid, Inside, Failed };
-  /// @brief Version used for GJK. Vanilla is default.
-  enum GJKVariant { DefaultGJK, NesterovAcceleration };
 
   MinkowskiDiff const* shape;
   Vec3f ray;

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -233,10 +233,12 @@ struct HPP_FCL_DLLAPI GJK {
   /// @brief Set which GJK version to use. Default is Vanilla.
   inline void setGJKVariant(GJKVariant variant) { gjk_variant = variant; }
 
-  /// @brief Set wether or not to use the normalization heuristic when computing a support point.
-  /// Only effective if acceleration version of GJK is used.
+  /// @brief Set wether or not to use the normalization heuristic when computing
+  /// a support point. Only effective if acceleration version of GJK is used.
   /// Default is false.
-  inline void setNormalizeSupportDirection(bool normalize) { normalize_support_direction = normalize; }
+  inline void setNormalizeSupportDirection(bool normalize) {
+    normalize_support_direction = normalize;
+  }
 
   /// @brief Get GJK number of iterations.
   inline size_t getIterations() { return iterations; }

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -321,9 +321,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
   Vec3f getCachedGuess() const { return cached_guess; }
 
-  void setGJKVariant(const GJKVariant& variant) const {
-    gjk_variant = variant;
-  }
+  void setGJKVariant(const GJKVariant& variant) const { gjk_variant = variant; }
 
   bool operator==(const GJKSolver& other) const {
     return epa_max_face_num == other.epa_max_face_num &&

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -74,7 +74,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
     if (enable_gjk_nesterov_acceleration)
       gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
     else
-     gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+      gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
@@ -236,7 +236,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
     if (enable_gjk_nesterov_acceleration)
       gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
     else
-     gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+      gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -332,7 +332,8 @@ struct HPP_FCL_DLLAPI GJKSolver {
            enable_cached_guess == other.enable_cached_guess &&
            cached_guess == other.cached_guess &&
            support_func_cached_guess == other.support_func_cached_guess &&
-           distance_upper_bound == other.distance_upper_bound;
+           distance_upper_bound == other.distance_upper_bound &&
+           gjk_variant == other.gjk_variant;
   }
 
   bool operator!=(const GJKSolver& other) const { return !(*this == other); }

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -71,10 +71,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
-    if (enable_gjk_nesterov_acceleration)
-      gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
-    else
-      gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+    gjk.setGJKVariant(gjk_variant);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
@@ -233,10 +230,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
-    if (enable_gjk_nesterov_acceleration)
-      gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
-    else
-      gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+    gjk.setGJKVariant(gjk_variant);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
@@ -316,7 +310,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
     cached_guess = Vec3f(1, 0, 0);
     support_func_cached_guess = support_func_guess_t::Zero();
     distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
-    enable_gjk_nesterov_acceleration = false;
+    gjk_variant = DefaultGJK;
   }
 
   void enableCachedGuess(bool if_enable) const {
@@ -327,8 +321,8 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
   Vec3f getCachedGuess() const { return cached_guess; }
 
-  void enableGJKNesterovAcceleration(bool if_enable) const {
-    enable_gjk_nesterov_acceleration = if_enable;
+  void setGJKVariant(const GJKVariant& variant) const {
+    gjk_variant = variant;
   }
 
   bool operator==(const GJKSolver& other) const {
@@ -369,8 +363,8 @@ struct HPP_FCL_DLLAPI GJKSolver {
   /// @brief smart guess
   mutable Vec3f cached_guess;
 
-  /// @brief Wether Nesterov acceleration is used for GJK
-  mutable bool enable_gjk_nesterov_acceleration;
+  /// @brief Variant to use for the GJK algorithm
+  mutable GJKVariant gjk_variant;
 
   /// @brief smart guess for the support function
   mutable support_func_guess_t support_func_cached_guess;

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -71,6 +71,11 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
+    if (enable_gjk_nesterov_acceleration)
+      gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
+    else
+     gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
       cached_guess = gjk.getGuessFromSimplex();
@@ -228,6 +233,11 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
+    if (enable_gjk_nesterov_acceleration)
+      gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
+    else
+     gjk.setGJKVariant(details::GJK::GJKVariant::DefaultGJK);
+
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
       cached_guess = gjk.getGuessFromSimplex();
@@ -306,6 +316,7 @@ struct HPP_FCL_DLLAPI GJKSolver {
     cached_guess = Vec3f(1, 0, 0);
     support_func_cached_guess = support_func_guess_t::Zero();
     distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
+    enable_gjk_nesterov_acceleration = false;
   }
 
   void enableCachedGuess(bool if_enable) const {
@@ -315,6 +326,10 @@ struct HPP_FCL_DLLAPI GJKSolver {
   void setCachedGuess(const Vec3f& guess) const { cached_guess = guess; }
 
   Vec3f getCachedGuess() const { return cached_guess; }
+
+  void enableGJKNesterovAcceleration(bool if_enable) const {
+    enable_gjk_nesterov_acceleration = if_enable;
+  }
 
   bool operator==(const GJKSolver& other) const {
     return epa_max_face_num == other.epa_max_face_num &&
@@ -353,6 +368,9 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
   /// @brief smart guess
   mutable Vec3f cached_guess;
+
+  /// @brief Wether Nesterov acceleration is used for GJK
+  mutable bool enable_gjk_nesterov_acceleration;
 
   /// @brief smart guess for the support function
   mutable support_func_guess_t support_func_cached_guess;

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -86,8 +86,8 @@ void exposeGJK() {
   if(!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>())
   {
     enum_ <GJK::GJKVariant> ("GJKVariant")
-      .value ("Vanilla", GJK::Vanilla)
-      .value ("Nesterov", GJK::Nesterov)
+      .value ("Default", GJK::Default)
+      .value ("NesterovAcceleration", GJK::NesterovAcceleration)
       .export_values()
       ;
   }

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -83,6 +83,15 @@ void exposeGJK() {
         .DEF_RW_CLASS_ATTRIB(MinkowskiDiff, inflation);
   }
 
+  if(!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>())
+  {
+    enum_ <GJK::GJKVariant> ("GJKVariant")
+      .value ("Vanilla", GJK::Vanilla)
+      .value ("Nesterov", GJK::Nesterov)
+      .export_values()
+      ;
+  }
+
   if (!eigenpy::register_symbolic_link_to_registered_type<GJK>()) {
     class_<GJK>("GJK", doxygen::class_doc<GJK>(), no_init)
         .def(doxygen::visitor::init<GJK, unsigned int, FCL_REAL>())
@@ -94,6 +103,10 @@ void exposeGJK() {
         .DEF_CLASS_FUNC(GJK, hasPenetrationInformation)
         .DEF_CLASS_FUNC(GJK, getClosestPoints)
         .DEF_CLASS_FUNC(GJK, setDistanceEarlyBreak)
-        .DEF_CLASS_FUNC(GJK, getGuessFromSimplex);
+        .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
+        .DEF_CLASS_FUNC(GJK, setGJKVariant)
+        .DEF_CLASS_FUNC(GJK, setNormalizeSupportDirection)
+        .DEF_CLASS_FUNC(GJK, getIterations)
+        ;
   }
 }

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -83,10 +83,10 @@ void exposeGJK() {
         .DEF_RW_CLASS_ATTRIB(MinkowskiDiff, inflation);
   }
 
-  if (!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>()) {
-    enum_<GJK::GJKVariant>("GJKVariant")
-        .value("DefaultGJK", GJK::DefaultGJK)
-        .value("NesterovAcceleration", GJK::NesterovAcceleration)
+  if (!eigenpy::register_symbolic_link_to_registered_type<GJKVariant>()) {
+    enum_<GJKVariant>("GJKVariant")
+        .value("DefaultGJK", DefaultGJK)
+        .value("NesterovAcceleration", NesterovAcceleration)
         .export_values();
   }
 

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -80,6 +80,7 @@ void exposeGJK() {
         .DEF_CLASS_FUNC(MinkowskiDiff, support0)
         .DEF_CLASS_FUNC(MinkowskiDiff, support1)
         .DEF_CLASS_FUNC(MinkowskiDiff, support)
+        .DEF_CLASS_FUNC(MinkowskiDiff, setNormalizeSupportDirection)
         .DEF_RW_CLASS_ATTRIB(MinkowskiDiff, inflation);
   }
 
@@ -103,7 +104,6 @@ void exposeGJK() {
         .DEF_CLASS_FUNC(GJK, setDistanceEarlyBreak)
         .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
         .DEF_CLASS_FUNC(GJK, setGJKVariant)
-        .DEF_CLASS_FUNC(GJK, setNormalizeSupportDirection)
         .DEF_CLASS_FUNC(GJK, getIterations);
   }
 }

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -83,13 +83,11 @@ void exposeGJK() {
         .DEF_RW_CLASS_ATTRIB(MinkowskiDiff, inflation);
   }
 
-  if(!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>())
-  {
-    enum_ <GJK::GJKVariant> ("GJKVariant")
-      .value ("Default", GJK::Default)
-      .value ("NesterovAcceleration", GJK::NesterovAcceleration)
-      .export_values()
-      ;
+  if (!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>()) {
+    enum_<GJK::GJKVariant>("GJKVariant")
+        .value("Default", GJK::Default)
+        .value("NesterovAcceleration", GJK::NesterovAcceleration)
+        .export_values();
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<GJK>()) {
@@ -106,7 +104,6 @@ void exposeGJK() {
         .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
         .DEF_CLASS_FUNC(GJK, setGJKVariant)
         .DEF_CLASS_FUNC(GJK, setNormalizeSupportDirection)
-        .DEF_CLASS_FUNC(GJK, getIterations)
-        ;
+        .DEF_CLASS_FUNC(GJK, getIterations);
   }
 }

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -85,7 +85,7 @@ void exposeGJK() {
 
   if (!eigenpy::register_symbolic_link_to_registered_type<GJK::GJKVariant>()) {
     enum_<GJK::GJKVariant>("GJKVariant")
-        .value("Default", GJK::Default)
+        .value("DefaultGJK", GJK::DefaultGJK)
         .value("NesterovAcceleration", GJK::NesterovAcceleration)
         .export_values();
   }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -77,6 +77,7 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   }
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
+  solver.enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -77,8 +77,7 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   }
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
-  solver.enableGJKNesterovAcceleration(
-      request.enable_gjk_nesterov_acceleration);
+  solver.setGJKVariant(request.gjk_variant);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -77,7 +77,8 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   }
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
-  solver.enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
+  solver.enableGJKNesterovAcceleration(
+      request.enable_gjk_nesterov_acceleration);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -80,6 +80,7 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
 
   DistanceResult distanceResult;
   DistanceRequest distanceRequest(request.enable_contact);
+  nsolver->enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
   FCL_REAL distance = ShapeShapeDistance<T_SH1, T_SH2>(
       o1, tf1, o2, tf2, nsolver, distanceRequest, distanceResult);
 

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -80,8 +80,7 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
 
   DistanceResult distanceResult;
   DistanceRequest distanceRequest(request.enable_contact);
-  nsolver->enableGJKNesterovAcceleration(
-      request.enable_gjk_nesterov_acceleration);
+  nsolver->setGJKVariant(request.gjk_variant);
   FCL_REAL distance = ShapeShapeDistance<T_SH1, T_SH2>(
       o1, tf1, o2, tf2, nsolver, distanceRequest, distanceResult);
 

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -80,7 +80,8 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
 
   DistanceResult distanceResult;
   DistanceRequest distanceRequest(request.enable_contact);
-  nsolver->enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
+  nsolver->enableGJKNesterovAcceleration(
+      request.enable_gjk_nesterov_acceleration);
   FCL_REAL distance = ShapeShapeDistance<T_SH1, T_SH2>(
       o1, tf1, o2, tf2, nsolver, distanceRequest, distanceResult);
 

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -62,6 +62,7 @@ FCL_REAL distance(const CollisionGeometry* o1, const Transform3f& tf1,
                   const DistanceRequest& request, DistanceResult& result) {
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
+  solver.enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -62,8 +62,7 @@ FCL_REAL distance(const CollisionGeometry* o1, const Transform3f& tf1,
                   const DistanceRequest& request, DistanceResult& result) {
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
-  solver.enableGJKNesterovAcceleration(
-      request.enable_gjk_nesterov_acceleration);
+  solver.setGJKVariant(request.gjk_variant);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -62,7 +62,8 @@ FCL_REAL distance(const CollisionGeometry* o1, const Transform3f& tf1,
                   const DistanceRequest& request, DistanceResult& result) {
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
-  solver.enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
+  solver.enableGJKNesterovAcceleration(
+      request.enable_gjk_nesterov_acceleration);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/distance_func_matrix.cpp
+++ b/src/distance_func_matrix.cpp
@@ -77,7 +77,8 @@ FCL_REAL ShapeShapeDistance(const CollisionGeometry* o1, const Transform3f& tf1,
   const T_SH1* obj1 = static_cast<const T_SH1*>(o1);
   const T_SH2* obj2 = static_cast<const T_SH2*>(o2);
 
-  nsolver->enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
+  nsolver->enableGJKNesterovAcceleration(
+      request.enable_gjk_nesterov_acceleration);
 
   initialize(node, *obj1, tf1, *obj2, tf2, nsolver, request, result);
   distance(&node);

--- a/src/distance_func_matrix.cpp
+++ b/src/distance_func_matrix.cpp
@@ -77,8 +77,7 @@ FCL_REAL ShapeShapeDistance(const CollisionGeometry* o1, const Transform3f& tf1,
   const T_SH1* obj1 = static_cast<const T_SH1*>(o1);
   const T_SH2* obj2 = static_cast<const T_SH2*>(o2);
 
-  nsolver->enableGJKNesterovAcceleration(
-      request.enable_gjk_nesterov_acceleration);
+  nsolver->setGJKVariant(request.gjk_variant);
 
   initialize(node, *obj1, tf1, *obj2, tf2, nsolver, request, result);
   distance(&node);

--- a/src/distance_func_matrix.cpp
+++ b/src/distance_func_matrix.cpp
@@ -77,6 +77,8 @@ FCL_REAL ShapeShapeDistance(const CollisionGeometry* o1, const Transform3f& tf1,
   const T_SH1* obj1 = static_cast<const T_SH1*>(o1);
   const T_SH2* obj2 = static_cast<const T_SH2*>(o2);
 
+  nsolver->enableGJKNesterovAcceleration(request.enable_gjk_nesterov_acceleration);
+
   initialize(node, *obj1, tf1, *obj2, tf2, nsolver, request, result);
   distance(&node);
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -621,8 +621,8 @@ bool GJK::getClosestPoints(const MinkowskiDiff& shape, Vec3f& w0, Vec3f& w1) {
 
 GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
                           const support_func_guess_t& supportHint) {
-  size_t iterations = 0;
   FCL_REAL alpha = 0;
+  iterations = 0;
   const FCL_REAL inflation = shape_.inflation.sum();
   const FCL_REAL upper_bound = distance_upper_bound + inflation;
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -520,7 +520,8 @@ void GJK::initialize() {
   distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
   simplex = NULL;
   gjk_variant = DefaultGJK;
-  normalize_support_direction = false;
+  // normalize_support_direction is only used in the Nesterov accelerated variant of GJK
+  normalize_support_direction = true;
 }
 
 Vec3f GJK::getGuessFromSimplex() const { return ray; }
@@ -678,7 +679,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
         break;
 
       case NesterovAcceleration:
-        // Normalize heuristic for collision pairs involving meshes
+        // Normalize heuristic for collision pairs involving convex but not strictly-convex shapes
+        // This corresponds to most use cases.
         if (normalize_support_direction) {
           momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
           y = momentum * ray + (1 - momentum) * w;

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -685,7 +685,13 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
         if (normalize_support_direction) {
           momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
           y = momentum * ray + (1 - momentum) * w;
-          dir = momentum * dir / dir.norm() + (1 - momentum) * y / y.norm();
+          FCL_REAL y_norm = y.norm();
+          // ray is the point of the Minkowski difference which currently the
+          // closest to the origin. Therefore, y.norm() > ray.norm() Hence, if
+          // check A above has not stopped the algorithm, we necessarily have
+          // y.norm() > tolerance. The following assert is just a safety check.
+          assert(y_norm > tolerance);
+          dir = momentum * dir / dir.norm() + (1 - momentum) * y / y_norm;
         } else {
           momentum = (FCL_REAL(iterations) + 1) / (FCL_REAL(iterations) + 3);
           y = momentum * ray + (1 - momentum) * w;

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -679,23 +679,20 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
 
       case NesterovAcceleration:
         // Normalize heuristic for collision pairs involving meshes
-        if (normalize_support_direction)
-        {
+        if (normalize_support_direction) {
           momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
           y = momentum * ray + (1 - momentum) * w;
-          dir = momentum * dir / dir.norm() + (1 -momentum) * y / y.norm();
-        }
-        else
-        {
+          dir = momentum * dir / dir.norm() + (1 - momentum) * y / y.norm();
+        } else {
           momentum = (FCL_REAL(iterations) + 1) / (FCL_REAL(iterations) + 3);
-          y =  momentum * ray + (1 - momentum) * w;
+          y = momentum * ray + (1 - momentum) * w;
           dir = momentum * dir + (1 - momentum) * y;
         }
         break;
 
-        default:
-          throw std::logic_error("Invalid momentum variant.");
-      }
+      default:
+        throw std::logic_error("Invalid momentum variant.");
+    }
 
     appendVertex(curr_simplex, -dir, false,
                  support_hint);  // see below, ray points away from origin

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -520,7 +520,8 @@ void GJK::initialize() {
   distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
   simplex = NULL;
   gjk_variant = DefaultGJK;
-  // normalize_support_direction is only used in the Nesterov accelerated variant of GJK
+  // normalize_support_direction is only used in the Nesterov accelerated
+  // variant of GJK
   normalize_support_direction = true;
 }
 
@@ -679,8 +680,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
         break;
 
       case NesterovAcceleration:
-        // Normalize heuristic for collision pairs involving convex but not strictly-convex shapes
-        // This corresponds to most use cases.
+        // Normalize heuristic for collision pairs involving convex but not
+        // strictly-convex shapes This corresponds to most use cases.
         if (normalize_support_direction) {
           momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
           y = momentum * ray + (1 - momentum) * w;

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -519,7 +519,7 @@ void GJK::initialize() {
   status = Failed;
   distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
   simplex = NULL;
-  gjk_variant = Vanilla;
+  gjk_variant = Default;
   normalize_support_direction = false;
 }
 
@@ -673,11 +673,11 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
 
     // Compute direction for support call
     switch (current_gjk_variant) {
-      case Vanilla:
+      case Default:
         dir = ray;
         break;
 
-      case Nesterov:
+      case NesterovAcceleration:
         // Normalize heuristic for collision pairs involving meshes
         if (normalize_support_direction)
         {
@@ -721,8 +721,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     // if(diff - tolerance * rl <= 0)
     if (iterations > 0 && diff - tolerance * rl <= 0) {
       if (iterations > 0) removeVertex(simplices[current]);
-      if (current_gjk_variant != Vanilla) {
-        current_gjk_variant = Vanilla;
+      if (current_gjk_variant != Default) {
+        current_gjk_variant = Default;
         continue;
       }
       distance = rl - inflation;

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -519,7 +519,7 @@ void GJK::initialize() {
   status = Failed;
   distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
   simplex = NULL;
-  gjk_variant = Default;
+  gjk_variant = DefaultGJK;
   normalize_support_direction = false;
 }
 
@@ -673,7 +673,7 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
 
     // Compute direction for support call
     switch (current_gjk_variant) {
-      case Default:
+      case DefaultGJK:
         dir = ray;
         break;
 
@@ -718,8 +718,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     // if(diff - tolerance * rl <= 0)
     if (iterations > 0 && diff - tolerance * rl <= 0) {
       if (iterations > 0) removeVertex(simplices[current]);
-      if (current_gjk_variant != Default) {
-        current_gjk_variant = Default;
+      if (current_gjk_variant != DefaultGJK) {
+        current_gjk_variant = DefaultGJK;
         continue;
       }
       distance = rl - inflation;

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -708,6 +708,16 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
       break;
     }
 
+    // Check to remove acceleration
+    if (current_gjk_variant != DefaultGJK){
+      FCL_REAL frank_wolfe_duality_gap = 2 * ray.dot(ray - w);
+      if (frank_wolfe_duality_gap - tolerance <= 0){
+        removeVertex(simplices[current]);
+        current_gjk_variant = DefaultGJK;
+        continue; // continue to next iteration
+      }
+    }
+
     // check C: when the new support point is close to the sub-simplex where the
     // ray point lies, stop (as the new simplex again is degenerated)
     alpha = std::max(alpha, omega);

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -709,12 +709,12 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     }
 
     // Check to remove acceleration
-    if (current_gjk_variant != DefaultGJK){
+    if (current_gjk_variant != DefaultGJK) {
       FCL_REAL frank_wolfe_duality_gap = 2 * ray.dot(ray - w);
-      if (frank_wolfe_duality_gap - tolerance <= 0){
+      if (frank_wolfe_duality_gap - tolerance <= 0) {
         removeVertex(simplices[current]);
         current_gjk_variant = DefaultGJK;
-        continue; // continue to next iteration
+        continue;  // continue to next iteration
       }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,7 @@ add_fcl_test(hfields hfields.cpp)
 add_fcl_test(profiling profiling.cpp)
 
 add_fcl_test(gjk gjk.cpp)
+add_fcl_test(nesterov_gjk nesterov_gjk.cpp)
 if(HPP_FCL_HAS_OCTOMAP)
   add_fcl_test(octree octree.cpp)
 endif(HPP_FCL_HAS_OCTOMAP)

--- a/test/gjk.cpp
+++ b/test/gjk.cpp
@@ -47,12 +47,12 @@
 
 using hpp::fcl::FCL_REAL;
 using hpp::fcl::GJKSolver;
+using hpp::fcl::GJKVariant;
 using hpp::fcl::Matrix3f;
 using hpp::fcl::Quaternion3f;
 using hpp::fcl::Transform3f;
 using hpp::fcl::TriangleP;
 using hpp::fcl::Vec3f;
-using hpp::fcl::GJKVariant;
 
 typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, 1> vector_t;
 typedef Eigen::Matrix<FCL_REAL, 6, 1> vector6_t;

--- a/test/gjk.cpp
+++ b/test/gjk.cpp
@@ -66,7 +66,8 @@ struct Result {
 
 typedef std::vector<Result> Results_t;
 
-void test_gjk_distance_triangle_triangle(bool enable_gjk_nesterov_acceleration) {
+void test_gjk_distance_triangle_triangle(
+    bool enable_gjk_nesterov_acceleration) {
   Eigen::IOFormat numpy(Eigen::FullPrecision, Eigen::DontAlignCols, ", ", ", ",
                         "np.array ((", "))", "", "");
   Eigen::IOFormat tuple(Eigen::FullPrecision, Eigen::DontAlignCols, "", ", ",

--- a/test/gjk.cpp
+++ b/test/gjk.cpp
@@ -52,6 +52,7 @@ using hpp::fcl::Quaternion3f;
 using hpp::fcl::Transform3f;
 using hpp::fcl::TriangleP;
 using hpp::fcl::Vec3f;
+using hpp::fcl::GJKVariant;
 
 typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, 1> vector_t;
 typedef Eigen::Matrix<FCL_REAL, 6, 1> vector6_t;
@@ -74,7 +75,8 @@ void test_gjk_distance_triangle_triangle(
                         "", "", "(", ")");
   std::size_t N = 10000;
   GJKSolver solver;
-  solver.enableGJKNesterovAcceleration(enable_gjk_nesterov_acceleration);
+  if (enable_gjk_nesterov_acceleration)
+    solver.setGJKVariant(GJKVariant::NesterovAcceleration);
   Transform3f tf1, tf2;
   Vec3f p1, p2, a1, a2;
   Matrix3f M;
@@ -332,7 +334,7 @@ void test_gjk_unit_sphere(FCL_REAL center_distance, Vec3f ray,
 
   details::GJK gjk(2, 1e-6);
   if (use_gjk_nesterov_acceleration)
-    gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
+    gjk.setGJKVariant(GJKVariant::NesterovAcceleration);
   details::GJK::Status status = gjk.evaluate(shape, Vec3f(1, 0, 0));
 
   if (expect_collision)
@@ -388,7 +390,7 @@ void test_gjk_triangle_capsule(Vec3f T, bool expect_collision,
 
   details::GJK gjk(10, 1e-6);
   if (use_gjk_nesterov_acceleration)
-    gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
+    gjk.setGJKVariant(GJKVariant::NesterovAcceleration);
   details::GJK::Status status = gjk.evaluate(shape, Vec3f(1, 0, 0));
 
   if (expect_collision)

--- a/test/gjk.cpp
+++ b/test/gjk.cpp
@@ -66,13 +66,14 @@ struct Result {
 
 typedef std::vector<Result> Results_t;
 
-BOOST_AUTO_TEST_CASE(distance_triangle_triangle_1) {
+void test_gjk_distance_triangle_triangle(bool enable_gjk_nesterov_acceleration) {
   Eigen::IOFormat numpy(Eigen::FullPrecision, Eigen::DontAlignCols, ", ", ", ",
                         "np.array ((", "))", "", "");
   Eigen::IOFormat tuple(Eigen::FullPrecision, Eigen::DontAlignCols, "", ", ",
                         "", "", "(", ")");
   std::size_t N = 10000;
   GJKSolver solver;
+  solver.enableGJKNesterovAcceleration(enable_gjk_nesterov_acceleration);
   Transform3f tf1, tf2;
   Vec3f p1, p2, a1, a2;
   Matrix3f M;
@@ -307,8 +308,14 @@ BOOST_AUTO_TEST_CASE(distance_triangle_triangle_1) {
             << "s" << std::endl;
 }
 
+BOOST_AUTO_TEST_CASE(distance_triangle_triangle_1) {
+  test_gjk_distance_triangle_triangle(false);
+  test_gjk_distance_triangle_triangle(true);
+}
+
 void test_gjk_unit_sphere(FCL_REAL center_distance, Vec3f ray,
-                          bool expect_collision) {
+                          bool expect_collision,
+                          bool use_gjk_nesterov_acceleration) {
   using namespace hpp::fcl;
   Sphere sphere(1.);
 
@@ -323,6 +330,8 @@ void test_gjk_unit_sphere(FCL_REAL center_distance, Vec3f ray,
   BOOST_CHECK_EQUAL(shape.inflation[1], sphere.radius);
 
   details::GJK gjk(2, 1e-6);
+  if (use_gjk_nesterov_acceleration)
+    gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
   details::GJK::Status status = gjk.evaluate(shape, Vec3f(1, 0, 0));
 
   if (expect_collision)
@@ -341,18 +350,27 @@ void test_gjk_unit_sphere(FCL_REAL center_distance, Vec3f ray,
 }
 
 BOOST_AUTO_TEST_CASE(sphere_sphere) {
-  test_gjk_unit_sphere(3., Vec3f(1, 0, 0), false);
-  test_gjk_unit_sphere(2.01, Vec3f(1, 0, 0), false);
-  test_gjk_unit_sphere(2., Vec3f(1, 0, 0), true);
-  test_gjk_unit_sphere(1., Vec3f(1, 0, 0), true);
+  test_gjk_unit_sphere(3., Vec3f(1, 0, 0), false, false);
+  test_gjk_unit_sphere(3., Vec3f(1, 0, 0), false, true);
+  test_gjk_unit_sphere(2.01, Vec3f(1, 0, 0), false, false);
+  test_gjk_unit_sphere(2.01, Vec3f(1, 0, 0), false, true);
+  test_gjk_unit_sphere(2., Vec3f(1, 0, 0), true, false);
+  test_gjk_unit_sphere(2., Vec3f(1, 0, 0), true, true);
+  test_gjk_unit_sphere(1., Vec3f(1, 0, 0), true, false);
+  test_gjk_unit_sphere(1., Vec3f(1, 0, 0), true, true);
 
-  test_gjk_unit_sphere(3., Vec3f::Random().normalized(), false);
-  test_gjk_unit_sphere(2.01, Vec3f::Random().normalized(), false);
-  test_gjk_unit_sphere(2., Vec3f::Random().normalized(), true);
-  test_gjk_unit_sphere(1., Vec3f::Random().normalized(), true);
+  test_gjk_unit_sphere(3., Vec3f::Random().normalized(), false, false);
+  test_gjk_unit_sphere(3., Vec3f::Random().normalized(), false, true);
+  test_gjk_unit_sphere(2.01, Vec3f::Random().normalized(), false, false);
+  test_gjk_unit_sphere(2.01, Vec3f::Random().normalized(), false, true);
+  test_gjk_unit_sphere(2., Vec3f::Random().normalized(), true, false);
+  test_gjk_unit_sphere(2., Vec3f::Random().normalized(), true, true);
+  test_gjk_unit_sphere(1., Vec3f::Random().normalized(), true, false);
+  test_gjk_unit_sphere(1., Vec3f::Random().normalized(), true, true);
 }
 
 void test_gjk_triangle_capsule(Vec3f T, bool expect_collision,
+                               bool use_gjk_nesterov_acceleration,
                                Vec3f w0_expected, Vec3f w1_expected) {
   using namespace hpp::fcl;
   Capsule capsule(1., 2.);  // Radius 1 and length 2
@@ -368,6 +386,8 @@ void test_gjk_triangle_capsule(Vec3f T, bool expect_collision,
   BOOST_CHECK_EQUAL(shape.inflation[1], 0.);
 
   details::GJK gjk(10, 1e-6);
+  if (use_gjk_nesterov_acceleration)
+    gjk.setGJKVariant(details::GJK::GJKVariant::NesterovAcceleration);
   details::GJK::Status status = gjk.evaluate(shape, Vec3f(1, 0, 0));
 
   if (expect_collision)
@@ -398,14 +418,23 @@ void test_gjk_triangle_capsule(Vec3f T, bool expect_collision,
 
 BOOST_AUTO_TEST_CASE(triangle_capsule) {
   // GJK -> no collision
-  test_gjk_triangle_capsule(Vec3f(1.01, 0, 0), false, Vec3f(1., 0, 0),
+  test_gjk_triangle_capsule(Vec3f(1.01, 0, 0), false, false, Vec3f(1., 0, 0),
+                            Vec3f(0., 0, 0));
+  // GJK + Nesterov acceleration -> no collision
+  test_gjk_triangle_capsule(Vec3f(1.01, 0, 0), false, true, Vec3f(1., 0, 0),
                             Vec3f(0., 0, 0));
 
   // GJK -> collision
-  test_gjk_triangle_capsule(Vec3f(0.5, 0, 0), true, Vec3f(1., 0, 0),
+  test_gjk_triangle_capsule(Vec3f(0.5, 0, 0), true, false, Vec3f(1., 0, 0),
+                            Vec3f(0., 0, 0));
+  // GJK + Nesterov acceleration -> collision
+  test_gjk_triangle_capsule(Vec3f(0.5, 0, 0), true, true, Vec3f(1., 0, 0),
                             Vec3f(0., 0, 0));
 
   // GJK + EPA -> collision
-  test_gjk_triangle_capsule(Vec3f(-0.5, -0.01, 0), true, Vec3f(0, 1, 0),
+  test_gjk_triangle_capsule(Vec3f(-0.5, -0.01, 0), true, false, Vec3f(0, 1, 0),
+                            Vec3f(0.5, 0, 0));
+  // GJK + Nesterov accleration + EPA -> collision
+  test_gjk_triangle_capsule(Vec3f(-0.5, -0.01, 0), true, true, Vec3f(0, 1, 0),
                             Vec3f(0.5, 0, 0));
 }

--- a/test/nesterov_gjk.cpp
+++ b/test/nesterov_gjk.cpp
@@ -1,0 +1,234 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, CNRS-LAAS INRIA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Louis Montaut */
+
+#define BOOST_TEST_MODULE FCL_NESTEROV_GJK
+#include <boost/test/included/unit_test.hpp>
+
+#include <Eigen/Geometry>
+#include <hpp/fcl/narrowphase/narrowphase.h>
+#include <hpp/fcl/shape/geometric_shapes.h>
+#include <hpp/fcl/internal/tools.h>
+
+#include "utility.h"
+
+using hpp::fcl::Box;
+using hpp::fcl::Capsule;
+using hpp::fcl::constructPolytopeFromEllipsoid;
+using hpp::fcl::Convex;
+using hpp::fcl::Ellipsoid;
+using hpp::fcl::FCL_REAL;
+using hpp::fcl::GJKVariant;
+using hpp::fcl::ShapeBase;
+using hpp::fcl::support_func_guess_t;
+using hpp::fcl::Transform3f;
+using hpp::fcl::Triangle;
+using hpp::fcl::Vec3f;
+using hpp::fcl::details::GJK;
+using hpp::fcl::details::MinkowskiDiff;
+using std::size_t;
+
+BOOST_AUTO_TEST_CASE(need_nesterov_normalize_support_direction) {
+  Ellipsoid ellipsoid = Ellipsoid(1, 1, 1);
+  Box box = Box(1, 1, 1);
+  Convex<Triangle> cvx;
+
+  MinkowskiDiff mink_diff1;
+  mink_diff1.set(&ellipsoid, &ellipsoid);
+  BOOST_CHECK(mink_diff1.normalize_support_direction == false);
+
+  MinkowskiDiff mink_diff2;
+  mink_diff2.set(&ellipsoid, &box);
+  BOOST_CHECK(mink_diff2.normalize_support_direction == false);
+
+  MinkowskiDiff mink_diff3;
+  mink_diff3.set(&cvx, &cvx);
+  BOOST_CHECK(mink_diff3.normalize_support_direction == true);
+}
+
+void test_nesterov_gjk(const ShapeBase& shape0, const ShapeBase& shape1) {
+  // Solvers
+  size_t max_iterations = 128;
+  FCL_REAL tolerance = 1e-6;
+  GJK gjk(max_iterations, tolerance);
+  GJK gjk_nesterov(max_iterations, tolerance);
+  gjk_nesterov.setGJKVariant(GJKVariant::NesterovAcceleration);
+
+  // Minkowski difference
+  MinkowskiDiff mink_diff;
+
+  // Generate random transforms
+  size_t n = 1000;
+  FCL_REAL extents[] = {-3., -3., 0, 3., 3., 3.};
+  std::vector<Transform3f> transforms;
+  generateRandomTransforms(extents, transforms, n);
+  Transform3f identity = Transform3f::Identity();
+
+  // Same init for both solvers
+  Vec3f init_guess = Vec3f(1, 0, 0);
+  support_func_guess_t init_support_guess;
+  init_support_guess.setZero();
+
+  for (size_t i = 0; i < n; ++i) {
+    mink_diff.set(&shape0, &shape1, identity, transforms[i]);
+
+    // Evaluate both solvers twice, make sure they give the same solution
+    GJK::Status res_gjk_1 =
+        gjk.evaluate(mink_diff, init_guess, init_support_guess);
+    Vec3f ray_gjk = gjk.ray;
+    GJK::Status res_gjk_2 =
+        gjk.evaluate(mink_diff, init_guess, init_support_guess);
+    BOOST_CHECK(res_gjk_1 == res_gjk_2);
+    EIGEN_VECTOR_IS_APPROX(ray_gjk, gjk.ray, 1e-8);
+
+    GJK::Status res_nesterov_gjk_1 =
+        gjk_nesterov.evaluate(mink_diff, init_guess, init_support_guess);
+    Vec3f ray_nesterov = gjk_nesterov.ray;
+    GJK::Status res_nesterov_gjk_2 =
+        gjk_nesterov.evaluate(mink_diff, init_guess, init_support_guess);
+    BOOST_CHECK(res_nesterov_gjk_1 == res_nesterov_gjk_2);
+    EIGEN_VECTOR_IS_APPROX(ray_nesterov, gjk_nesterov.ray, 1e-8);
+
+    // Make sure GJK and Nesterov accelerated GJK find the same distance between
+    // the shapes
+    BOOST_CHECK(res_nesterov_gjk_1 == res_gjk_1);
+    BOOST_CHECK_SMALL(fabs(ray_gjk.norm() - ray_nesterov.norm()), 1e-4);
+
+    // Make sure GJK and Nesterov accelerated GJK converges in a reasonable
+    // amount of iterations
+    BOOST_CHECK(gjk.getIterations() < max_iterations);
+    BOOST_CHECK(gjk_nesterov.getIterations() < max_iterations);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ellipsoid_ellipsoid) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.3, 0.4, 0.5);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+
+  test_nesterov_gjk(ellipsoid0, ellipsoid1);
+  test_nesterov_gjk(ellipsoid0, ellipsoid1);
+}
+
+BOOST_AUTO_TEST_CASE(ellipsoid_capsule) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Capsule capsule0 = Capsule(0.1, 0.3);
+  Capsule capsule1 = Capsule(1.1, 1.3);
+
+  test_nesterov_gjk(ellipsoid0, capsule0);
+  test_nesterov_gjk(ellipsoid0, capsule1);
+  test_nesterov_gjk(ellipsoid1, capsule0);
+  test_nesterov_gjk(ellipsoid1, capsule1);
+}
+
+BOOST_AUTO_TEST_CASE(ellipsoid_box) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Box box0 = Box(0.1, 0.2, 0.3);
+  Box box1 = Box(1.1, 1.2, 1.3);
+
+  test_nesterov_gjk(ellipsoid0, box0);
+  test_nesterov_gjk(ellipsoid0, box1);
+  test_nesterov_gjk(ellipsoid1, box0);
+  test_nesterov_gjk(ellipsoid1, box1);
+}
+
+BOOST_AUTO_TEST_CASE(ellipsoid_mesh) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Convex<Triangle> cvx0 = constructPolytopeFromEllipsoid(ellipsoid0);
+  Convex<Triangle> cvx1 = constructPolytopeFromEllipsoid(ellipsoid1);
+
+  test_nesterov_gjk(ellipsoid0, cvx0);
+  test_nesterov_gjk(ellipsoid0, cvx1);
+  test_nesterov_gjk(ellipsoid1, cvx0);
+  test_nesterov_gjk(ellipsoid1, cvx1);
+}
+
+BOOST_AUTO_TEST_CASE(capsule_mesh) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Convex<Triangle> cvx0 = constructPolytopeFromEllipsoid(ellipsoid0);
+  Convex<Triangle> cvx1 = constructPolytopeFromEllipsoid(ellipsoid1);
+  Capsule capsule0 = Capsule(0.1, 0.3);
+  Capsule capsule1 = Capsule(1.1, 1.3);
+
+  test_nesterov_gjk(capsule0, cvx0);
+  test_nesterov_gjk(capsule0, cvx1);
+  test_nesterov_gjk(capsule1, cvx0);
+  test_nesterov_gjk(capsule1, cvx1);
+}
+
+BOOST_AUTO_TEST_CASE(capsule_capsule) {
+  Capsule capsule0 = Capsule(0.1, 0.3);
+  Capsule capsule1 = Capsule(1.1, 1.3);
+
+  test_nesterov_gjk(capsule0, capsule0);
+  test_nesterov_gjk(capsule1, capsule1);
+  test_nesterov_gjk(capsule0, capsule1);
+}
+
+BOOST_AUTO_TEST_CASE(box_box) {
+  Box box0 = Box(0.1, 0.2, 0.3);
+  Box box1 = Box(1.1, 1.2, 1.3);
+  test_nesterov_gjk(box0, box0);
+  test_nesterov_gjk(box0, box1);
+  test_nesterov_gjk(box1, box1);
+}
+
+BOOST_AUTO_TEST_CASE(box_mesh) {
+  Box box0 = Box(0.1, 0.2, 0.3);
+  Box box1 = Box(1.1, 1.2, 1.3);
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Convex<Triangle> cvx0 = constructPolytopeFromEllipsoid(ellipsoid0);
+  Convex<Triangle> cvx1 = constructPolytopeFromEllipsoid(ellipsoid1);
+
+  test_nesterov_gjk(box0, cvx0);
+  test_nesterov_gjk(box0, cvx1);
+  test_nesterov_gjk(box1, cvx0);
+  test_nesterov_gjk(box1, cvx1);
+}
+
+BOOST_AUTO_TEST_CASE(mesh_mesh) {
+  Ellipsoid ellipsoid0 = Ellipsoid(0.5, 0.4, 0.3);
+  Ellipsoid ellipsoid1 = Ellipsoid(1.5, 1.4, 1.3);
+  Convex<Triangle> cvx0 = constructPolytopeFromEllipsoid(ellipsoid0);
+  Convex<Triangle> cvx1 = constructPolytopeFromEllipsoid(ellipsoid1);
+
+  test_nesterov_gjk(cvx0, cvx0);
+  test_nesterov_gjk(cvx0, cvx1);
+  test_nesterov_gjk(cvx1, cvx1);
+}

--- a/test/utility.h
+++ b/test/utility.h
@@ -42,6 +42,7 @@
 #include <hpp/fcl/collision_data.h>
 #include <hpp/fcl/collision_object.h>
 #include <hpp/fcl/broadphase/default_broadphase_callbacks.h>
+#include <hpp/fcl/shape/convex.h>
 
 #ifdef HPP_FCL_HAS_OCTOMAP
 #include <hpp/fcl/octree.h>
@@ -191,6 +192,13 @@ void generateEnvironments(std::vector<CollisionObject*>& env,
 
 void generateEnvironmentsMesh(std::vector<CollisionObject*>& env,
                               FCL_REAL env_scale, std::size_t n);
+
+/// @brief We give an ellipsoid as input. The output is a 20 faces polytope
+/// which vertices belong to the original ellipsoid surface. The procedure is
+/// simple: we construct a icosahedron, see
+/// https://sinestesia.co/blog/tutorials/python-icospheres/ . We then apply an
+/// ellipsoid tranformation to each vertex of the icosahedron.
+Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid);
 
 }  // namespace fcl
 


### PR DESCRIPTION
This PR implements a Nesterov acceleration for the GJK algorithm. 
In `gjk.cpp`, we simply replace the direction used to compute support points from `ray` to `dir`, where `dir` is obtained using the Nesterov scheme. An enum allows to switch from `Default` GJK to `NesterovAcceleration` GJK.

The python bindings are modified accordingly.

In a following PR I will put a link to the corresponding paper.  