### PR TITLE
Feature: adding convergence criterions for GJK algorithm

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -123,6 +123,12 @@ struct HPP_FCL_DLLAPI QueryRequest {
   /// @brief whether to enable the Nesterov accleration of GJK
   GJKVariant gjk_variant;
 
+  /// @brief convergence criterion used to stop GJK
+  GJKConvergenceCriterion convergence_criterion;
+
+  /// @brief convergence criterion used to stop GJK
+  GJKConvergenceCriterionType convergence_criterion_type;
+
   /// @brief the gjk initial guess set by user
   Vec3f cached_gjk_guess;
 
@@ -135,6 +141,8 @@ struct HPP_FCL_DLLAPI QueryRequest {
   QueryRequest()
       : enable_cached_gjk_guess(false),
         gjk_variant(GJKVariant::DefaultGJK),
+        convergence_criterion(GJKConvergenceCriterion::VDB),
+        convergence_criterion_type(GJKConvergenceCriterionType::Relative),
         cached_gjk_guess(1, 0, 0),
         cached_support_func_guess(support_func_guess_t::Zero()),
         enable_timings(false) {}

--- a/include/hpp/fcl/data_types.h
+++ b/include/hpp/fcl/data_types.h
@@ -74,6 +74,16 @@ typedef Eigen::Vector2i support_func_guess_t;
 /// @brief Variant to use for the GJK algorithm
 enum GJKVariant { DefaultGJK, NesterovAcceleration };
 
+/// @brief Which convergence criterion is used to stop the algorithm (when the
+/// shapes are not in collision). (default) VDB: Van den Bergen (A Fast and
+/// Robust GJK Implementation, 1999) DG: duality-gap, as used in the Frank-Wolfe
+/// and the vanilla 1988 GJK algorithms Hybrid: a mix between VDB and DG.
+enum GJKConvergenceCriterion { VDB, DualityGap, Hybrid };
+
+/// @brief Wether the convergence criterion is scaled on the norm of the
+/// solution or not
+enum GJKConvergenceCriterionType { Relative, Absolute };
+
 /// @brief Triangle with 3 indices for points
 class HPP_FCL_DLLAPI Triangle {
  public:

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -98,7 +98,10 @@ struct HPP_FCL_DLLAPI MinkowskiDiff {
                                      ShapeData data[2]);
   GetSupportFunction getSupportFunc;
 
-  MinkowskiDiff() : linear_log_convex_threshold(32), getSupportFunc(NULL) {}
+  MinkowskiDiff()
+      : linear_log_convex_threshold(32),
+        getSupportFunc(NULL),
+        normalize_support_direction(false) {}
 
   /// Set the two shapes,
   /// assuming the relative transformation between them is identity.

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -161,6 +161,10 @@ struct HPP_FCL_DLLAPI GJK {
     Simplex() {}
   };
 
+  /// @brief Status of the GJK algorithm:
+  /// Valid: GJK converged and the shapes are not in collision.
+  /// Inside: GJK converged and the shapes are in collision.
+  /// Failed: GJK did not converge.
   enum Status { Valid, Inside, Failed };
 
   MinkowskiDiff const* shape;

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -244,6 +244,28 @@ struct HPP_FCL_DLLAPI GJK {
 
   /// @brief Set which GJK version to use. Default is Vanilla.
   inline void setGJKVariant(GJKVariant variant) { gjk_variant = variant; }
+  inline GJKVariant getGJKVariant() { return gjk_variant; }
+
+  /// @brief Convergence check used to stop GJK when shapes are not in
+  /// collision.
+  bool checkConvergence(const Vec3f& w, const FCL_REAL& rl, FCL_REAL& alpha,
+                        const FCL_REAL& omega);
+
+  inline void setConvergenceCriterion(
+      const GJKConvergenceCriterion& criterion) {
+    convergence_criterion = criterion;
+  }
+  inline GJKConvergenceCriterion getConvergenceCriterion() {
+    return convergence_criterion;
+  }
+
+  inline void setConvergenceCriterionType(
+      const GJKConvergenceCriterionType& criterion_type) {
+    convergence_criterion_type = criterion_type;
+  }
+  inline GJKConvergenceCriterionType getConvergenceCriterionType() {
+    return convergence_criterion_type;
+  }
 
   /// @brief Get GJK number of iterations.
   inline size_t getIterations() { return iterations; }
@@ -261,6 +283,8 @@ struct HPP_FCL_DLLAPI GJK {
   FCL_REAL distance_upper_bound;
   GJKVariant gjk_variant;
   size_t iterations;
+  GJKConvergenceCriterion convergence_criterion;
+  GJKConvergenceCriterionType convergence_criterion_type;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/narrowphase.h
+++ b/include/hpp/fcl/narrowphase/narrowphase.h
@@ -72,6 +72,8 @@ struct HPP_FCL_DLLAPI GJKSolver {
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
     gjk.setGJKVariant(gjk_variant);
+    gjk.setConvergenceCriterion(convergence_criterion);
+    gjk.setConvergenceCriterionType(convergence_criterion_type);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
@@ -231,6 +233,8 @@ struct HPP_FCL_DLLAPI GJKSolver {
     gjk.setDistanceEarlyBreak(distance_upper_bound);
 
     gjk.setGJKVariant(gjk_variant);
+    gjk.setConvergenceCriterion(convergence_criterion);
+    gjk.setConvergenceCriterionType(convergence_criterion_type);
 
     details::GJK::Status gjk_status = gjk.evaluate(shape, guess, support_hint);
     if (enable_cached_guess) {
@@ -310,7 +314,9 @@ struct HPP_FCL_DLLAPI GJKSolver {
     cached_guess = Vec3f(1, 0, 0);
     support_func_cached_guess = support_func_guess_t::Zero();
     distance_upper_bound = (std::numeric_limits<FCL_REAL>::max)();
-    gjk_variant = DefaultGJK;
+    gjk_variant = GJKVariant::DefaultGJK;
+    convergence_criterion = GJKConvergenceCriterion::VDB;
+    convergence_criterion_type = GJKConvergenceCriterionType::Relative;
   }
 
   void enableCachedGuess(bool if_enable) const {
@@ -323,6 +329,16 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
   void setGJKVariant(const GJKVariant& variant) const { gjk_variant = variant; }
 
+  void setGJKConvergenceCriterion(
+      const GJKConvergenceCriterion& criterion) const {
+    convergence_criterion = criterion;
+  }
+
+  void setGJKConvergenceCriterionType(
+      const GJKConvergenceCriterionType& criterion_type) const {
+    convergence_criterion_type = criterion_type;
+  }
+
   bool operator==(const GJKSolver& other) const {
     return epa_max_face_num == other.epa_max_face_num &&
            epa_max_vertex_num == other.epa_max_vertex_num &&
@@ -333,7 +349,9 @@ struct HPP_FCL_DLLAPI GJKSolver {
            cached_guess == other.cached_guess &&
            support_func_cached_guess == other.support_func_cached_guess &&
            distance_upper_bound == other.distance_upper_bound &&
-           gjk_variant == other.gjk_variant;
+           gjk_variant == other.gjk_variant &&
+           convergence_criterion == other.convergence_criterion &&
+           convergence_criterion_type == other.convergence_criterion_type;
   }
 
   bool operator!=(const GJKSolver& other) const { return !(*this == other); }
@@ -364,6 +382,12 @@ struct HPP_FCL_DLLAPI GJKSolver {
 
   /// @brief Variant to use for the GJK algorithm
   mutable GJKVariant gjk_variant;
+
+  /// @brief Criterion used to stop GJK
+  mutable GJKConvergenceCriterion convergence_criterion;
+
+  /// @brief Relative or absolute
+  mutable GJKConvergenceCriterionType convergence_criterion_type;
 
   /// @brief smart guess for the support function
   mutable support_func_guess_t support_func_cached_guess;

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -91,7 +91,8 @@ void exposeGJK() {
         .export_values();
   }
 
-  if (!eigenpy::register_symbolic_link_to_registered_type<GJKConvergenceCriterion>()) {
+  if (!eigenpy::register_symbolic_link_to_registered_type<
+          GJKConvergenceCriterion>()) {
     enum_<GJKConvergenceCriterion>("GJKConvergenceCriterion")
         .value("VDB", GJKConvergenceCriterion::VDB)
         .value("DualityGap", GJKConvergenceCriterion::DualityGap)
@@ -99,7 +100,8 @@ void exposeGJK() {
         .export_values();
   }
 
-  if (!eigenpy::register_symbolic_link_to_registered_type<GJKConvergenceCriterionType>()) {
+  if (!eigenpy::register_symbolic_link_to_registered_type<
+          GJKConvergenceCriterionType>()) {
     enum_<GJKConvergenceCriterionType>("GJKConvergenceCriterionType")
         .value("Absolute", GJKConvergenceCriterionType::Absolute)
         .value("Relative", GJKConvergenceCriterionType::Relative)

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -86,8 +86,8 @@ void exposeGJK() {
 
   if (!eigenpy::register_symbolic_link_to_registered_type<GJKVariant>()) {
     enum_<GJKVariant>("GJKVariant")
-        .value("DefaultGJK", DefaultGJK)
-        .value("NesterovAcceleration", NesterovAcceleration)
+        .value("DefaultGJK", GJKVariant::DefaultGJK)
+        .value("NesterovAcceleration", GJKVariant::NesterovAcceleration)
         .export_values();
   }
 

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -91,6 +91,21 @@ void exposeGJK() {
         .export_values();
   }
 
+  if (!eigenpy::register_symbolic_link_to_registered_type<GJKConvergenceCriterion>()) {
+    enum_<GJKConvergenceCriterion>("GJKConvergenceCriterion")
+        .value("VDB", GJKConvergenceCriterion::VDB)
+        .value("DualityGap", GJKConvergenceCriterion::DualityGap)
+        .value("Hybrid", GJKConvergenceCriterion::Hybrid)
+        .export_values();
+  }
+
+  if (!eigenpy::register_symbolic_link_to_registered_type<GJKConvergenceCriterionType>()) {
+    enum_<GJKConvergenceCriterionType>("GJKConvergenceCriterionType")
+        .value("Absolute", GJKConvergenceCriterionType::Absolute)
+        .value("Relative", GJKConvergenceCriterionType::Relative)
+        .export_values();
+  }
+
   if (!eigenpy::register_symbolic_link_to_registered_type<GJK>()) {
     class_<GJK>("GJK", doxygen::class_doc<GJK>(), no_init)
         .def(doxygen::visitor::init<GJK, unsigned int, FCL_REAL>())

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -78,6 +78,8 @@ std::size_t collide(const CollisionGeometry* o1, const Transform3f& tf1,
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
   solver.setGJKVariant(request.gjk_variant);
+  solver.setGJKConvergenceCriterion(request.convergence_criterion);
+  solver.setGJKConvergenceCriterionType(request.convergence_criterion_type);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/collision_func_matrix.cpp
+++ b/src/collision_func_matrix.cpp
@@ -81,6 +81,8 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
   DistanceResult distanceResult;
   DistanceRequest distanceRequest(request.enable_contact);
   nsolver->setGJKVariant(request.gjk_variant);
+  nsolver->setGJKConvergenceCriterion(request.convergence_criterion);
+  nsolver->setGJKConvergenceCriterionType(request.convergence_criterion_type);
   FCL_REAL distance = ShapeShapeDistance<T_SH1, T_SH2>(
       o1, tf1, o2, tf2, nsolver, distanceRequest, distanceResult);
 

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -63,6 +63,8 @@ FCL_REAL distance(const CollisionGeometry* o1, const Transform3f& tf1,
   GJKSolver solver;
   solver.enable_cached_guess = request.enable_cached_gjk_guess;
   solver.setGJKVariant(request.gjk_variant);
+  solver.setGJKConvergenceCriterion(request.convergence_criterion);
+  solver.setGJKConvergenceCriterionType(request.convergence_criterion_type);
   if (solver.enable_cached_guess) {
     solver.cached_guess = request.cached_gjk_guess;
     solver.support_func_cached_guess = request.cached_support_func_guess;

--- a/src/distance_func_matrix.cpp
+++ b/src/distance_func_matrix.cpp
@@ -78,6 +78,8 @@ FCL_REAL ShapeShapeDistance(const CollisionGeometry* o1, const Transform3f& tf1,
   const T_SH2* obj2 = static_cast<const T_SH2*>(o2);
 
   nsolver->setGJKVariant(request.gjk_variant);
+  nsolver->setGJKConvergenceCriterion(request.convergence_criterion);
+  nsolver->setGJKConvergenceCriterionType(request.convergence_criterion_type);
 
   initialize(node, *obj1, tf1, *obj2, tf2, nsolver, request, result);
   distance(&node);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_fcl_test(profiling profiling.cpp)
 
 add_fcl_test(gjk gjk.cpp)
 add_fcl_test(nesterov_gjk nesterov_gjk.cpp)
+add_fcl_test(gjk_convergence_criterion gjk_convergence_criterion.cpp)
 if(HPP_FCL_HAS_OCTOMAP)
   add_fcl_test(octree octree.cpp)
 endif(HPP_FCL_HAS_OCTOMAP)

--- a/test/gjk_convergence_criterion.cpp
+++ b/test/gjk_convergence_criterion.cpp
@@ -1,0 +1,162 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, CNRS-LAAS INRIA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Louis Montaut */
+
+#include "hpp/fcl/data_types.h"
+#include <boost/test/tools/old/interface.hpp>
+#include <stdexcept>
+#define BOOST_TEST_MODULE FCL_NESTEROV_GJK
+#include <boost/test/included/unit_test.hpp>
+
+#include <Eigen/Geometry>
+#include <hpp/fcl/narrowphase/narrowphase.h>
+#include <hpp/fcl/shape/geometric_shapes.h>
+#include <hpp/fcl/internal/tools.h>
+
+#include "utility.h"
+
+using hpp::fcl::Box;
+using hpp::fcl::FCL_REAL;
+using hpp::fcl::support_func_guess_t;
+using hpp::fcl::Transform3f;
+using hpp::fcl::Vec3f;
+using hpp::fcl::ShapeBase;
+using hpp::fcl::details::GJK;
+using hpp::fcl::details::MinkowskiDiff;
+using hpp::fcl::GJKSolver;
+using hpp::fcl::GJKConvergenceCriterion;
+using hpp::fcl::GJKConvergenceCriterionType;
+using std::size_t;
+
+BOOST_AUTO_TEST_CASE(set_cv_criterion) {
+    GJKSolver solver;
+    GJK gjk(128, 1e-6);
+
+    // Checking defaults
+    BOOST_CHECK(solver.convergence_criterion == GJKConvergenceCriterion::VDB);
+    BOOST_CHECK(solver.convergence_criterion_type == GJKConvergenceCriterionType::Relative);
+
+    BOOST_CHECK(gjk.getConvergenceCriterion() == GJKConvergenceCriterion::VDB);
+    BOOST_CHECK(gjk.getConvergenceCriterionType() == GJKConvergenceCriterionType::Relative);
+
+    // Checking set
+    solver.setGJKConvergenceCriterion(GJKConvergenceCriterion::DualityGap);
+    gjk.setConvergenceCriterion(GJKConvergenceCriterion::DualityGap);
+    solver.setGJKConvergenceCriterionType(GJKConvergenceCriterionType::Absolute);
+    gjk.setConvergenceCriterionType(GJKConvergenceCriterionType::Absolute);
+
+    BOOST_CHECK(solver.convergence_criterion == GJKConvergenceCriterion::DualityGap);
+    BOOST_CHECK(solver.convergence_criterion_type == GJKConvergenceCriterionType::Absolute);
+
+    BOOST_CHECK(gjk.getConvergenceCriterion() == GJKConvergenceCriterion::DualityGap);
+    BOOST_CHECK(gjk.getConvergenceCriterionType() == GJKConvergenceCriterionType::Absolute);
+}
+
+void test_gjk_cv_criterion(const ShapeBase& shape0, const ShapeBase& shape1, const GJKConvergenceCriterionType cv_type) {
+    // Solvers
+    size_t max_iterations = 128;
+    // by default GJK uses the VDB convergence criterion, which is relative.
+    GJK gjk1(max_iterations, 1e-6);
+
+    FCL_REAL tol;
+    switch (cv_type) {
+        // need to lower the tolerance when absolute
+        case GJKConvergenceCriterionType::Absolute:
+            tol = 1e-8;
+            break;
+        case GJKConvergenceCriterionType::Relative:
+            tol = 1e-6;
+            break;
+        default:
+            throw std::logic_error("Wrong convergence criterion type");
+    }
+
+    GJK gjk2(max_iterations, tol);
+    gjk2.setConvergenceCriterion(GJKConvergenceCriterion::DualityGap);
+    gjk2.setConvergenceCriterionType(cv_type);
+
+    GJK gjk3(max_iterations, tol);
+    gjk3.setConvergenceCriterion(GJKConvergenceCriterion::Hybrid);
+    gjk3.setConvergenceCriterionType(cv_type);
+
+    // Minkowski difference
+    MinkowskiDiff mink_diff;
+
+    // Generate random transforms
+    size_t n = 1000;
+    FCL_REAL extents[] = {-3., -3., 0, 3., 3., 3.};
+    std::vector<Transform3f> transforms;
+    generateRandomTransforms(extents, transforms, n);
+    Transform3f identity = Transform3f::Identity();
+
+    // Same init for both solvers
+    Vec3f init_guess = Vec3f(1, 0, 0);
+    support_func_guess_t init_support_guess;
+    init_support_guess.setZero();
+
+    // Run for 3 different cv criterions
+    for (size_t i = 0; i < n; ++i) {
+        mink_diff.set(&shape0, &shape1, identity, transforms[i]);
+
+        GJK::Status res1 = gjk1.evaluate(mink_diff, init_guess, init_support_guess);
+        BOOST_CHECK(gjk1.getIterations() <= max_iterations);
+        Vec3f ray1 = gjk1.ray;
+        res1 = gjk1.evaluate(mink_diff, init_guess, init_support_guess);
+        EIGEN_VECTOR_IS_APPROX(gjk1.ray, ray1, 1e-8);
+
+        GJK::Status res2 = gjk2.evaluate(mink_diff, init_guess, init_support_guess);
+        BOOST_CHECK(gjk2.getIterations() <= max_iterations);
+        Vec3f ray2 = gjk2.ray;
+        res2 = gjk2.evaluate(mink_diff, init_guess, init_support_guess);
+        EIGEN_VECTOR_IS_APPROX(gjk2.ray, ray2, 1e-8);
+
+        GJK::Status res3 = gjk3.evaluate(mink_diff, init_guess, init_support_guess);
+        BOOST_CHECK(gjk3.getIterations() <= max_iterations);
+        Vec3f ray3 = gjk3.ray;
+        res3 = gjk3.evaluate(mink_diff, init_guess, init_support_guess);
+        EIGEN_VECTOR_IS_APPROX(gjk3.ray, ray3, 1e-8);
+
+        // check that solutions are close enough
+        EIGEN_VECTOR_IS_APPROX(gjk1.ray, gjk2.ray, 1e-4);
+        EIGEN_VECTOR_IS_APPROX(gjk1.ray, gjk3.ray, 1e-4);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(cv_criterion_same_solution) {
+    Box box0 = Box(0.1, 0.2, 0.3);
+    Box box1 = Box(1.1, 1.2, 1.3);
+    test_gjk_cv_criterion(box0, box1, GJKConvergenceCriterionType::Absolute);
+    test_gjk_cv_criterion(box0, box1, GJKConvergenceCriterionType::Relative);
+}

--- a/test/gjk_convergence_criterion.cpp
+++ b/test/gjk_convergence_criterion.cpp
@@ -1,7 +1,7 @@
 /*
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2022, CNRS-LAAS INRIA
+ *  Copyright (c) 2022, INRIA
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/test/nesterov_gjk.cpp
+++ b/test/nesterov_gjk.cpp
@@ -1,7 +1,7 @@
 /*
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2022, CNRS-LAAS INRIA
+ *  Copyright (c) 2022, INRIA
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/test/nesterov_gjk.cpp
+++ b/test/nesterov_gjk.cpp
@@ -50,6 +50,7 @@ using hpp::fcl::constructPolytopeFromEllipsoid;
 using hpp::fcl::Convex;
 using hpp::fcl::Ellipsoid;
 using hpp::fcl::FCL_REAL;
+using hpp::fcl::GJKSolver;
 using hpp::fcl::GJKVariant;
 using hpp::fcl::ShapeBase;
 using hpp::fcl::support_func_guess_t;
@@ -59,6 +60,26 @@ using hpp::fcl::Vec3f;
 using hpp::fcl::details::GJK;
 using hpp::fcl::details::MinkowskiDiff;
 using std::size_t;
+
+BOOST_AUTO_TEST_CASE(set_gjk_variant) {
+  GJKSolver solver;
+  GJK gjk(128, 1e-6);
+  MinkowskiDiff shape;
+
+  // Checking defaults
+  BOOST_CHECK(solver.gjk_variant == GJKVariant::DefaultGJK);
+  BOOST_CHECK(gjk.getGJKVariant() == GJKVariant::DefaultGJK);
+  BOOST_CHECK(shape.normalize_support_direction == false);
+
+  // Checking set
+  solver.setGJKVariant(GJKVariant::NesterovAcceleration);
+  gjk.setGJKVariant(GJKVariant::NesterovAcceleration);
+  shape.setNormalizeSupportDirection(true);
+
+  BOOST_CHECK(solver.gjk_variant == GJKVariant::NesterovAcceleration);
+  BOOST_CHECK(gjk.getGJKVariant() == GJKVariant::NesterovAcceleration);
+  BOOST_CHECK(shape.normalize_support_direction == true);
+}
 
 BOOST_AUTO_TEST_CASE(need_nesterov_normalize_support_direction) {
   Ellipsoid ellipsoid = Ellipsoid(1, 1, 1);


### PR DESCRIPTION
This PR adds the following:
- 2 more convergence criterions in addition to the default hppfcl criterion, in `GJK`. These provide different guarantees on the distance between the solution found by GJK and the optimal solution (the projection of the origin onto the Minkowski difference). Currently, hppfcl is using the criterion from the 1999 Van den Bergen [paper](http://www.dtecta.com/papers/jgt98convex.pdf). This PR adds the frank-wolf duality gap (used in the original GJK paper) as well as a mix between VDB and the duality-gap.
- exposing them to the collision/distance api, and to python
- tests for these criterions