### PR TITLE
CI : add build options (Debug, AVX2)

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -4,13 +4,22 @@ on: [push,pull_request]
 
 jobs:
   hpp-fcl-conda:
-    name: CI on ${{ matrix.os }} with Conda
+    name: CI on ${{ matrix.os }} with Conda - ${{ matrix.build_type }} ${{ matrix.cxx_options }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
+        cxx_options: ['', '-mavx2']
+        build_type: [Release, Debug]
+        exclude:
+          - build_type: Debug
+            cxx_options: -mavx2
+            os: macos-latest
+          - build_type: Release
+            cxx_options: -mavx2
+            os: macos-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -48,7 +57,8 @@ jobs:
         mkdir build
         cd build
 
-        cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DGENERATE_PYTHON_STUBS=ON -DHPP_FCL_HAS_QHULL=ON
+        export CXXFLAGS=${{ matrix.cxx_options }}
+        cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPYTHON_EXECUTABLE=$(which python3) -DGENERATE_PYTHON_STUBS=ON -DHPP_FCL_HAS_QHULL=ON
         make -j2
         make build_tests
         export CTEST_OUTPUT_ON_FAILURE=1


### PR DESCRIPTION
In this PR, we add options for the macos/linux build on Conda, similar to what was done [here](https://github.com/stack-of-tasks/eigenpy/blob/e9ba801d6563ce7a7aecaf9ca37eea54f5073714/.github/workflows/macos-linux-conda.yml) after [this PR](https://github.com/stack-of-tasks/eigenpy/pull/336/files).

The added build options are:
* compiling with the CMake `Debug` build type
* compiling with the `-mavx2` flag