### PR TITLE
Fix incoherent overlap

### DIFF
--- a/include/hpp/fcl/internal/traversal_node_bvh_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_bvh_shape.h
@@ -176,7 +176,7 @@ class MeshShapeCollisionTraversalNode
           this->model2_bv, this->request, sqrDistLowerBound);
     else
       disjoint = !overlap(this->tf1.getRotation(), this->tf1.getTranslation(),
-                          this->model2_bv, this->model1->getBV(b1).bv,
+                          this->model1->getBV(b1).bv, this->model2_bv,
                           this->request, sqrDistLowerBound);
     if (disjoint)
       internal::updateDistanceLowerBoundFromBV(this->request, *this->result,
@@ -287,7 +287,7 @@ class ShapeMeshCollisionTraversalNode
                                                      sqrDistLowerBound);
     else
       disjoint = !overlap(this->tf2.getRotation(), this->tf2.getTranslation(),
-                          this->model1_bv, this->model2->getBV(b2).bv,
+                          this->model2->getBV(b2).bv, this->model1_bv,
                           sqrDistLowerBound);
     if (disjoint)
       internal::updateDistanceLowerBoundFromBV(this->request, *this->result,

--- a/include/hpp/fcl/internal/traversal_node_bvhs.h
+++ b/include/hpp/fcl/internal/traversal_node_bvhs.h
@@ -168,8 +168,8 @@ class MeshCollisionTraversalNode : public BVHCollisionTraversalNode<BV> {
       disjoint = !this->model1->getBV(b1).overlap(
           this->model2->getBV(b2), this->request, sqrDistLowerBound);
     else {
-      disjoint = !overlap(RT._R(), RT._T(), this->model1->getBV(b1).bv,
-                          this->model2->getBV(b2).bv, this->request,
+      disjoint = !overlap(RT._R(), RT._T(), this->model2->getBV(b2).bv,
+                          this->model1->getBV(b1).bv, this->request,
                           sqrDistLowerBound);
     }
     if (disjoint)

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -250,7 +250,7 @@ class HeightFieldShapeCollisionTraversalNode
           this->model2_bv, this->request, sqrDistLowerBound);
     } else {
       disjoint = !overlap(this->tf1.getRotation(), this->tf1.getTranslation(),
-                          this->model2_bv, this->model1->getBV(b1).bv,
+                          this->model1->getBV(b1).bv, this->model2_bv,
                           this->request, sqrDistLowerBound);
     }
     if (disjoint)

--- a/src/BV/OBB.cpp
+++ b/src/BV/OBB.cpp
@@ -455,18 +455,18 @@ FCL_REAL OBB::distance(const OBB& /*other*/, Vec3f* /*P*/, Vec3f* /*Q*/) const {
 
 bool overlap(const Matrix3f& R0, const Vec3f& T0, const OBB& b1,
              const OBB& b2) {
-  Vec3f Ttemp(R0 * b2.To + T0 - b1.To);
+  Vec3f Ttemp(R0.transpose() * (b2.To - T0) - b1.To);
   Vec3f T(b1.axes.transpose() * Ttemp);
-  Matrix3f R(b1.axes.transpose() * R0 * b2.axes);
+  Matrix3f R(b1.axes.transpose() * R0.transpose() * b2.axes);
 
   return !obbDisjoint(R, T, b1.extent, b2.extent);
 }
 
 bool overlap(const Matrix3f& R0, const Vec3f& T0, const OBB& b1, const OBB& b2,
              const CollisionRequest& request, FCL_REAL& sqrDistLowerBound) {
-  Vec3f Ttemp(R0 * b2.To + T0 - b1.To);
+  Vec3f Ttemp(R0.transpose() * (b2.To - T0) - b1.To);
   Vec3f T(b1.axes.transpose() * Ttemp);
-  Matrix3f R(b1.axes.transpose() * R0 * b2.axes);
+  Matrix3f R(b1.axes.transpose() * R0.transpose() * b2.axes);
 
   return !obbDisjointAndLowerBoundDistance(R, T, b1.extent, b2.extent, request,
                                            sqrDistLowerBound);

--- a/src/BV/RSS.cpp
+++ b/src/BV/RSS.cpp
@@ -731,9 +731,9 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const RSS& b1,
 
   // (1 0 0)^T R0b2^T axis [0] = (1 0 0)^T b2^T R0^T axis [0]
   // R = b2^T RO^T b1
-  Vec3f Ttemp(R0 * b2.Tr + T0 - b1.Tr);
+  Vec3f Ttemp(R0.transpose() * (b2.Tr - T0) - b1.Tr);
   Vec3f T(b1.axes.transpose() * Ttemp);
-  Matrix3f R(b1.axes.transpose() * R0 * b2.axes);
+  Matrix3f R(b1.axes.transpose() * R0.transpose() * b2.axes);
 
   FCL_REAL dist = rectDistance(R, T, b1.length, b2.length);
   return (dist <= (b1.radius + b2.radius));
@@ -746,9 +746,9 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const RSS& b1, const RSS& b2,
 
   // (1 0 0)^T R0b2^T axis [0] = (1 0 0)^T b2^T R0^T axis [0]
   // R = b2^T RO^T b1
-  Vec3f Ttemp(R0 * b2.Tr + T0 - b1.Tr);
+  Vec3f Ttemp(R0.transpose() * (b2.Tr - T0) - b1.Tr);
   Vec3f T(b1.axes.transpose() * Ttemp);
-  Matrix3f R(b1.axes.transpose() * R0 * b2.axes);
+  Matrix3f R(b1.axes.transpose() * R0.transpose() * b2.axes);
 
   FCL_REAL dist =
       rectDistance(R, T, b1.length, b2.length) - b1.radius - b2.radius;

--- a/src/BV/kIOS.cpp
+++ b/src/BV/kIOS.cpp
@@ -153,11 +153,11 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const kIOS& b1,
              const kIOS& b2) {
   kIOS b2_temp = b2;
   for (unsigned int i = 0; i < b2_temp.num_spheres; ++i) {
-    b2_temp.spheres[i].o = R0 * b2_temp.spheres[i].o + T0;
+    b2_temp.spheres[i].o.noalias() = R0.transpose() * (b2_temp.spheres[i].o - T0);
   }
 
-  b2_temp.obb.To = R0 * b2_temp.obb.To + T0;
-  b2_temp.obb.axes.applyOnTheLeft(R0);
+  b2_temp.obb.To.noalias() = R0.transpose() * (b2_temp.obb.To - T0);
+  b2_temp.obb.axes.applyOnTheLeft(R0.transpose());
 
   return b1.overlap(b2_temp);
 }
@@ -167,11 +167,11 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const kIOS& b1,
              FCL_REAL& sqrDistLowerBound) {
   kIOS b2_temp = b2;
   for (unsigned int i = 0; i < b2_temp.num_spheres; ++i) {
-    b2_temp.spheres[i].o = R0 * b2_temp.spheres[i].o + T0;
+    b2_temp.spheres[i].o.noalias() = R0.transpose() * (b2_temp.spheres[i].o - T0);
   }
 
-  b2_temp.obb.To = R0 * b2_temp.obb.To + T0;
-  b2_temp.obb.axes.applyOnTheLeft(R0);
+  b2_temp.obb.To.noalias() = R0.transpose() * (b2_temp.obb.To - T0);
+  b2_temp.obb.axes.applyOnTheLeft(R0.transpose());
 
   return b1.overlap(b2_temp, request, sqrDistLowerBound);
 }

--- a/src/BV/kIOS.cpp
+++ b/src/BV/kIOS.cpp
@@ -153,7 +153,8 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const kIOS& b1,
              const kIOS& b2) {
   kIOS b2_temp = b2;
   for (unsigned int i = 0; i < b2_temp.num_spheres; ++i) {
-    b2_temp.spheres[i].o.noalias() = R0.transpose() * (b2_temp.spheres[i].o - T0);
+    b2_temp.spheres[i].o.noalias() =
+        R0.transpose() * (b2_temp.spheres[i].o - T0);
   }
 
   b2_temp.obb.To.noalias() = R0.transpose() * (b2_temp.obb.To - T0);
@@ -167,7 +168,8 @@ bool overlap(const Matrix3f& R0, const Vec3f& T0, const kIOS& b1,
              FCL_REAL& sqrDistLowerBound) {
   kIOS b2_temp = b2;
   for (unsigned int i = 0; i < b2_temp.num_spheres; ++i) {
-    b2_temp.spheres[i].o.noalias() = R0.transpose() * (b2_temp.spheres[i].o - T0);
+    b2_temp.spheres[i].o.noalias() =
+        R0.transpose() * (b2_temp.spheres[i].o - T0);
   }
 
   b2_temp.obb.To.noalias() = R0.transpose() * (b2_temp.obb.To - T0);


### PR DESCRIPTION
According to the definition of overlap, R0,T0 expressed the placement of the BV b1 and b2 is at the identity.
Consequently, we need either to transfert b1 to the origin or to express b2 in the frame of b1, defined by (R0,T0).