### PR TITLE
[CI] Remove EOL Galactic

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -14,7 +14,6 @@ jobs:
           - {ROS_DISTRO: melodic, PRERELEASE: false}
           - {ROS_DISTRO: noetic}
           - {ROS_DISTRO: foxy}
-          - {ROS_DISTRO: galactic}
           - {ROS_DISTRO: rolling}
           - {ROS_DISTRO: humble}
     env:


### PR DESCRIPTION
Remove CI for EOL distro Galactic. This is likely to have caused the CI failures in #363