### PR TITLE
Adding mesh double description

### DIFF
--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -476,10 +476,14 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
 
     if (num_bvs != other.num_bvs) return false;
 
-    const std::vector<BVNode<BV>>& bvs_ = *bvs;
-    const std::vector<BVNode<BV>>& other_bvs_ = *(other.bvs);
-    for (unsigned int k = 0; k < num_bvs; ++k) {
-      if (bvs_[k] != other_bvs_[k]) return false;
+    if ((!(bvs.get()) && other.bvs.get()) || (bvs.get() && !(other.bvs.get())))
+      return false;
+    if (bvs.get() && other.bvs.get()) {
+      const std::vector<BVNode<BV>>& bvs_ = *bvs;
+      const std::vector<BVNode<BV>>& other_bvs_ = *(other.bvs);
+      for (unsigned int k = 0; k < num_bvs; ++k) {
+        if (bvs_[k] != other_bvs_[k]) return false;
+      }
     }
 
     return true;

--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -341,13 +341,13 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
   /// @brief Access the bv giving the its index
   const BVNode<BV>& getBV(unsigned int i) const {
     assert(i < num_bvs);
-    return bvs.get()[i];
+    return (*bvs)[i];
   }
 
   /// @brief Access the bv giving the its index
   BVNode<BV>& getBV(unsigned int i) {
     assert(i < num_bvs);
-    return bvs.get()[i];
+    return (*bvs)[i];
   }
 
   /// @brief Get the number of bv in the BVH
@@ -373,10 +373,10 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
   bool allocateBVs();
 
   unsigned int num_bvs_allocated;
-  std::shared_ptr<unsigned int> primitive_indices;
+  std::shared_ptr<std::vector<unsigned int>> primitive_indices;
 
   /// @brief Bounding volume hierarchy
-  std::shared_ptr<BVNode<BV>> bvs;
+  std::shared_ptr<std::vector<BVNode<BV>>> bvs;
 
   /// @brief Number of BV nodes in bounding volume hierarchy
   unsigned int num_bvs;
@@ -407,16 +407,19 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
   /// OBBRSS), special implementation is provided.
   void makeParentRelativeRecurse(int bv_id, Matrix3f& parent_axes,
                                  const Vec3f& parent_c) {
-    BVNode<BV>* bvs_ = bvs.get();
-    if (!bvs_[bv_id].isLeaf()) {
-      makeParentRelativeRecurse(bvs_[bv_id].first_child, parent_axes,
-                                bvs_[bv_id].getCenter());
+    std::vector<BVNode<BV>>& bvs_ = *bvs;
+    if (!bvs_[static_cast<size_t>(bv_id)].isLeaf()) {
+      makeParentRelativeRecurse(bvs_[static_cast<size_t>(bv_id)].first_child,
+                                parent_axes,
+                                bvs_[static_cast<size_t>(bv_id)].getCenter());
 
-      makeParentRelativeRecurse(bvs_[bv_id].first_child + 1, parent_axes,
-                                bvs_[bv_id].getCenter());
+      makeParentRelativeRecurse(
+          bvs_[static_cast<size_t>(bv_id)].first_child + 1, parent_axes,
+          bvs_[static_cast<size_t>(bv_id)].getCenter());
     }
 
-    bvs_[bv_id].bv = translate(bvs_[bv_id].bv, -parent_c);
+    bvs_[static_cast<size_t>(bv_id)].bv =
+        translate(bvs_[static_cast<size_t>(bv_id)].bv, -parent_c);
   }
 
  private:
@@ -473,8 +476,8 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
 
     if (num_bvs != other.num_bvs) return false;
 
-    BVNode<BV>* bvs_ = bvs.get();
-    BVNode<BV>* other_bvs_ = other.bvs.get();
+    const std::vector<BVNode<BV>>& bvs_ = *bvs;
+    const std::vector<BVNode<BV>>& other_bvs_ = *(other.bvs);
     for (unsigned int k = 0; k < num_bvs; ++k) {
       if (bvs_[k] != other_bvs_[k]) return false;
     }

--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -67,7 +67,7 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
   std::shared_ptr<std::vector<Vec3f>> vertices;
 
   /// @brief Geometry triangle index data, will be NULL for point clouds
-  std::shared_ptr<Triangle> tri_indices;
+  std::shared_ptr<std::vector<Triangle>> tri_indices;
 
   /// @brief Geometry point data in previous frame
   std::shared_ptr<std::vector<Vec3f>> prev_vertices;
@@ -200,22 +200,28 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
   Vec3f computeCOM() const {
     FCL_REAL vol = 0;
     Vec3f com(0, 0, 0);
-    if (vertices.get()) {
-      const std::vector<Vec3f>& vertices_ = *vertices;
-      const Triangle* tri_indices_ = tri_indices.get();
-      for (unsigned int i = 0; i < num_tris; ++i) {
-        const Triangle& tri = tri_indices_[i];
-        FCL_REAL d_six_vol =
-          (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
-        vol += d_six_vol;
-        com += (vertices_[tri[0]] + vertices_[tri[1]] + vertices_[tri[2]]) *
-          d_six_vol;
-      }
-    } else {
+    if (!(vertices.get())) {
       std::cerr << "BVH Error in `computeCOM`! The BVHModel does not contain "
                    "vertices."
                 << std::endl;
       return com;
+    }
+    const std::vector<Vec3f>& vertices_ = *vertices;
+    if (!(tri_indices.get())) {
+      std::cerr << "BVH Error in `computeCOM`! The BVHModel does not contain "
+                   "triangles."
+                << std::endl;
+      return com;
+    }
+    const std::vector<Triangle>& tri_indices_ = *tri_indices;
+
+    for (unsigned int i = 0; i < num_tris; ++i) {
+      const Triangle& tri = tri_indices_[i];
+      FCL_REAL d_six_vol =
+          (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
+      vol += d_six_vol;
+      com += (vertices_[tri[0]] + vertices_[tri[1]] + vertices_[tri[2]]) *
+             d_six_vol;
     }
 
     return com / (vol * 4);
@@ -223,19 +229,25 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
 
   FCL_REAL computeVolume() const {
     FCL_REAL vol = 0;
-    if (vertices.get()) {
-      const std::vector<Vec3f>& vertices_ = *vertices;
-      const Triangle* tri_indices_ = tri_indices.get();
-      for (unsigned int i = 0; i < num_tris; ++i) {
-        const Triangle& tri = tri_indices_[i];
-        FCL_REAL d_six_vol =
-          (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
-        vol += d_six_vol;
-      }
-    } else {
-      std::cerr << "BVH Error in `computeVolume`! The BVHModel does not "
-                   "contain vertices."
+    if (!(vertices.get())) {
+      std::cerr << "BVH Error in `computeCOM`! The BVHModel does not contain "
+                   "vertices."
                 << std::endl;
+      return vol;
+    }
+    const std::vector<Vec3f>& vertices_ = *vertices;
+    if (!(tri_indices.get())) {
+      std::cerr << "BVH Error in `computeCOM`! The BVHModel does not contain "
+                   "triangles."
+                << std::endl;
+      return vol;
+    }
+    const std::vector<Triangle>& tri_indices_ = *tri_indices;
+    for (unsigned int i = 0; i < num_tris; ++i) {
+      const Triangle& tri = tri_indices_[i];
+      FCL_REAL d_six_vol =
+          (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
+      vol += d_six_vol;
     }
 
     return vol / 6;
@@ -248,22 +260,28 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
     C_canonical << 1 / 60.0, 1 / 120.0, 1 / 120.0, 1 / 120.0, 1 / 60.0,
         1 / 120.0, 1 / 120.0, 1 / 120.0, 1 / 60.0;
 
-    if (vertices.get()) {
-      const std::vector<Vec3f>& vertices_ = *vertices;
-      const Triangle* tri_indices_ = tri_indices.get();
-      for (unsigned int i = 0; i < num_tris; ++i) {
-        const Triangle& tri = tri_indices_[i];
-        const Vec3f& v1 = vertices_[tri[0]];
-        const Vec3f& v2 = vertices_[tri[1]];
-        const Vec3f& v3 = vertices_[tri[2]];
-        Matrix3f A;
-        A << v1.transpose(), v2.transpose(), v3.transpose();
-        C += A.derived().transpose() * C_canonical * A * (v1.cross(v2)).dot(v3);
-      }
-    } else {
+    if (!(vertices.get())) {
       std::cerr << "BVH Error in `computeMomentofInertia`! The BVHModel does "
                    "not contain vertices."
                 << std::endl;
+      return C;
+    }
+    const std::vector<Vec3f>& vertices_ = *vertices;
+    if (!(vertices.get())) {
+      std::cerr << "BVH Error in `computeMomentofInertia`! The BVHModel does "
+                   "not contain vertices."
+                << std::endl;
+      return C;
+    }
+    const std::vector<Triangle>& tri_indices_ = *tri_indices;
+    for (unsigned int i = 0; i < num_tris; ++i) {
+      const Triangle& tri = tri_indices_[i];
+      const Vec3f& v1 = vertices_[tri[0]];
+      const Vec3f& v2 = vertices_[tri[1]];
+      const Vec3f& v3 = vertices_[tri[2]];
+      Matrix3f A;
+      A << v1.transpose(), v2.transpose(), v3.transpose();
+      C += A.derived().transpose() * C_canonical * A * (v1.cross(v2)).dot(v3);
     }
 
     return C.trace() * Matrix3f::Identity() - C;

--- a/include/hpp/fcl/data_types.h
+++ b/include/hpp/fcl/data_types.h
@@ -68,8 +68,9 @@ typedef Eigen::Matrix<FCL_REAL, 3, 1> Vec3f;
 typedef Eigen::Matrix<FCL_REAL, 6, 1> Vec6f;
 typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, 1> VecXf;
 typedef Eigen::Matrix<FCL_REAL, 3, 3> Matrix3f;
-typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, 3> Matrixx3f;
-typedef Eigen::Matrix<Eigen::DenseIndex, Eigen::Dynamic, 3> Matrixx3i;
+typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, 3, Eigen::RowMajor> Matrixx3f;
+typedef Eigen::Matrix<Eigen::DenseIndex, Eigen::Dynamic, 3, Eigen::RowMajor>
+    Matrixx3i;
 typedef Eigen::Matrix<FCL_REAL, Eigen::Dynamic, Eigen::Dynamic> MatrixXf;
 typedef Eigen::Vector2i support_func_guess_t;
 

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -74,16 +74,16 @@ Convex<Quadrilateral> buildConvexQuadrilateral(const HFNode<BV>& node,
          "max_height is lower than min_height");  // Check whether the geometry
                                                   // is degenerated
 
-  std::shared_ptr<Vec3f> pts(new Vec3f[8]);
-  Vec3f* pts_ = pts.get();
-  pts_[0] = Vec3f(x0, y0, min_height);
-  pts_[1] = Vec3f(x0, y1, min_height);
-  pts_[2] = Vec3f(x1, y1, min_height);
-  pts_[3] = Vec3f(x1, y0, min_height);
-  pts_[4] = Vec3f(x0, y0, cell(0, 0));
-  pts_[5] = Vec3f(x0, y1, cell(1, 0));
-  pts_[6] = Vec3f(x1, y1, cell(1, 1));
-  pts_[7] = Vec3f(x1, y0, cell(0, 1));
+  std::shared_ptr<std::vector<Vec3f>> pts(new std::vector<Vec3f>({
+      Vec3f(x0, y0, min_height),
+      Vec3f(x0, y1, min_height),
+      Vec3f(x1, y1, min_height),
+      Vec3f(x1, y0, min_height),
+      Vec3f(x0, y0, cell(0, 0)),
+      Vec3f(x0, y1, cell(1, 0)),
+      Vec3f(x1, y1, cell(1, 1)),
+      Vec3f(x1, y0, cell(0, 1)),
+  }));
 
   std::shared_ptr<Quadrilateral> polygons(new Quadrilateral[6]);
   Quadrilateral* polygons_ = polygons.get();
@@ -123,14 +123,14 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
   HPP_FCL_UNUSED_VARIABLE(max_height);
 
   {
-    std::shared_ptr<Vec3f> pts(new Vec3f[6]);
-    Vec3f* pts_ = pts.get();
-    pts_[0] = Vec3f(x0, y0, min_height);  //
-    pts_[1] = Vec3f(x0, y1, min_height);  //
-    pts_[2] = Vec3f(x1, y0, min_height);  //
-    pts_[3] = Vec3f(x0, y0, cell(0, 0));  //
-    pts_[4] = Vec3f(x0, y1, cell(1, 0));  //
-    pts_[5] = Vec3f(x1, y0, cell(0, 1));  //
+    std::shared_ptr<std::vector<Vec3f>> pts(new std::vector<Vec3f>({
+        Vec3f(x0, y0, min_height),
+        Vec3f(x0, y1, min_height),
+        Vec3f(x1, y0, min_height),
+        Vec3f(x0, y0, cell(0, 0)),
+        Vec3f(x0, y1, cell(1, 0)),
+        Vec3f(x1, y0, cell(0, 1)),
+    }));
 
     std::shared_ptr<Triangle> triangles(new Triangle[8]);
     Triangle* triangles_ = triangles.get();
@@ -151,14 +151,14 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
   }
 
   {
-    std::shared_ptr<Vec3f> pts(new Vec3f[6]);
-    Vec3f* pts_ = pts.get();
-    pts_[0] = Vec3f(x0, y1, min_height);
-    pts_[1] = Vec3f(x1, y1, min_height);
-    pts_[2] = Vec3f(x1, y0, min_height);
-    pts_[3] = Vec3f(x0, y1, cell(1, 0));
-    pts_[4] = Vec3f(x1, y1, cell(1, 1));
-    pts_[5] = Vec3f(x1, y0, cell(0, 1));
+    std::shared_ptr<std::vector<Vec3f>> pts(new std::vector<Vec3f>({
+        Vec3f(x0, y1, min_height),
+        Vec3f(x1, y1, min_height),
+        Vec3f(x1, y0, min_height),
+        Vec3f(x0, y1, cell(1, 0)),
+        Vec3f(x1, y1, cell(1, 1)),
+        Vec3f(x1, y0, cell(0, 1)),
+    }));
 
     std::shared_ptr<Triangle> triangles(new Triangle[8]);
     Triangle* triangles_ = triangles.get();
@@ -196,7 +196,7 @@ bool binCorrection(const Convex<Polygone>& convex, const Shape& shape,
                    Vec3f& contact_1, Vec3f& contact_2, Vec3f& normal,
                    Vec3f& normal_top, bool& is_collision) {
   const Polygone& top_triangle = convex.polygons.get()[1];
-  const Vec3f* points = convex.points.get();
+  const std::vector<Vec3f>& points = *(convex.points);
   const Vec3f pointA = points[top_triangle[0]];
   const Vec3f pointB = points[top_triangle[1]];
   const Vec3f pointC = points[top_triangle[2]];

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -85,14 +85,14 @@ Convex<Quadrilateral> buildConvexQuadrilateral(const HFNode<BV>& node,
       Vec3f(x1, y0, cell(0, 1)),
   }));
 
-  std::shared_ptr<Quadrilateral> polygons(new Quadrilateral[6]);
-  Quadrilateral* polygons_ = polygons.get();
-  polygons_[0].set(0, 3, 2, 1);  // x+ side
-  polygons_[1].set(0, 1, 5, 4);  // y- side
-  polygons_[2].set(1, 2, 6, 5);  // x- side
-  polygons_[3].set(2, 3, 7, 6);  // y+ side
-  polygons_[4].set(3, 0, 4, 7);  // z- side
-  polygons_[5].set(4, 5, 6, 7);  // z+ side
+  std::shared_ptr<std::vector<Quadrilateral>> polygons(
+      new std::vector<Quadrilateral>(6));
+  (*polygons)[0].set(0, 3, 2, 1);  // x+ side
+  (*polygons)[1].set(0, 1, 5, 4);  // y- side
+  (*polygons)[2].set(1, 2, 6, 5);  // x- side
+  (*polygons)[3].set(2, 3, 7, 6);  // y+ side
+  (*polygons)[4].set(3, 0, 4, 7);  // z- side
+  (*polygons)[5].set(4, 5, 6, 7);  // z+ side
 
   return Convex<Quadrilateral>(pts,  // points
                                8,    // num points
@@ -132,16 +132,16 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
         Vec3f(x1, y0, cell(0, 1)),
     }));
 
-    std::shared_ptr<Triangle> triangles(new Triangle[8]);
-    Triangle* triangles_ = triangles.get();
-    triangles_[0].set(0, 1, 2);  // bottom
-    triangles_[1].set(3, 5, 4);  // top
-    triangles_[2].set(0, 3, 1);
-    triangles_[3].set(3, 4, 1);
-    triangles_[4].set(1, 5, 2);
-    triangles_[5].set(1, 4, 5);
-    triangles_[6].set(0, 2, 5);
-    triangles_[7].set(5, 3, 0);
+    std::shared_ptr<std::vector<Triangle>> triangles(
+        new std::vector<Triangle>(8));
+    (*triangles)[0].set(0, 1, 2);  // bottom
+    (*triangles)[1].set(3, 5, 4);  // top
+    (*triangles)[2].set(0, 3, 1);
+    (*triangles)[3].set(3, 4, 1);
+    (*triangles)[4].set(1, 5, 2);
+    (*triangles)[5].set(1, 4, 5);
+    (*triangles)[6].set(0, 2, 5);
+    (*triangles)[7].set(5, 3, 0);
 
     convex1.set(pts,  // points
                 6,    // num points
@@ -160,16 +160,16 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
         Vec3f(x1, y0, cell(0, 1)),
     }));
 
-    std::shared_ptr<Triangle> triangles(new Triangle[8]);
-    Triangle* triangles_ = triangles.get();
-    triangles_[0].set(2, 0, 1);  // bottom
-    triangles_[1].set(3, 5, 4);  // top
-    triangles_[2].set(0, 3, 1);
-    triangles_[3].set(3, 4, 1);
-    triangles_[4].set(0, 2, 5);
-    triangles_[5].set(0, 5, 3);
-    triangles_[6].set(1, 5, 2);
-    triangles_[7].set(4, 2, 1);
+    std::shared_ptr<std::vector<Triangle>> triangles(
+        new std::vector<Triangle>(8));
+    (*triangles)[0].set(2, 0, 1);  // bottom
+    (*triangles)[1].set(3, 5, 4);  // top
+    (*triangles)[2].set(0, 3, 1);
+    (*triangles)[3].set(3, 4, 1);
+    (*triangles)[4].set(0, 2, 5);
+    (*triangles)[5].set(0, 5, 3);
+    (*triangles)[6].set(1, 5, 2);
+    (*triangles)[7].set(4, 2, 1);
 
     convex2.set(pts,  // points
                 6,    // num points
@@ -195,7 +195,7 @@ bool binCorrection(const Convex<Polygone>& convex, const Shape& shape,
                    const Transform3f& shape_pose, FCL_REAL& distance,
                    Vec3f& contact_1, Vec3f& contact_2, Vec3f& normal,
                    Vec3f& normal_top, bool& is_collision) {
-  const Polygone& top_triangle = convex.polygons.get()[1];
+  const Polygone& top_triangle = (*(convex.polygons))[1];
   const std::vector<Vec3f>& points = *(convex.points);
   const Vec3f pointA = points[top_triangle[0]];
   const Vec3f pointB = points[top_triangle[1]];

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -372,9 +372,9 @@ class HPP_FCL_DLLAPI OcTreeSolver {
 
         int primitive_id = tree2->getBV(root2).primitiveId();
         const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
-        const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
-        const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
-        const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];
+        const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
+        const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
+        const Vec3f& p3 = (*(tree2->vertices))[tri_id[2]];
 
         FCL_REAL dist;
         Vec3f closest_p1, closest_p2, normal;
@@ -485,9 +485,9 @@ class HPP_FCL_DLLAPI OcTreeSolver {
 
       int primitive_id = bvn2.primitiveId();
       const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
-      const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
-      const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
-      const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];
+      const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
+      const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
+      const Vec3f& p3 = (*(tree2->vertices))[tri_id[2]];
 
       Vec3f c1, c2, normal;
       FCL_REAL distance;

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -370,7 +370,8 @@ class HPP_FCL_DLLAPI OcTreeSolver {
         Transform3f box_tf;
         constructBox(bv1, tf1, box, box_tf);
 
-        int primitive_id = tree2->getBV(root2).primitiveId();
+        size_t primitive_id =
+            static_cast<size_t>(tree2->getBV(root2).primitiveId());
         const Triangle& tri_id = (*(tree2->tri_indices))[primitive_id];
         const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
         const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
@@ -382,7 +383,8 @@ class HPP_FCL_DLLAPI OcTreeSolver {
                                          closest_p1, closest_p2, normal);
 
         dresult->update(dist, tree1, tree2, (int)(root1 - tree1->getRoot()),
-                        primitive_id, closest_p1, closest_p2, normal);
+                        static_cast<int>(primitive_id), closest_p1, closest_p2,
+                        normal);
 
         return drequest->isSatisfied(*dresult);
       } else
@@ -483,7 +485,7 @@ class HPP_FCL_DLLAPI OcTreeSolver {
       Transform3f box_tf;
       constructBox(bv1, tf1, box, box_tf);
 
-      int primitive_id = bvn2.primitiveId();
+      size_t primitive_id = static_cast<size_t>(bvn2.primitiveId());
       const Triangle& tri_id = (*(tree2->tri_indices))[primitive_id];
       const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
       const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
@@ -498,9 +500,9 @@ class HPP_FCL_DLLAPI OcTreeSolver {
 
       if (cresult->numContacts() < crequest->num_max_contacts) {
         if (distToCollision <= crequest->collision_distance_threshold) {
-          cresult->addContact(Contact(tree1, tree2,
-                                      (int)(root1 - tree1->getRoot()),
-                                      primitive_id, c1, c2, normal, distance));
+          cresult->addContact(Contact(
+              tree1, tree2, (int)(root1 - tree1->getRoot()),
+              static_cast<int>(primitive_id), c1, c2, normal, distance));
         }
       }
       internal::updateDistanceLowerBoundFromLeaf(*crequest, *cresult,

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -371,7 +371,7 @@ class HPP_FCL_DLLAPI OcTreeSolver {
         constructBox(bv1, tf1, box, box_tf);
 
         int primitive_id = tree2->getBV(root2).primitiveId();
-        const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
+        const Triangle& tri_id = (*(tree2->tri_indices))[primitive_id];
         const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
         const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
         const Vec3f& p3 = (*(tree2->vertices))[tri_id[2]];
@@ -484,7 +484,7 @@ class HPP_FCL_DLLAPI OcTreeSolver {
       constructBox(bv1, tf1, box, box_tf);
 
       int primitive_id = bvn2.primitiveId();
-      const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
+      const Triangle& tri_id = (*(tree2->tri_indices))[primitive_id];
       const Vec3f& p1 = (*(tree2->vertices))[tri_id[0]];
       const Vec3f& p2 = (*(tree2->vertices))[tri_id[1]];
       const Vec3f& p3 = (*(tree2->vertices))[tri_id[2]];

--- a/include/hpp/fcl/internal/traversal_node_setup.h
+++ b/include/hpp/fcl/internal/traversal_node_setup.h
@@ -365,7 +365,8 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
-  node.tri_indices = model1.tri_indices.get();
+  node.tri_indices =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
 
   node.result = &result;
 
@@ -393,7 +394,8 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S, 0>& node,
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
-  node.tri_indices = model1.tri_indices.get();
+  node.tri_indices =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
 
   node.result = &result;
 
@@ -450,7 +452,8 @@ static inline bool setupShapeMeshCollisionOrientedNode(
   computeBV(model1, tf1, node.model1_bv);
 
   node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
-  node.tri_indices = model2.tri_indices.get();
+  node.tri_indices =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   node.result = &result;
 
@@ -516,8 +519,10 @@ bool initialize(
   node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
-  node.tri_indices1 = model1.tri_indices.get();
-  node.tri_indices2 = model2.tri_indices.get();
+  node.tri_indices1 =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
+  node.tri_indices2 =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   node.result = &result;
 
@@ -541,8 +546,10 @@ bool initialize(MeshCollisionTraversalNode<BV, 0>& node,
   node.vertices1 = model1.vertices ? model1.vertices->data() : NULL;
   node.vertices2 = model2.vertices ? model2.vertices->data() : NULL;
 
-  node.tri_indices1 = model1.tri_indices.get();
-  node.tri_indices2 = model2.tri_indices.get();
+  node.tri_indices1 =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
+  node.tri_indices2 =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   node.model1 = &model1;
   node.tf1 = tf1;
@@ -636,8 +643,10 @@ bool initialize(
   node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
-  node.tri_indices1 = model1.tri_indices.get();
-  node.tri_indices2 = model2.tri_indices.get();
+  node.tri_indices1 =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
+  node.tri_indices2 =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   return true;
 }
@@ -668,8 +677,10 @@ bool initialize(MeshDistanceTraversalNode<BV, 0>& node,
   node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
-  node.tri_indices1 = model1.tri_indices.get();
-  node.tri_indices2 = model2.tri_indices.get();
+  node.tri_indices1 =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
+  node.tri_indices2 =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   relativeTransform(tf1.getRotation(), tf1.getTranslation(), tf2.getRotation(),
                     tf2.getTranslation(), node.RT.R, node.RT.T);
@@ -716,7 +727,8 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
   node.nsolver = nsolver;
 
   node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
-  node.tri_indices = model1.tri_indices.get();
+  node.tri_indices =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
 
   computeBV(model2, tf2, node.model2_bv);
 
@@ -762,7 +774,8 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
   node.nsolver = nsolver;
 
   node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
-  node.tri_indices = model2.tri_indices.get();
+  node.tri_indices =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
 
   computeBV(model1, tf1, node.model1_bv);
 
@@ -794,7 +807,8 @@ static inline bool setupMeshShapeDistanceOrientedNode(
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
-  node.tri_indices = model1.tri_indices.get();
+  node.tri_indices =
+      model1.tri_indices.get() ? model1.tri_indices->data() : NULL;
 
   return true;
 }
@@ -861,7 +875,8 @@ static inline bool setupShapeMeshDistanceOrientedNode(
   computeBV(model1, tf1, node.model1_bv);
 
   node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
-  node.tri_indices = model2.tri_indices.get();
+  node.tri_indices =
+      model2.tri_indices.get() ? model2.tri_indices->data() : NULL;
   node.R = tf2.getRotation();
   node.T = tf2.getTranslation();
 

--- a/include/hpp/fcl/internal/traversal_node_setup.h
+++ b/include/hpp/fcl/internal/traversal_node_setup.h
@@ -338,10 +338,11 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
         "model1 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  if (!tf1.isIdentity())  // TODO(jcarpent): vectorized version
+  if (!tf1.isIdentity() &&
+      model1.vertices.get())  // TODO(jcarpent): vectorized version
   {
     std::vector<Vec3f> vertices_transformed(model1.num_vertices);
-    const Vec3f* model1_vertices_ = model1.vertices.get();
+    const std::vector<Vec3f>& model1_vertices_ = *(model1.vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
       const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
@@ -363,7 +364,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices.get();
+  node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.tri_indices = model1.tri_indices.get();
 
   node.result = &result;
@@ -391,7 +392,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S, 0>& node,
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices.get();
+  node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.tri_indices = model1.tri_indices.get();
 
   node.result = &result;
@@ -448,7 +449,7 @@ static inline bool setupShapeMeshCollisionOrientedNode(
 
   computeBV(model1, tf1, node.model1_bv);
 
-  node.vertices = model2.vertices.get();
+  node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
   node.tri_indices = model2.tri_indices.get();
 
   node.result = &result;
@@ -475,9 +476,9 @@ bool initialize(
         "model2 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  if (!tf1.isIdentity()) {
+  if (!tf1.isIdentity() && model1.vertices.get()) {
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
-    const Vec3f* model1_vertices_ = model1.vertices.get();
+    const std::vector<Vec3f>& model1_vertices_ = *(model1.vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
       const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
@@ -491,9 +492,9 @@ bool initialize(
     tf1.setIdentity();
   }
 
-  if (!tf2.isIdentity()) {
+  if (!tf2.isIdentity() && model2.vertices.get()) {
     std::vector<Vec3f> vertices_transformed2(model2.num_vertices);
-    const Vec3f* model2_vertices_ = model2.vertices.get();
+    const std::vector<Vec3f>& model2_vertices_ = *(model2.vertices);
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
       const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
@@ -512,8 +513,8 @@ bool initialize(
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices.get();
-  node.vertices2 = model2.vertices.get();
+  node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
+  node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
   node.tri_indices1 = model1.tri_indices.get();
   node.tri_indices2 = model2.tri_indices.get();
@@ -537,8 +538,8 @@ bool initialize(MeshCollisionTraversalNode<BV, 0>& node,
         "model2 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  node.vertices1 = model1.vertices.get();
-  node.vertices2 = model2.vertices.get();
+  node.vertices1 = model1.vertices ? model1.vertices->data() : NULL;
+  node.vertices2 = model2.vertices ? model2.vertices->data() : NULL;
 
   node.tri_indices1 = model1.tri_indices.get();
   node.tri_indices2 = model2.tri_indices.get();
@@ -592,9 +593,9 @@ bool initialize(
         "model2 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  if (!tf1.isIdentity()) {
-    const Vec3f* model1_vertices_ = model1.vertices.get();
+  if (!tf1.isIdentity() && model1.vertices.get()) {
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
+    const std::vector<Vec3f>& model1_vertices_ = *(model1.vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
       const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
@@ -608,9 +609,9 @@ bool initialize(
     tf1.setIdentity();
   }
 
-  if (!tf2.isIdentity()) {
-    const Vec3f* model2_vertices_ = model2.vertices.get();
+  if (!tf2.isIdentity() && model2.vertices.get()) {
     std::vector<Vec3f> vertices_transformed2(model2.num_vertices);
+    const std::vector<Vec3f>& model2_vertices_ = *(model2.vertices);
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
       const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
@@ -632,8 +633,8 @@ bool initialize(
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices.get();
-  node.vertices2 = model2.vertices.get();
+  node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
+  node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
   node.tri_indices1 = model1.tri_indices.get();
   node.tri_indices2 = model2.tri_indices.get();
@@ -664,8 +665,8 @@ bool initialize(MeshDistanceTraversalNode<BV, 0>& node,
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices.get();
-  node.vertices2 = model2.vertices.get();
+  node.vertices1 = model1.vertices.get() ? model1.vertices->data() : NULL;
+  node.vertices2 = model2.vertices.get() ? model2.vertices->data() : NULL;
 
   node.tri_indices1 = model1.tri_indices.get();
   node.tri_indices2 = model2.tri_indices.get();
@@ -689,8 +690,8 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
         "model1 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  const Vec3f* model1_vertices_ = model1.vertices.get();
-  if (!tf1.isIdentity()) {
+  if (!tf1.isIdentity() && model1.vertices.get()) {
+    const std::vector<Vec3f>& model1_vertices_ = *(model1.vertices);
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
       const Vec3f& p = model1_vertices_[i];
@@ -714,7 +715,7 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
   node.tf2 = tf2;
   node.nsolver = nsolver;
 
-  node.vertices = model1.vertices.get();
+  node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.tri_indices = model1.tri_indices.get();
 
   computeBV(model2, tf2, node.model2_bv);
@@ -735,9 +736,9 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
         "model2 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  if (!tf2.isIdentity()) {
+  if (!tf2.isIdentity() && model2.vertices.get()) {
     std::vector<Vec3f> vertices_transformed(model2.num_vertices);
-    const Vec3f* model2_vertices_ = model2.vertices.get();
+    const std::vector<Vec3f>& model2_vertices_ = *(model2.vertices);
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
       const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
@@ -760,7 +761,7 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
   node.tf2 = tf2;
   node.nsolver = nsolver;
 
-  node.vertices = model2.vertices.get();
+  node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
   node.tri_indices = model2.tri_indices.get();
 
   computeBV(model1, tf1, node.model1_bv);
@@ -792,7 +793,7 @@ static inline bool setupMeshShapeDistanceOrientedNode(
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices.get();
+  node.vertices = model1.vertices.get() ? model1.vertices->data() : NULL;
   node.tri_indices = model1.tri_indices.get();
 
   return true;
@@ -859,7 +860,7 @@ static inline bool setupShapeMeshDistanceOrientedNode(
 
   computeBV(model1, tf1, node.model1_bv);
 
-  node.vertices = model2.vertices.get();
+  node.vertices = model2.vertices.get() ? model2.vertices->data() : NULL;
   node.tri_indices = model2.tri_indices.get();
   node.R = tf2.getRotation();
   node.T = tf2.getTranslation();

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -43,10 +43,10 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
                    bvh_model));
 
   ar &make_nvp("num_vertices", bvh_model.num_vertices);
-  if (bvh_model.num_vertices > 0) {
+  if (bvh_model.num_vertices > 0 && bvh_model.vertices.get()) {
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;
     const Eigen::Map<const AsVertixMatrix> vertices_map(
-        reinterpret_cast<const double *>(bvh_model.vertices.get()), 3,
+        reinterpret_cast<const double *>(bvh_model.vertices->data()), 3,
         bvh_model.num_vertices);
     ar &make_nvp("vertices", vertices_map);
   }
@@ -68,7 +68,7 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
     ar << make_nvp("has_prev_vertices", has_prev_vertices);
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;
     const Eigen::Map<const AsVertixMatrix> prev_vertices_map(
-        reinterpret_cast<const double *>(bvh_model.prev_vertices.get()), 3,
+        reinterpret_cast<const double *>(bvh_model.prev_vertices->data()), 3,
         bvh_model.num_vertices);
     ar &make_nvp("prev_vertices", prev_vertices_map);
   } else {
@@ -102,12 +102,13 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
   if (num_vertices != bvh_model.num_vertices) {
     bvh_model.vertices.reset();
     bvh_model.num_vertices = num_vertices;
-    if (num_vertices > 0) bvh_model.vertices.reset(new Vec3f[num_vertices]);
+    if (num_vertices > 0)
+      bvh_model.vertices.reset(new std::vector<Vec3f>(num_vertices));
   }
   if (num_vertices > 0) {
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;
     Eigen::Map<AsVertixMatrix> vertices_map(
-        reinterpret_cast<double *>(bvh_model.vertices.get()), 3,
+        reinterpret_cast<double *>(bvh_model.vertices->data()), 3,
         bvh_model.num_vertices);
     ar >> make_nvp("vertices", vertices_map);
   } else
@@ -143,12 +144,12 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
     if (num_vertices != bvh_model.num_vertices) {
       bvh_model.prev_vertices.reset();
       if (num_vertices > 0)
-        bvh_model.prev_vertices.reset(new Vec3f[num_vertices]);
+        bvh_model.prev_vertices.reset(new std::vector<Vec3f>(num_vertices));
     }
     if (num_vertices > 0) {
       typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;
       Eigen::Map<AsVertixMatrix> prev_vertices_map(
-          reinterpret_cast<double *>(bvh_model.prev_vertices.get()), 3,
+          reinterpret_cast<double *>(bvh_model.prev_vertices->data()), 3,
           bvh_model.num_vertices);
       ar &make_nvp("prev_vertices", prev_vertices_map);
     }

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -52,12 +52,12 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
   }
 
   ar &make_nvp("num_tris", bvh_model.num_tris);
-  if (bvh_model.num_tris > 0) {
+  if (bvh_model.num_tris > 0 && bvh_model.tri_indices.get()) {
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     const Eigen::Map<const AsTriangleMatrix> tri_indices_map(
         reinterpret_cast<const Triangle::index_type *>(
-            bvh_model.tri_indices.get()),
+            bvh_model.tri_indices->data()),
         3, bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   }
@@ -120,13 +120,14 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
   if (num_tris != bvh_model.num_tris) {
     bvh_model.tri_indices.reset();
     bvh_model.num_tris = num_tris;
-    if (num_tris > 0) bvh_model.tri_indices.reset(new Triangle[num_tris]);
+    if (num_tris > 0)
+      bvh_model.tri_indices.reset(new std::vector<Triangle>(num_tris));
   }
   if (num_tris > 0) {
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     Eigen::Map<AsTriangleMatrix> tri_indices_map(
-        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices.get()),
+        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices->data()),
         3, bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   } else

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -304,7 +304,7 @@ namespace fcl {
 
 namespace internal {
 template <typename BV>
-struct memory_footprint_evaluator< ::hpp::fcl::BVHModel<BV> > {
+struct memory_footprint_evaluator<::hpp::fcl::BVHModel<BV>> {
   static size_t run(const ::hpp::fcl::BVHModel<BV> &bvh_model) {
     return static_cast<size_t>(bvh_model.memUsage(false));
   }

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -63,7 +63,7 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
   }
   ar &make_nvp("build_state", bvh_model.build_state);
 
-  if (bvh_model.prev_vertices.get()) {
+  if (bvh_model.num_vertices > 0 && bvh_model.prev_vertices.get()) {
     const bool has_prev_vertices = true;
     ar << make_nvp("has_prev_vertices", has_prev_vertices);
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;
@@ -292,7 +292,7 @@ void load(Archive &ar, hpp::fcl::BVHModel<BV> &bvh_model_,
                      make_array(reinterpret_cast<char *>(bvh_model.bvs->data()),
                                 sizeof(Node) * (std::size_t)num_bvs));
     } else
-      bvh_model.bvs = NULL;
+      bvh_model.bvs.reset();
   }
 }
 

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -229,14 +229,14 @@ void save(Archive &ar, const hpp::fcl::BVHModel<BV> &bvh_model_,
   //      }
   //
 
-  if (bvh_model.bvs) {
+  if (bvh_model.bvs.get()) {
     const bool with_bvs = true;
     ar &make_nvp("with_bvs", with_bvs);
     ar &make_nvp("num_bvs", bvh_model.num_bvs);
     ar &make_nvp(
         "bvs",
         make_array(
-            reinterpret_cast<const char *>(bvh_model.bvs.get()),
+            reinterpret_cast<const char *>(bvh_model.bvs->data()),
             sizeof(Node) *
                 (std::size_t)bvh_model.num_bvs));  // Assuming BVs are POD.
   } else {
@@ -284,11 +284,12 @@ void load(Archive &ar, hpp::fcl::BVHModel<BV> &bvh_model_,
     if (num_bvs != bvh_model.num_bvs) {
       bvh_model.bvs.reset();
       bvh_model.num_bvs = num_bvs;
-      if (num_bvs > 0) bvh_model.bvs.reset(new BVNode<BV>[num_bvs]);
+      if (num_bvs > 0)
+        bvh_model.bvs.reset(new std::vector<BVNode<BV>>(num_bvs));
     }
     if (num_bvs > 0) {
       ar >> make_nvp("bvs",
-                     make_array(reinterpret_cast<char *>(bvh_model.bvs.get()),
+                     make_array(reinterpret_cast<char *>(bvh_model.bvs->data()),
                                 sizeof(Node) * (std::size_t)num_bvs));
     } else
       bvh_model.bvs = NULL;

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -36,7 +36,7 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
 
   if (Archive::is_loading::value) {
     if (num_points_previous != convex_base.num_points) {
-      convex_base.points.reset(new Vec3f[convex_base.num_points]);
+      convex_base.points.reset(new std::vector<Vec3f>(convex_base.num_points));
       convex_base.normals.reset(new Vec3f[convex_base.num_normals_and_offsets]);
       convex_base.offsets.reset(
           new double[convex_base.num_normals_and_offsets]);
@@ -46,7 +46,7 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
   {
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> MatrixPoints;
     Eigen::Map<MatrixPoints> points_map(
-        reinterpret_cast<double *>(convex_base.points.get()), 3,
+        reinterpret_cast<double *>(convex_base.points->data()), 3,
         convex_base.num_points);
     ar &make_nvp("points", points_map);
   }

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -32,10 +32,14 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
                            convex_base));
   const unsigned int num_points_previous = convex_base.num_points;
   ar &make_nvp("num_points", convex_base.num_points);
+  ar &make_nvp("num_normals_and_offsets", convex_base.num_normals_and_offsets);
 
   if (Archive::is_loading::value) {
     if (num_points_previous != convex_base.num_points) {
       convex_base.points.reset(new Vec3f[convex_base.num_points]);
+      convex_base.normals.reset(new Vec3f[convex_base.num_normals_and_offsets]);
+      convex_base.offsets.reset(
+          new double[convex_base.num_normals_and_offsets]);
     }
   }
 
@@ -45,6 +49,22 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
         reinterpret_cast<double *>(convex_base.points.get()), 3,
         convex_base.num_points);
     ar &make_nvp("points", points_map);
+  }
+
+  {
+    typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> MatrixPoints;
+    Eigen::Map<MatrixPoints> normals_map(
+        reinterpret_cast<double *>(convex_base.normals.get()), 3,
+        convex_base.num_normals_and_offsets);
+    ar &make_nvp("normals", normals_map);
+  }
+
+  {
+    typedef Eigen::Matrix<FCL_REAL, 1, Eigen::Dynamic> VecOfDoubles;
+    Eigen::Map<VecOfDoubles> offsets_map(
+        reinterpret_cast<double *>(convex_base.offsets.get()), 1,
+        convex_base.num_normals_and_offsets);
+    ar &make_nvp("offsets", offsets_map);
   }
 
   ar &make_nvp("center", convex_base.center);

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -95,11 +95,11 @@ void serialize(Archive &ar, hpp::fcl::Convex<PolygonT> &convex_,
 
   if (Archive::is_loading::value) {
     if (num_polygons_previous != convex.num_polygons) {
-      convex.polygons.reset(new PolygonT[convex.num_polygons]);
+      convex.polygons.reset(new std::vector<PolygonT>(convex.num_polygons));
     }
   }
 
-  ar &make_array<PolygonT>(convex.polygons.get(), convex.num_polygons);
+  ar &make_array<PolygonT>(convex.polygons->data(), convex.num_polygons);
 
   if (Archive::is_loading::value) convex.fillNeighbors();
 }

--- a/include/hpp/fcl/shape/convex.h
+++ b/include/hpp/fcl/shape/convex.h
@@ -62,7 +62,8 @@ class Convex : public ConvexBase {
   /// \param num_polygons_ the number of polygons.
   /// \note num_polygons_ is not the allocated size of polygons_.
   Convex(std::shared_ptr<std::vector<Vec3f>> points_, unsigned int num_points_,
-         std::shared_ptr<PolygonT> polygons_, unsigned int num_polygons_);
+         std::shared_ptr<std::vector<PolygonT>> polygons_,
+         unsigned int num_polygons_);
 
   /// @brief Copy constructor
   /// Only the list of neighbors is copied.
@@ -73,7 +74,7 @@ class Convex : public ConvexBase {
   /// @brief An array of PolygonT object.
   /// PolygonT should contains a list of vertices for each polygon,
   /// in counter clockwise order.
-  std::shared_ptr<PolygonT> polygons;
+  std::shared_ptr<std::vector<PolygonT>> polygons;
   unsigned int num_polygons;
 
   /// based on http://number-none.com/blow/inertia/bb_inertia.doc
@@ -95,7 +96,8 @@ class Convex : public ConvexBase {
   /// \note num_polygons is not the allocated size of polygons.
   ///
   void set(std::shared_ptr<std::vector<Vec3f>> points, unsigned int num_points,
-           std::shared_ptr<PolygonT> polygons, unsigned int num_polygons);
+           std::shared_ptr<std::vector<PolygonT>> polygons,
+           unsigned int num_polygons);
 
   ///  @brief Clone (deep copy).
   virtual Convex<PolygonT>* clone() const;

--- a/include/hpp/fcl/shape/convex.h
+++ b/include/hpp/fcl/shape/convex.h
@@ -61,7 +61,7 @@ class Convex : public ConvexBase {
   /// \param polygons_ \copydoc Convex::polygons
   /// \param num_polygons_ the number of polygons.
   /// \note num_polygons_ is not the allocated size of polygons_.
-  Convex(std::shared_ptr<Vec3f> points_, unsigned int num_points_,
+  Convex(std::shared_ptr<std::vector<Vec3f>> points_, unsigned int num_points_,
          std::shared_ptr<PolygonT> polygons_, unsigned int num_polygons_);
 
   /// @brief Copy constructor
@@ -94,7 +94,7 @@ class Convex : public ConvexBase {
   /// \param num_polygons the number of polygons.
   /// \note num_polygons is not the allocated size of polygons.
   ///
-  void set(std::shared_ptr<Vec3f> points, unsigned int num_points,
+  void set(std::shared_ptr<std::vector<Vec3f>> points, unsigned int num_points,
            std::shared_ptr<PolygonT> polygons, unsigned int num_polygons);
 
   ///  @brief Clone (deep copy).

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -44,7 +44,7 @@ namespace hpp {
 namespace fcl {
 
 template <typename PolygonT>
-Convex<PolygonT>::Convex(std::shared_ptr<Vec3f> points_,
+Convex<PolygonT>::Convex(std::shared_ptr<std::vector<Vec3f>> points_,
                          unsigned int num_points_,
                          std::shared_ptr<PolygonT> polygons_,
                          unsigned int num_polygons_)
@@ -68,7 +68,7 @@ template <typename PolygonT>
 Convex<PolygonT>::~Convex() {}
 
 template <typename PolygonT>
-void Convex<PolygonT>::set(std::shared_ptr<Vec3f> points_,
+void Convex<PolygonT>::set(std::shared_ptr<std::vector<Vec3f>> points_,
                            unsigned int num_points_,
                            std::shared_ptr<PolygonT> polygons_,
                            unsigned int num_polygons_) {
@@ -96,7 +96,7 @@ Matrix3f Convex<PolygonT>::computeMomentofInertia() const {
   C_canonical << 1 / 60.0, 1 / 120.0, 1 / 120.0, 1 / 120.0, 1 / 60.0, 1 / 120.0,
       1 / 120.0, 1 / 120.0, 1 / 60.0;
 
-  const Vec3f* points_ = points.get();
+  const std::vector<Vec3f>& points_ = *(points);
   const PolygonT* polygons_ = polygons.get();
   for (unsigned int i = 0; i < num_polygons; ++i) {
     const PolygonT& polygon = polygons_[i];
@@ -133,7 +133,7 @@ Vec3f Convex<PolygonT>::computeCOM() const {
 
   Vec3f com(0, 0, 0);
   FCL_REAL vol = 0;
-  const Vec3f* points_ = points.get();
+  const std::vector<Vec3f>& points_ = *(points);
   const PolygonT* polygons_ = polygons.get();
   for (unsigned int i = 0; i < num_polygons; ++i) {
     const PolygonT& polygon = polygons_[i];
@@ -167,7 +167,7 @@ FCL_REAL Convex<PolygonT>::computeVolume() const {
   typedef typename PolygonT::index_type index_type;
 
   FCL_REAL vol = 0;
-  const Vec3f* points_ = points.get();
+  const std::vector<Vec3f>& points_ = *(points);
   const PolygonT* polygons_ = polygons.get();
   for (unsigned int i = 0; i < num_polygons; ++i) {
     const PolygonT& polygon = polygons_[i];
@@ -201,7 +201,7 @@ void Convex<PolygonT>::fillNeighbors() {
 
   typedef typename PolygonT::size_type size_type;
   typedef typename PolygonT::index_type index_type;
-  std::vector<std::set<index_type> > nneighbors(num_points);
+  std::vector<std::set<index_type>> nneighbors(num_points);
   unsigned int c_nneighbors = 0;
 
   const PolygonT* polygons_ = polygons.get();

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -228,7 +228,7 @@ FCL_REAL Convex<PolygonT>::computeVolume() const {
 
 template <typename PolygonT>
 void Convex<PolygonT>::fillNeighbors() {
-  neighbors.reset(new Neighbors[num_points]);
+  neighbors.reset(new std::vector<Neighbors>(num_points));
 
   typedef typename PolygonT::size_type size_type;
   typedef typename PolygonT::index_type index_type;
@@ -261,10 +261,10 @@ void Convex<PolygonT>::fillNeighbors() {
     }
   }
 
-  nneighbors_.reset(new unsigned int[c_nneighbors]);
+  nneighbors_.reset(new std::vector<unsigned int>(c_nneighbors));
 
-  unsigned int* p_nneighbors = nneighbors_.get();
-  Neighbors* neighbors_ = neighbors.get();
+  unsigned int* p_nneighbors = nneighbors_->data();
+  std::vector<Neighbors>& neighbors_ = *neighbors;
   for (unsigned int i = 0; i < num_points; ++i) {
     Neighbors& n = neighbors_[i];
     if (nneighbors[i].size() >= (std::numeric_limits<unsigned char>::max)())
@@ -274,7 +274,7 @@ void Convex<PolygonT>::fillNeighbors() {
     p_nneighbors =
         std::copy(nneighbors[i].begin(), nneighbors[i].end(), p_nneighbors);
   }
-  assert(p_nneighbors == nneighbors_.get() + c_nneighbors);
+  assert(p_nneighbors == nneighbors_->data() + c_nneighbors);
 }
 
 }  // namespace fcl

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -671,7 +671,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// Neighbors of each vertex.
   /// It is an array of size num_points. For each vertex, it contains the number
   /// of neighbors and a list of indices to them.
-  std::shared_ptr<Neighbors> neighbors;
+  std::shared_ptr<std::vector<Neighbors>> neighbors;
 
   /// @brief center of the convex polytope, this is used for collision: center
   /// is guaranteed in the internal of the polytope (as it is convex)
@@ -703,7 +703,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// Only the list of neighbors is copied.
   ConvexBase(const ConvexBase& other);
 
-  std::shared_ptr<unsigned int> nneighbors_;
+  std::shared_ptr<std::vector<unsigned int>> nneighbors_;
 
  private:
   void computeCenter();
@@ -716,16 +716,26 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
 
     if (num_points != other.num_points) return false;
 
-    const std::vector<Vec3f>& points_ = *points;
-    const std::vector<Vec3f>& other_points_ = *(other.points);
-    for (unsigned int i = 0; i < num_points; ++i) {
-      if (points_[i] != (other_points_)[i]) return false;
+    if ((!(points.get()) && other.points.get()) ||
+        (points.get() && !(other.points.get())))
+      return false;
+    if (points.get() && other.points.get()) {
+      const std::vector<Vec3f>& points_ = *points;
+      const std::vector<Vec3f>& other_points_ = *(other.points);
+      for (unsigned int i = 0; i < num_points; ++i) {
+        if (points_[i] != (other_points_)[i]) return false;
+      }
     }
 
-    const Neighbors* neighbors_ = neighbors.get();
-    const Neighbors* other_neighbors_ = other.neighbors.get();
-    for (unsigned int i = 0; i < num_points; ++i) {
-      if (neighbors_[i] != other_neighbors_[i]) return false;
+    if ((!(neighbors.get()) && other.neighbors.get()) ||
+        (neighbors.get() && !(other.neighbors.get())))
+      return false;
+    if (neighbors.get() && other.neighbors.get()) {
+      const std::vector<Neighbors>& neighbors_ = *neighbors;
+      const std::vector<Neighbors>& other_neighbors_ = *(other.neighbors);
+      for (unsigned int i = 0; i < num_points; ++i) {
+        if (neighbors_[i] != other_neighbors_[i]) return false;
+      }
     }
 
     const Vec3f* normals_ = normals.get();

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -46,15 +46,9 @@
 #include <memory>
 
 #ifdef HPP_FCL_HAS_QHULL
-#include <libqhullcpp/QhullError.h>
-#include <libqhullcpp/QhullFacet.h>
-#include <libqhullcpp/QhullLinkedList.h>
-#include <libqhullcpp/QhullVertex.h>
-#include <libqhullcpp/QhullVertexSet.h>
-#include <libqhullcpp/QhullRidge.h>
-#include <libqhullcpp/Qhull.h>
-
-using orgQhull::Qhull;
+namespace orgQhull {
+class Qhull;
+}
 #endif
 
 namespace hpp {
@@ -643,7 +637,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   void buildDoubleDescription();
 
  protected:
-  void buildDoubleDescriptionFromQHullResult(const Qhull& qh);
+  void buildDoubleDescriptionFromQHullResult(const orgQhull::Qhull& qh);
 #endif
 
  public:

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -732,6 +732,18 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
       if (neighbors_[i] != other_neighbors_[i]) return false;
     }
 
+    const Vec3f* normals_ = normals.get();
+    const Vec3f* other_normals_ = other.normals.get();
+    for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
+      if (normals_[i] != other_normals_[i]) return false;
+    }
+
+    const double* offsets_ = offsets.get();
+    const double* other_offsets_ = other.offsets.get();
+    for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
+      if (offsets_[i] != other_offsets_[i]) return false;
+    }
+
     return center == other.center;
   }
 

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -626,10 +626,10 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   unsigned int num_points;
 
   /// @brief An array of the normals of the polygon.
-  std::shared_ptr<Vec3f> normals;
+  std::shared_ptr<std::vector<Vec3f>> normals;
   /// @brief An array of the offsets to the normals of the polygon.
   /// Note: there are as many offsets as normals.
-  std::shared_ptr<double> offsets;
+  std::shared_ptr<std::vector<double>> offsets;
   unsigned int num_normals_and_offsets;
 
 #ifdef HPP_FCL_HAS_QHULL
@@ -738,16 +738,26 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
       }
     }
 
-    const Vec3f* normals_ = normals.get();
-    const Vec3f* other_normals_ = other.normals.get();
-    for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
-      if (normals_[i] != other_normals_[i]) return false;
+    if ((!(normals.get()) && other.normals.get()) ||
+        (normals.get() && !(other.normals.get())))
+      return false;
+    if (normals.get() && other.normals.get()) {
+      const std::vector<Vec3f>& normals_ = *normals;
+      const std::vector<Vec3f>& other_normals_ = *(other.normals);
+      for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
+        if (normals_[i] != other_normals_[i]) return false;
+      }
     }
 
-    const double* offsets_ = offsets.get();
-    const double* other_offsets_ = other.offsets.get();
-    for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
-      if (offsets_[i] != other_offsets_[i]) return false;
+    if ((!(offsets.get()) && other.offsets.get()) ||
+        (offsets.get() && !(other.offsets.get())))
+      return false;
+    if (offsets.get() && other.offsets.get()) {
+      const std::vector<double>& offsets_ = *offsets;
+      const std::vector<double>& other_offsets_ = *(other.offsets);
+      for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
+        if (offsets_[i] != other_offsets_[i]) return false;
+      }
     }
 
     return center == other.center;

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -599,7 +599,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   ///          Qhull.
   /// \note hpp-fcl must have been compiled with option \c HPP_FCL_HAS_QHULL set
   ///       to \c ON.
-  static ConvexBase* convexHull(const std::shared_ptr<const Vec3f> points,
+  static ConvexBase* convexHull(std::shared_ptr<std::vector<Vec3f>> points,
                                 unsigned int num_points, bool keepTriangles,
                                 const char* qhullCommand = NULL);
 
@@ -622,7 +622,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   NODE_TYPE getNodeType() const { return GEOM_CONVEX; }
 
   /// @brief An array of the points of the polygon.
-  std::shared_ptr<Vec3f> points;
+  std::shared_ptr<std::vector<Vec3f>> points;
   unsigned int num_points;
 
   /// @brief An array of the normals of the polygon.
@@ -688,14 +688,16 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
-  void initialize(std::shared_ptr<Vec3f> points_, unsigned int num_points_);
+  void initialize(std::shared_ptr<std::vector<Vec3f>> points_,
+                  unsigned int num_points_);
 
   /// @brief Set the points of the convex shape.
   ///
   /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
-  void set(std::shared_ptr<Vec3f> points_, unsigned int num_points_);
+  void set(std::shared_ptr<std::vector<Vec3f>> points_,
+           unsigned int num_points_);
 
   /// @brief Copy constructor
   /// Only the list of neighbors is copied.
@@ -714,8 +716,8 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
 
     if (num_points != other.num_points) return false;
 
-    const Vec3f* points_ = points.get();
-    const Vec3f* other_points_ = other.points.get();
+    const std::vector<Vec3f>& points_ = *points;
+    const std::vector<Vec3f>& other_points_ = *(other.points);
     for (unsigned int i = 0; i < num_points; ++i) {
       if (points_[i] != (other_points_)[i]) return false;
     }

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -612,7 +612,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// @brief Compute AABB
   void computeLocalAABB();
 
-  /// @brief Get node type: a conex polytope
+  /// @brief Get node type: a convex polytope
   NODE_TYPE getNodeType() const { return GEOM_CONVEX; }
 
   /// @brief An array of the points of the polygon.

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -45,6 +45,18 @@
 #include <string.h>
 #include <memory>
 
+#ifdef HPP_FCL_HAS_QHULL
+#include <libqhullcpp/QhullError.h>
+#include <libqhullcpp/QhullFacet.h>
+#include <libqhullcpp/QhullLinkedList.h>
+#include <libqhullcpp/QhullVertex.h>
+#include <libqhullcpp/QhullVertexSet.h>
+#include <libqhullcpp/QhullRidge.h>
+#include <libqhullcpp/Qhull.h>
+
+using orgQhull::Qhull;
+#endif
+
 namespace hpp {
 namespace fcl {
 
@@ -619,6 +631,22 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   std::shared_ptr<Vec3f> points;
   unsigned int num_points;
 
+  /// @brief An array of the normals of the polygon.
+  std::shared_ptr<Vec3f> normals;
+  /// @brief An array of the offsets to the normals of the polygon.
+  /// Note: there are as many offsets as normals.
+  std::shared_ptr<double> offsets;
+  unsigned int num_normals_and_offsets;
+
+#ifdef HPP_FCL_HAS_QHULL
+ public:
+  void buildDoubleDescription();
+
+ protected:
+  void buildDoubleDescriptionFromQHullResult(const Qhull& qh);
+#endif
+
+ public:
   struct HPP_FCL_DLLAPI Neighbors {
     unsigned char count_;
     unsigned int* n_;

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -43,6 +43,7 @@
 #include <hpp/fcl/collision_object.h>
 #include <hpp/fcl/data_types.h>
 #include <string.h>
+#include <vector>
 #include <memory>
 
 #ifdef HPP_FCL_HAS_QHULL

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -164,12 +164,11 @@ struct ConvexBaseWrapper {
   static Vec3f& point(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_points)
       throw std::out_of_range("index is out of range");
-    return (convex.points.get())[i];
+    return (*(convex.points))[i];
   }
 
   static RefRowMatrixX3 points(const ConvexBase& convex) {
-    return MapRowMatrixX3((convex.points.get())[0].data(), convex.num_points,
-                          3);
+    return MapRowMatrixX3((*(convex.points))[0].data(), convex.num_points, 3);
   }
 
   static Vec3f& normal(const ConvexBase& convex, unsigned int i) {
@@ -223,8 +222,9 @@ struct ConvexWrapper {
 
   static shared_ptr<Convex_t> constructor(const Vec3fs& _points,
                                           const Triangles& _tris) {
-    std::shared_ptr<Vec3f> points(new Vec3f[_points.size()]);
-    Vec3f* points_ = points.get();
+    std::shared_ptr<std::vector<Vec3f>> points(
+        new std::vector<Vec3f>(_points.size()));
+    std::vector<Vec3f>& points_ = *points;
     for (std::size_t i = 0; i < _points.size(); ++i) points_[i] = _points[i];
 
     std::shared_ptr<Triangle> tris(new Triangle[_tris.size()]);

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -157,10 +157,9 @@ struct ConvexBaseWrapper {
   typedef Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> RowMatrixX3;
   typedef Eigen::Map<RowMatrixX3> MapRowMatrixX3;
   typedef Eigen::Ref<RowMatrixX3> RefRowMatrixX3;
-  typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::RowMajor>
-      VecOfDoubles;
-  typedef Eigen::Map<RowMatrixX3> MapVecOfDoubles;
-  typedef Eigen::Ref<RowMatrixX3> RefVecOfDoubles;
+  typedef Eigen::VectorXd VecOfDoubles;
+  typedef Eigen::Map<VecOfDoubles> MapVecOfDoubles;
+  typedef Eigen::Ref<VecOfDoubles> RefVecOfDoubles;
 
   static Vec3f& point(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_points)

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -217,7 +217,7 @@ struct ConvexWrapper {
   static PolygonT polygons(const Convex_t& convex, unsigned int i) {
     if (i >= convex.num_polygons)
       throw std::out_of_range("index is out of range");
-    return convex.polygons.get()[i];
+    return (*convex.polygons)[i];
   }
 
   static shared_ptr<Convex_t> constructor(const Vec3fs& _points,
@@ -227,8 +227,9 @@ struct ConvexWrapper {
     std::vector<Vec3f>& points_ = *points;
     for (std::size_t i = 0; i < _points.size(); ++i) points_[i] = _points[i];
 
-    std::shared_ptr<Triangle> tris(new Triangle[_tris.size()]);
-    Triangle* tris_ = tris.get();
+    std::shared_ptr<std::vector<Triangle>> tris(
+        new std::vector<Triangle>(_tris.size()));
+    std::vector<Triangle>& tris_ = *tris;
     for (std::size_t i = 0; i < _tris.size(); ++i) tris_[i] = _tris[i];
     return shared_ptr<Convex_t>(new Convex_t(points,
                                              (unsigned int)_points.size(), tris,

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -197,7 +197,7 @@ struct ConvexBaseWrapper {
     if (i >= convex.num_points)
       throw std::out_of_range("index is out of range");
     list n;
-    const ConvexBase::Neighbors* neighbors_ = convex.neighbors.get();
+    const std::vector<ConvexBase::Neighbors>& neighbors_ = *(convex.neighbors);
     for (unsigned char j = 0; j < neighbors_[i].count(); ++j)
       n.append(neighbors_[i][j]);
     return n;

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -92,7 +92,7 @@ struct BVHModelBaseWrapper {
 
   static Triangle tri_indices(const BVHModelBase& bvh, unsigned int i) {
     if (i >= bvh.num_tris) throw std::out_of_range("index is out of range");
-    return bvh.tri_indices.get()[i];
+    return (*bvh.tri_indices)[i];
   }
 };
 

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -83,11 +83,11 @@ struct BVHModelBaseWrapper {
 
   static Vec3f& vertex(BVHModelBase& bvh, unsigned int i) {
     if (i >= bvh.num_vertices) throw std::out_of_range("index is out of range");
-    return bvh.vertices.get()[i];
+    return (*(bvh.vertices))[i];
   }
 
   static RefRowMatrixX3 vertices(BVHModelBase& bvh) {
-    return MapRowMatrixX3(bvh.vertices.get()[0].data(), bvh.num_vertices, 3);
+    return MapRowMatrixX3((*(bvh.vertices))[0].data(), bvh.num_vertices, 3);
   }
 
   static Triangle tri_indices(const BVHModelBase& bvh, unsigned int i) {

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -101,7 +101,7 @@ void exposeBVHModel(const std::string& bvname) {
   typedef BVHModel<BV> BVH;
 
   const std::string type_name = "BVHModel" + bvname;
-  class_<BVH, bases<BVHModelBase>, shared_ptr<BVH> >(
+  class_<BVH, bases<BVHModelBase>, shared_ptr<BVH>>(
       type_name.c_str(), doxygen::class_doc<BVH>(), no_init)
       .def(dv::init<BVH>())
       .def(dv::init<BVH, const BVH&>())
@@ -120,12 +120,12 @@ void exposeHeightField(const std::string& bvname) {
   typedef typename Geometry::Node Node;
 
   const std::string type_name = "HeightField" + bvname;
-  class_<Geometry, bases<Base>, shared_ptr<Geometry> >(
+  class_<Geometry, bases<Base>, shared_ptr<Geometry>>(
       type_name.c_str(), doxygen::class_doc<Geometry>(), no_init)
-      .def(dv::init<HeightField<BV> >())
+      .def(dv::init<HeightField<BV>>())
       .def(dv::init<HeightField<BV>, const HeightField<BV>&>())
       .def(dv::init<HeightField<BV>, FCL_REAL, FCL_REAL, const MatrixXf&,
-                    bp::optional<FCL_REAL> >())
+                    bp::optional<FCL_REAL>>())
 
       .DEF_CLASS_FUNC(Geometry, getXDim)
       .DEF_CLASS_FUNC(Geometry, getYDim)
@@ -189,8 +189,8 @@ struct ConvexBaseWrapper {
   }
 
   static RefVecOfDoubles offsets(const ConvexBase& convex) {
-    return MapVecOfDoubles(convex.offsets->data(), convex.num_normals_and_offsets,
-                           1);
+    return MapVecOfDoubles(convex.offsets->data(),
+                           convex.num_normals_and_offsets, 1);
   }
 
   static list neighbors(const ConvexBase& convex, unsigned int i) {
@@ -253,9 +253,9 @@ void exposeComputeMemoryFootprint() {
   defComputeMemoryFootprint<Halfspace>();
   defComputeMemoryFootprint<TriangleP>();
 
-  defComputeMemoryFootprint<BVHModel<OBB> >();
-  defComputeMemoryFootprint<BVHModel<RSS> >();
-  defComputeMemoryFootprint<BVHModel<OBBRSS> >();
+  defComputeMemoryFootprint<BVHModel<OBB>>();
+  defComputeMemoryFootprint<BVHModel<RSS>>();
+  defComputeMemoryFootprint<BVHModel<OBBRSS>>();
 }
 
 void exposeShapes() {
@@ -264,7 +264,7 @@ void exposeShapes() {
       //.def ("getObjectType", &CollisionGeometry::getObjectType)
       ;
 
-  class_<Box, bases<ShapeBase>, shared_ptr<Box> >(
+  class_<Box, bases<ShapeBase>, shared_ptr<Box>>(
       "Box", doxygen::class_doc<ShapeBase>(), no_init)
       .def(dv::init<Box>())
       .def(dv::init<Box, const Box&>())
@@ -275,7 +275,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Box>());
 
-  class_<Capsule, bases<ShapeBase>, shared_ptr<Capsule> >(
+  class_<Capsule, bases<ShapeBase>, shared_ptr<Capsule>>(
       "Capsule", doxygen::class_doc<Capsule>(), no_init)
       .def(dv::init<Capsule>())
       .def(dv::init<Capsule, FCL_REAL, FCL_REAL>())
@@ -286,7 +286,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Capsule>());
 
-  class_<Cone, bases<ShapeBase>, shared_ptr<Cone> >(
+  class_<Cone, bases<ShapeBase>, shared_ptr<Cone>>(
       "Cone", doxygen::class_doc<Cone>(), no_init)
       .def(dv::init<Cone>())
       .def(dv::init<Cone, FCL_REAL, FCL_REAL>())
@@ -308,7 +308,7 @@ void exposeShapes() {
       .def("points", &ConvexBaseWrapper::point, bp::args("self", "index"),
            "Retrieve the point given by its index.",
            ::hpp::fcl::python::deprecated_member<
-               bp::return_internal_reference<> >())
+               bp::return_internal_reference<>>())
       .def("points", &ConvexBaseWrapper::points, bp::args("self"),
            "Retrieve all the points.",
            bp::with_custodian_and_ward_postcall<0, 1>())
@@ -335,17 +335,16 @@ void exposeShapes() {
            doxygen::member_func_doc(&ConvexBase::clone),
            return_value_policy<manage_new_object>());
 
-  class_<Convex<Triangle>, bases<ConvexBase>, shared_ptr<Convex<Triangle> >,
-         noncopyable>("Convex", doxygen::class_doc<Convex<Triangle> >(),
-                      no_init)
+  class_<Convex<Triangle>, bases<ConvexBase>, shared_ptr<Convex<Triangle>>,
+         noncopyable>("Convex", doxygen::class_doc<Convex<Triangle>>(), no_init)
       .def("__init__", make_constructor(&ConvexWrapper<Triangle>::constructor))
-      .def(dv::init<Convex<Triangle> >())
+      .def(dv::init<Convex<Triangle>>())
       .def(dv::init<Convex<Triangle>, const Convex<Triangle>&>())
       .DEF_RO_CLASS_ATTRIB(Convex<Triangle>, num_polygons)
       .def("polygons", &ConvexWrapper<Triangle>::polygons)
-      .def_pickle(PickleObject<Convex<Triangle> >());
+      .def_pickle(PickleObject<Convex<Triangle>>());
 
-  class_<Cylinder, bases<ShapeBase>, shared_ptr<Cylinder> >(
+  class_<Cylinder, bases<ShapeBase>, shared_ptr<Cylinder>>(
       "Cylinder", doxygen::class_doc<Cylinder>(), no_init)
       .def(dv::init<Cylinder>())
       .def(dv::init<Cylinder, FCL_REAL, FCL_REAL>())
@@ -357,7 +356,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Cylinder>());
 
-  class_<Halfspace, bases<ShapeBase>, shared_ptr<Halfspace> >(
+  class_<Halfspace, bases<ShapeBase>, shared_ptr<Halfspace>>(
       "Halfspace", doxygen::class_doc<Halfspace>(), no_init)
       .def(dv::init<Halfspace, const Vec3f&, FCL_REAL>())
       .def(dv::init<Halfspace, const Halfspace&>())
@@ -370,7 +369,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Halfspace>());
 
-  class_<Plane, bases<ShapeBase>, shared_ptr<Plane> >(
+  class_<Plane, bases<ShapeBase>, shared_ptr<Plane>>(
       "Plane", doxygen::class_doc<Plane>(), no_init)
       .def(dv::init<Plane, const Vec3f&, FCL_REAL>())
       .def(dv::init<Plane, const Plane&>())
@@ -382,7 +381,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Plane>());
 
-  class_<Sphere, bases<ShapeBase>, shared_ptr<Sphere> >(
+  class_<Sphere, bases<ShapeBase>, shared_ptr<Sphere>>(
       "Sphere", doxygen::class_doc<Sphere>(), no_init)
       .def(dv::init<Sphere>())
       .def(dv::init<Sphere, const Sphere&>())
@@ -392,7 +391,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Sphere>());
 
-  class_<Ellipsoid, bases<ShapeBase>, shared_ptr<Ellipsoid> >(
+  class_<Ellipsoid, bases<ShapeBase>, shared_ptr<Ellipsoid>>(
       "Ellipsoid", doxygen::class_doc<Ellipsoid>(), no_init)
       .def(dv::init<Ellipsoid>())
       .def(dv::init<Ellipsoid, FCL_REAL, FCL_REAL, FCL_REAL>())
@@ -404,7 +403,7 @@ void exposeShapes() {
            return_value_policy<manage_new_object>())
       .def_pickle(PickleObject<Ellipsoid>());
 
-  class_<TriangleP, bases<ShapeBase>, shared_ptr<TriangleP> >(
+  class_<TriangleP, bases<ShapeBase>, shared_ptr<TriangleP>>(
       "TriangleP", doxygen::class_doc<TriangleP>(), no_init)
       .def(dv::init<TriangleP>())
       .def(dv::init<TriangleP, const Vec3f&, const Vec3f&, const Vec3f&>())
@@ -625,7 +624,7 @@ void exposeCollisionGeometries() {
       .def("vertices", &BVHModelBaseWrapper::vertex, bp::args("self", "index"),
            "Retrieve the vertex given by its index.",
            ::hpp::fcl::python::deprecated_member<
-               bp::return_internal_reference<> >())
+               bp::return_internal_reference<>>())
       .def("vertices", &BVHModelBaseWrapper::vertices, bp::args("self"),
            "Retrieve all the vertices.",
            bp::with_custodian_and_ward_postcall<0, 1>())
@@ -677,11 +676,11 @@ void exposeCollisionObject() {
   if (!eigenpy::register_symbolic_link_to_registered_type<CollisionObject>()) {
     class_<CollisionObject, CollisionObjectPtr_t>("CollisionObject", no_init)
         .def(dv::init<CollisionObject, const CollisionGeometryPtr_t&,
-                      bp::optional<bool> >())
+                      bp::optional<bool>>())
         .def(dv::init<CollisionObject, const CollisionGeometryPtr_t&,
-                      const Transform3f&, bp::optional<bool> >())
+                      const Transform3f&, bp::optional<bool>>())
         .def(dv::init<CollisionObject, const CollisionGeometryPtr_t&,
-                      const Matrix3f&, const Vec3f&, bp::optional<bool> >())
+                      const Matrix3f&, const Vec3f&, bp::optional<bool>>())
 
         .DEF_CLASS_FUNC(CollisionObject, getObjectType)
         .DEF_CLASS_FUNC(CollisionObject, getNodeType)

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -157,6 +157,10 @@ struct ConvexBaseWrapper {
   typedef Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> RowMatrixX3;
   typedef Eigen::Map<RowMatrixX3> MapRowMatrixX3;
   typedef Eigen::Ref<RowMatrixX3> RefRowMatrixX3;
+  typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::RowMajor>
+      VecOfDoubles;
+  typedef Eigen::Map<RowMatrixX3> MapVecOfDoubles;
+  typedef Eigen::Ref<RowMatrixX3> RefVecOfDoubles;
 
   static Vec3f& point(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_points)
@@ -167,6 +171,28 @@ struct ConvexBaseWrapper {
   static RefRowMatrixX3 points(const ConvexBase& convex) {
     return MapRowMatrixX3((convex.points.get())[0].data(), convex.num_points,
                           3);
+  }
+
+  static Vec3f& normal(const ConvexBase& convex, unsigned int i) {
+    if (i >= convex.num_normals_and_offsets)
+      throw std::out_of_range("index is out of range");
+    return (convex.normals.get())[i];
+  }
+
+  static RefRowMatrixX3 normals(const ConvexBase& convex) {
+    return MapRowMatrixX3((convex.normals.get())[0].data(),
+                          convex.num_normals_and_offsets, 3);
+  }
+
+  static double offset(const ConvexBase& convex, unsigned int i) {
+    if (i >= convex.num_normals_and_offsets)
+      throw std::out_of_range("index is out of range");
+    return (convex.offsets.get())[i];
+  }
+
+  static RefVecOfDoubles offsets(const ConvexBase& convex) {
+    return MapVecOfDoubles(convex.offsets.get(), convex.num_normals_and_offsets,
+                           1);
   }
 
   static list neighbors(const ConvexBase& convex, unsigned int i) {
@@ -275,6 +301,7 @@ void exposeShapes() {
       "ConvexBase", doxygen::class_doc<ConvexBase>(), no_init)
       .DEF_RO_CLASS_ATTRIB(ConvexBase, center)
       .DEF_RO_CLASS_ATTRIB(ConvexBase, num_points)
+      .DEF_RO_CLASS_ATTRIB(ConvexBase, num_normals_and_offsets)
       .def("point", &ConvexBaseWrapper::point, bp::args("self", "index"),
            "Retrieve the point given by its index.",
            bp::return_internal_reference<>())
@@ -288,6 +315,17 @@ void exposeShapes() {
       //    .add_property ("points",
       //                   bp::make_function(&ConvexBaseWrapper::points,bp::with_custodian_and_ward_postcall<0,1>()),
       //                   "Points of the convex.")
+      .def("normal", &ConvexBaseWrapper::normal, bp::args("self", "index"),
+           "Retrieve the normal given by its index.",
+           bp::return_internal_reference<>())
+      .def("normals", &ConvexBaseWrapper::normals, bp::args("self"),
+           "Retrieve all the normals.",
+           bp::with_custodian_and_ward_postcall<0, 1>())
+      .def("offset", &ConvexBaseWrapper::offset, bp::args("self", "index"),
+           "Retrieve the offset given by its index.")
+      .def("offsets", &ConvexBaseWrapper::offsets, bp::args("self"),
+           "Retrieve all the offsets.",
+           bp::with_custodian_and_ward_postcall<0, 1>())
       .def("neighbors", &ConvexBaseWrapper::neighbors)
       .def("convexHull", &ConvexBaseWrapper::convexHull,
            // doxygen::member_func_doc(&ConvexBase::convexHull),

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -174,22 +174,22 @@ struct ConvexBaseWrapper {
   static Vec3f& normal(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_normals_and_offsets)
       throw std::out_of_range("index is out of range");
-    return (convex.normals.get())[i];
+    return (*(convex.normals))[i];
   }
 
   static RefRowMatrixX3 normals(const ConvexBase& convex) {
-    return MapRowMatrixX3((convex.normals.get())[0].data(),
+    return MapRowMatrixX3((*(convex.normals))[0].data(),
                           convex.num_normals_and_offsets, 3);
   }
 
   static double offset(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_normals_and_offsets)
       throw std::out_of_range("index is out of range");
-    return (convex.offsets.get())[i];
+    return (*(convex.offsets))[i];
   }
 
   static RefVecOfDoubles offsets(const ConvexBase& convex) {
-    return MapVecOfDoubles(convex.offsets.get(), convex.num_normals_and_offsets,
+    return MapVecOfDoubles(convex.offsets->data(), convex.num_normals_and_offsets,
                            1);
   }
 

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -1141,23 +1141,23 @@ NODE_TYPE BVHModel<OBBRSS>::getNodeType() const {
 }
 
 template <>
-NODE_TYPE BVHModel<KDOP<16> >::getNodeType() const {
+NODE_TYPE BVHModel<KDOP<16>>::getNodeType() const {
   return BV_KDOP16;
 }
 
 template <>
-NODE_TYPE BVHModel<KDOP<18> >::getNodeType() const {
+NODE_TYPE BVHModel<KDOP<18>>::getNodeType() const {
   return BV_KDOP18;
 }
 
 template <>
-NODE_TYPE BVHModel<KDOP<24> >::getNodeType() const {
+NODE_TYPE BVHModel<KDOP<24>>::getNodeType() const {
   return BV_KDOP24;
 }
 
-template class BVHModel<KDOP<16> >;
-template class BVHModel<KDOP<18> >;
-template class BVHModel<KDOP<24> >;
+template class BVHModel<KDOP<16>>;
+template class BVHModel<KDOP<18>>;
+template class BVHModel<KDOP<24>>;
 template class BVHModel<OBB>;
 template class BVHModel<AABB>;
 template class BVHModel<RSS>;

--- a/src/BVH/BVH_utility.cpp
+++ b/src/BVH/BVH_utility.cpp
@@ -63,7 +63,7 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   std::vector<bool> keep_tri(model.num_tris, false);
   unsigned int ntri = 0;
   const std::vector<Vec3f>& model_vertices_ = *(model.vertices);
-  const Triangle* model_tri_indices_ = model.tri_indices.get();
+  const std::vector<Triangle>& model_tri_indices_ = *(model.tri_indices);
   for (unsigned int i = 0; i < model.num_tris; ++i) {
     const Triangle& t = model_tri_indices_[i];
 
@@ -110,7 +110,7 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
     }
   }
   assert(new_model->num_tris == 0);
-  Triangle* new_model_tri_indices_ = new_model->tri_indices.get();
+  std::vector<Triangle>& new_model_tri_indices_ = *(new_model->tri_indices);
   for (unsigned int i = 0; i < keep_tri.size(); ++i) {
     if (keep_tri[i]) {
       new_model_tri_indices_[new_model->num_tris].set(

--- a/src/BVH/BVH_utility.cpp
+++ b/src/BVH/BVH_utility.cpp
@@ -62,7 +62,7 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   std::vector<bool> keep_vertex(model.num_vertices, false);
   std::vector<bool> keep_tri(model.num_tris, false);
   unsigned int ntri = 0;
-  const Vec3f* model_vertices_ = model.vertices.get();
+  const std::vector<Vec3f>& model_vertices_ = *(model.vertices);
   const Triangle* model_tri_indices_ = model.tri_indices.get();
   for (unsigned int i = 0; i < model.num_tris; ++i) {
     const Triangle& t = model_tri_indices_[i];
@@ -101,7 +101,7 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   new_model->beginModel(ntri, std::min(ntri * 3, model.num_vertices));
   std::vector<unsigned int> idxConversion(model.num_vertices);
   assert(new_model->num_vertices == 0);
-  Vec3f* new_model_vertices_ = new_model->vertices.get();
+  std::vector<Vec3f>& new_model_vertices_ = *(new_model->vertices);
   for (unsigned int i = 0; i < keep_vertex.size(); ++i) {
     if (keep_vertex[i]) {
       idxConversion[i] = new_model->num_vertices;

--- a/src/narrowphase/details.h
+++ b/src/narrowphase/details.h
@@ -1618,7 +1618,7 @@ inline bool convexHalfspaceIntersect(
   Vec3f v;
   FCL_REAL depth = (std::numeric_limits<FCL_REAL>::max)();
 
-  const Vec3f* points_ = s1.points.get();
+  const std::vector<Vec3f>& points_ = *(s1.points);
   for (unsigned int i = 0; i < s1.num_points; ++i) {
     Vec3f p = tf1.transform(points_[i]);
 
@@ -2272,7 +2272,7 @@ inline bool convexPlaneIntersect(const ConvexBase& s1, const Transform3f& tf1,
   FCL_REAL d_min = (std::numeric_limits<FCL_REAL>::max)(),
            d_max = -(std::numeric_limits<FCL_REAL>::max)();
 
-  const Vec3f* points_ = s1.points.get();
+  const std::vector<Vec3f>& points_ = *(s1.points);
   for (unsigned int i = 0; i < s1.num_points; ++i) {
     Vec3f p = tf1.transform(points_[i]);
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -174,7 +174,7 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
   assert(data != NULL);
 
   const std::vector<Vec3f>& pts = *(convex->points);
-  const ConvexBase::Neighbors* nn = convex->neighbors.get();
+  const std::vector<ConvexBase::Neighbors>& nn = *(convex->neighbors);
 
   if (hint < 0 || hint >= (int)convex->num_points) hint = 0;
   FCL_REAL maxdot = pts[static_cast<size_t>(hint)].dot(dir);
@@ -185,7 +185,7 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
   // equal. Yet, the neighbors must be visited.
   bool found = true, loose_check = true;
   while (found) {
-    const ConvexBase::Neighbors& n = nn[hint];
+    const ConvexBase::Neighbors& n = nn[static_cast<size_t>(hint)];
     found = false;
     for (int in = 0; in < n.count(); ++in) {
       const unsigned int ip = n[in];

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -173,11 +173,11 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
                         MinkowskiDiff::ShapeData* data) {
   assert(data != NULL);
 
-  const Vec3f* pts = convex->points.get();
+  const std::vector<Vec3f>& pts = *(convex->points);
   const ConvexBase::Neighbors* nn = convex->neighbors.get();
 
   if (hint < 0 || hint >= (int)convex->num_points) hint = 0;
-  FCL_REAL maxdot = pts[hint].dot(dir);
+  FCL_REAL maxdot = pts[static_cast<size_t>(hint)].dot(dir);
   std::vector<int8_t>& visited = data->visited;
   visited.assign(convex->num_points, false);
   visited[static_cast<std::size_t>(hint)] = true;
@@ -206,24 +206,24 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
     }
   }
 
-  support = pts[hint];
+  support = pts[static_cast<size_t>(hint)];
 }
 
 void getShapeSupportLinear(const ConvexBase* convex, const Vec3f& dir,
                            Vec3f& support, int& hint,
                            MinkowskiDiff::ShapeData*) {
-  const Vec3f* pts = convex->points.get();
+  const std::vector<Vec3f>& pts = *(convex->points);
 
   hint = 0;
   FCL_REAL maxdot = pts[0].dot(dir);
   for (int i = 1; i < (int)convex->num_points; ++i) {
-    FCL_REAL dot = pts[i].dot(dir);
+    FCL_REAL dot = pts[static_cast<size_t>(i)].dot(dir);
     if (dot > maxdot) {
       maxdot = dot;
       hint = i;
     }
   }
-  support = pts[hint];
+  support = pts[static_cast<size_t>(hint)];
 }
 
 void getShapeSupport(const ConvexBase* convex, const Vec3f& dir, Vec3f& support,

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -220,10 +220,10 @@ void ConvexBase::buildDoubleDescription() {
 
 void ConvexBase::buildDoubleDescriptionFromQHullResult(const Qhull& qh) {
   num_normals_and_offsets = static_cast<unsigned int>(qh.facetCount());
-  normals.reset(new Vec3f[num_normals_and_offsets]);
-  Vec3f* normals_ = normals.get();
-  offsets.reset(new double[num_normals_and_offsets]);
-  double* offsets_ = offsets.get();
+  normals.reset(new std::vector<Vec3f>(num_normals_and_offsets));
+  std::vector<Vec3f>& normals_ = *normals;
+  offsets.reset(new std::vector<double>(num_normals_and_offsets));
+  std::vector<double>& offsets_ = *offsets;
   unsigned int i_normal = 0;
   for (QhullFacet facet = qh.beginFacet(); facet != qh.endFacet();
        facet = facet.next()) {

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -1,11 +1,13 @@
 #include <hpp/fcl/shape/convex.h>
 
+#ifdef HPP_FCL_HAS_QHULL
 using orgQhull::Qhull;
 using orgQhull::QhullFacet;
 using orgQhull::QhullPoint;
 using orgQhull::QhullRidgeSet;
 using orgQhull::QhullVertexList;
 using orgQhull::QhullVertexSet;
+#endif
 
 namespace hpp {
 namespace fcl {

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -104,7 +104,8 @@ ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
   std::vector<std::set<index_type>> nneighbors(static_cast<size_t>(nvertex));
   if (keepTriangles) {
     convex_tri->num_polygons = static_cast<unsigned int>(qh.facetCount());
-    convex_tri->polygons.reset(new Triangle[convex_tri->num_polygons]);
+    convex_tri->polygons.reset(
+        new std::vector<Triangle>(convex_tri->num_polygons));
     convex_tri->computeCenter();
   }
 
@@ -128,7 +129,7 @@ ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
               f_vertices[2].point().id())]));
       if (keepTriangles) {
         reorderTriangle(convex_tri, tri);
-        convex_tri->polygons.get()[i_polygon++] = tri;
+        (*convex_tri->polygons)[i_polygon++] = tri;
       }
       for (size_t j = 0; j < n; ++j) {
         size_t i = (j == 0) ? n - 1 : j - 1;

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -100,7 +100,7 @@ ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
   convex->initialize(vertices, static_cast<unsigned int>(nvertex));
 
   // Build the neighbors
-  convex->neighbors.reset(new Neighbors[size_t(nvertex)]);
+  convex->neighbors.reset(new std::vector<Neighbors>(size_t(nvertex)));
   std::vector<std::set<index_type>> nneighbors(static_cast<size_t>(nvertex));
   if (keepTriangles) {
     convex_tri->num_polygons = static_cast<unsigned int>(qh.facetCount());
@@ -173,9 +173,9 @@ ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
   convex->buildDoubleDescriptionFromQHullResult(qh);
 
   // Fill the neighbor attribute of the returned object.
-  convex->nneighbors_.reset(new unsigned int[c_nneighbors]);
-  unsigned int* p_nneighbors = convex->nneighbors_.get();
-  Neighbors* neighbors_ = convex->neighbors.get();
+  convex->nneighbors_.reset(new std::vector<unsigned int>(c_nneighbors));
+  unsigned int* p_nneighbors = convex->nneighbors_->data();
+  std::vector<Neighbors>& neighbors_ = *(convex->neighbors);
   for (size_t i = 0; i < static_cast<size_t>(nvertex); ++i) {
     Neighbors& n = neighbors_[i];
     if (nneighbors[i].size() >= (std::numeric_limits<unsigned char>::max)())
@@ -185,7 +185,7 @@ ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
     p_nneighbors =
         std::copy(nneighbors[i].begin(), nneighbors[i].end(), p_nneighbors);
   }
-  assert(p_nneighbors == convex->nneighbors_.get() + c_nneighbors);
+  assert(p_nneighbors == convex->nneighbors_->data() + c_nneighbors);
   return convex;
 #else
   throw std::logic_error(

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -1,6 +1,14 @@
 #include <hpp/fcl/shape/convex.h>
 
 #ifdef HPP_FCL_HAS_QHULL
+#include <libqhullcpp/QhullError.h>
+#include <libqhullcpp/QhullFacet.h>
+#include <libqhullcpp/QhullLinkedList.h>
+#include <libqhullcpp/QhullVertex.h>
+#include <libqhullcpp/QhullVertexSet.h>
+#include <libqhullcpp/QhullRidge.h>
+#include <libqhullcpp/Qhull.h>
+
 using orgQhull::Qhull;
 using orgQhull::QhullFacet;
 using orgQhull::QhullPoint;

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -61,30 +61,19 @@ ConvexBase::ConvexBase(const ConvexBase& other)
       num_points(other.num_points),
       num_normals_and_offsets(other.num_normals_and_offsets),
       center(other.center) {
-  if (other.points.get()) {
-    if (other.points->size() > 0) {
-      // Deep copy of other points
-      points.reset(new std::vector<Vec3f>(*other.points));
-    } else
-      points.reset();
+  if (other.points.get() && other.points->size() > 0) {
+    // Deep copy of other points
+    points.reset(new std::vector<Vec3f>(*other.points));
   } else
     points.reset();
 
-  if (other.neighbors.get()) {
-    neighbors.reset(new Neighbors[num_points]);
-    std::copy(other.neighbors.get(), other.neighbors.get() + num_points,
-              neighbors.get());
+  if (other.neighbors.get() && other.neighbors->size() > 0) {
+    neighbors.reset(new std::vector<Neighbors>(*(other.neighbors)));
   } else
     neighbors.reset();
 
-  if (other.nneighbors_.get()) {
-    std::size_t c_nneighbors = 0;
-    const Neighbors* neighbors_ = neighbors.get();
-    for (std::size_t i = 0; i < num_points; ++i)
-      c_nneighbors += neighbors_[i].count();
-    nneighbors_.reset(new unsigned int[c_nneighbors]);
-    std::copy(other.nneighbors_.get(), other.nneighbors_.get() + c_nneighbors,
-              nneighbors_.get());
+  if (other.nneighbors_.get() && other.nneighbors_->size() > 0) {
+    nneighbors_.reset(new std::vector<unsigned int>(*(other.nneighbors_)));
   } else
     nneighbors_.reset();
 

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -45,6 +45,9 @@ void ConvexBase::initialize(std::shared_ptr<Vec3f> points_,
                             unsigned int num_points_) {
   points = points_;
   num_points = num_points_;
+  num_normals_and_offsets = 0;
+  normals.reset();
+  offsets.reset();
   computeCenter();
 }
 
@@ -53,7 +56,10 @@ void ConvexBase::set(std::shared_ptr<Vec3f> points_, unsigned int num_points_) {
 }
 
 ConvexBase::ConvexBase(const ConvexBase& other)
-    : ShapeBase(other), num_points(other.num_points), center(other.center) {
+    : ShapeBase(other),
+      num_points(other.num_points),
+      num_normals_and_offsets(other.num_normals_and_offsets),
+      center(other.center) {
   if (other.points.get()) {
     points.reset(new Vec3f[num_points]);
     std::copy(other.points.get(), other.points.get() + num_points,
@@ -78,6 +84,20 @@ ConvexBase::ConvexBase(const ConvexBase& other)
               nneighbors_.get());
   } else
     nneighbors_.reset();
+
+  if (other.normals.get()) {
+    normals.reset(new Vec3f[num_normals_and_offsets]);
+    std::copy(other.normals.get(),
+              other.normals.get() + num_normals_and_offsets, normals.get());
+  } else
+    normals.reset();
+
+  if (other.offsets.get()) {
+    offsets.reset(new double[num_normals_and_offsets]);
+    std::copy(other.offsets.get(),
+              other.offsets.get() + num_normals_and_offsets, offsets.get());
+  } else
+    offsets.reset();
 
   ShapeBase::operator=(*this);
 }

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -77,17 +77,13 @@ ConvexBase::ConvexBase(const ConvexBase& other)
   } else
     nneighbors_.reset();
 
-  if (other.normals.get()) {
-    normals.reset(new Vec3f[num_normals_and_offsets]);
-    std::copy(other.normals.get(),
-              other.normals.get() + num_normals_and_offsets, normals.get());
+  if (other.normals.get() && other.normals->size() > 0) {
+    normals.reset(new std::vector<Vec3f>(*(other.normals)));
   } else
     normals.reset();
 
-  if (other.offsets.get()) {
-    offsets.reset(new double[num_normals_and_offsets]);
-    std::copy(other.offsets.get(),
-              other.offsets.get() + num_normals_and_offsets, offsets.get());
+  if (other.offsets.get() && other.offsets->size() > 0) {
+    offsets.reset(new std::vector<double>(*(other.offsets)));
   } else
     offsets.reset();
 

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -41,7 +41,7 @@
 namespace hpp {
 namespace fcl {
 
-void ConvexBase::initialize(std::shared_ptr<Vec3f> points_,
+void ConvexBase::initialize(std::shared_ptr<std::vector<Vec3f>> points_,
                             unsigned int num_points_) {
   points = points_;
   num_points = num_points_;
@@ -51,7 +51,8 @@ void ConvexBase::initialize(std::shared_ptr<Vec3f> points_,
   computeCenter();
 }
 
-void ConvexBase::set(std::shared_ptr<Vec3f> points_, unsigned int num_points_) {
+void ConvexBase::set(std::shared_ptr<std::vector<Vec3f>> points_,
+                     unsigned int num_points_) {
   initialize(points_, num_points_);
 }
 
@@ -61,9 +62,11 @@ ConvexBase::ConvexBase(const ConvexBase& other)
       num_normals_and_offsets(other.num_normals_and_offsets),
       center(other.center) {
   if (other.points.get()) {
-    points.reset(new Vec3f[num_points]);
-    std::copy(other.points.get(), other.points.get() + num_points,
-              points.get());
+    if (other.points->size() > 0) {
+      // Deep copy of other points
+      points.reset(new std::vector<Vec3f>(*other.points));
+    } else
+      points.reset();
   } else
     points.reset();
 
@@ -106,7 +109,7 @@ ConvexBase::~ConvexBase() {}
 
 void ConvexBase::computeCenter() {
   center.setZero();
-  const Vec3f* points_ = points.get();
+  const std::vector<Vec3f>& points_ = *points;
   for (std::size_t i = 0; i < num_points; ++i)
     center += points_[i];  // TODO(jcarpent): vectorization
   center /= num_points;

--- a/src/shape/geometric_shapes_utility.cpp
+++ b/src/shape/geometric_shapes_utility.cpp
@@ -226,7 +226,7 @@ std::vector<Vec3f> getBoundVertices(const Cylinder& cylinder,
 std::vector<Vec3f> getBoundVertices(const ConvexBase& convex,
                                     const Transform3f& tf) {
   std::vector<Vec3f> result(convex.num_points);
-  const Vec3f* points_ = convex.points.get();
+  const std::vector<Vec3f>& points_ = *(convex.points);
   for (std::size_t i = 0; i < convex.num_points; ++i) {
     result[i] = tf.transform(points_[i]);
   }
@@ -355,7 +355,7 @@ void computeBV<AABB, ConvexBase>(const ConvexBase& s, const Transform3f& tf,
   const Vec3f& T = tf.getTranslation();
 
   AABB bv_;
-  const Vec3f* points_ = s.points.get();
+  const std::vector<Vec3f>& points_ = *(s.points);
   for (std::size_t i = 0; i < s.num_points; ++i) {
     Vec3f new_p = R * points_[i] + T;
     bv_ += new_p;
@@ -494,7 +494,7 @@ void computeBV<OBB, ConvexBase>(const ConvexBase& s, const Transform3f& tf,
   const Matrix3f& R = tf.getRotation();
   const Vec3f& T = tf.getTranslation();
 
-  fit(s.points.get(), s.num_points, bv);
+  fit(s.points->data(), s.num_points, bv);
 
   bv.axes.applyOnTheLeft(R);
 

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -72,40 +72,40 @@ BOOST_AUTO_TEST_CASE(convex) {
   Convex<Quadrilateral> box(buildBox(l, w, d));
 
   // Check neighbors
-  for (int i = 0; i < 8; ++i) {
-    BOOST_CHECK_EQUAL(box.neighbors.get()[i].count(), 3);
+  for (size_t i = 0; i < 8; ++i) {
+    BOOST_CHECK_EQUAL((*box.neighbors)[i].count(), 3);
   }
-  BOOST_CHECK_EQUAL(box.neighbors.get()[0][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[0][1], 2);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[0][2], 4);
+  BOOST_CHECK_EQUAL((*box.neighbors)[0][0], 1);
+  BOOST_CHECK_EQUAL((*box.neighbors)[0][1], 2);
+  BOOST_CHECK_EQUAL((*box.neighbors)[0][2], 4);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[1][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[1][1], 3);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[1][2], 5);
+  BOOST_CHECK_EQUAL((*box.neighbors)[1][0], 0);
+  BOOST_CHECK_EQUAL((*box.neighbors)[1][1], 3);
+  BOOST_CHECK_EQUAL((*box.neighbors)[1][2], 5);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[2][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[2][1], 3);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[2][2], 6);
+  BOOST_CHECK_EQUAL((*box.neighbors)[2][0], 0);
+  BOOST_CHECK_EQUAL((*box.neighbors)[2][1], 3);
+  BOOST_CHECK_EQUAL((*box.neighbors)[2][2], 6);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[3][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[3][1], 2);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[3][2], 7);
+  BOOST_CHECK_EQUAL((*box.neighbors)[3][0], 1);
+  BOOST_CHECK_EQUAL((*box.neighbors)[3][1], 2);
+  BOOST_CHECK_EQUAL((*box.neighbors)[3][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[4][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[4][1], 5);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[4][2], 6);
+  BOOST_CHECK_EQUAL((*box.neighbors)[4][0], 0);
+  BOOST_CHECK_EQUAL((*box.neighbors)[4][1], 5);
+  BOOST_CHECK_EQUAL((*box.neighbors)[4][2], 6);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[5][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[5][1], 4);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[5][2], 7);
+  BOOST_CHECK_EQUAL((*box.neighbors)[5][0], 1);
+  BOOST_CHECK_EQUAL((*box.neighbors)[5][1], 4);
+  BOOST_CHECK_EQUAL((*box.neighbors)[5][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[6][0], 2);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[6][1], 4);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[6][2], 7);
+  BOOST_CHECK_EQUAL((*box.neighbors)[6][0], 2);
+  BOOST_CHECK_EQUAL((*box.neighbors)[6][1], 4);
+  BOOST_CHECK_EQUAL((*box.neighbors)[6][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors.get()[7][0], 3);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[7][1], 5);
-  BOOST_CHECK_EQUAL(box.neighbors.get()[7][2], 6);
+  BOOST_CHECK_EQUAL((*box.neighbors)[7][0], 3);
+  BOOST_CHECK_EQUAL((*box.neighbors)[7][1], 5);
+  BOOST_CHECK_EQUAL((*box.neighbors)[7][2], 6);
 }
 
 template <typename Sa, typename Sb>
@@ -220,9 +220,9 @@ BOOST_AUTO_TEST_CASE(convex_hull_quad) {
   ConvexBase* convexHull = ConvexBase::convexHull(points, 4, false, NULL);
 
   BOOST_REQUIRE_EQUAL(convexHull->num_points, 4);
-  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[0].count(), 3);
-  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[1].count(), 3);
-  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[2].count(), 3);
+  BOOST_CHECK_EQUAL((*(convexHull->neighbors))[0].count(), 3);
+  BOOST_CHECK_EQUAL((*(convexHull->neighbors))[1].count(), 3);
+  BOOST_CHECK_EQUAL((*(convexHull->neighbors))[2].count(), 3);
   delete convexHull;
 }
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
     const std::vector<Vec3f>& cvxhull_points = *(convexHull->points);
     for (size_t i = 0; i < 8; ++i) {
       BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
-      BOOST_CHECK_EQUAL(convexHull->neighbors.get()[i].count(), 3);
+      BOOST_CHECK_EQUAL((*(convexHull->neighbors))[i].count(), 3);
     }
   }
   delete convexHull;
@@ -261,8 +261,8 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
     const std::vector<Vec3f>& cvxhull_points = *(convexHull->points);
     for (size_t i = 0; i < 8; ++i) {
       BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
-      BOOST_CHECK(convexHull->neighbors.get()[i].count() >= 3);
-      BOOST_CHECK(convexHull->neighbors.get()[i].count() <= 6);
+      BOOST_CHECK((*(convexHull->neighbors))[i].count() >= 3);
+      BOOST_CHECK((*(convexHull->neighbors))[i].count() <= 6);
     }
   }
   delete convexHull;

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -51,14 +51,14 @@ Convex<Quadrilateral> buildBox(FCL_REAL l, FCL_REAL w, FCL_REAL d) {
        Vec3f(-l, w, d), Vec3f(-l, w, -d), Vec3f(-l, -w, d),
        Vec3f(-l, -w, -d)}));
 
-  std::shared_ptr<Quadrilateral> polygons(new Quadrilateral[6]);
-  Quadrilateral* polygons_ = polygons.get();
-  polygons_[0].set(0, 2, 3, 1);  // x+ side
-  polygons_[1].set(2, 6, 7, 3);  // y- side
-  polygons_[2].set(4, 5, 7, 6);  // x- side
-  polygons_[3].set(0, 1, 5, 4);  // y+ side
-  polygons_[4].set(1, 3, 7, 5);  // z- side
-  polygons_[5].set(0, 2, 6, 4);  // z+ side
+  std::shared_ptr<std::vector<Quadrilateral>> polygons(
+      new std::vector<Quadrilateral>(6));
+  (*polygons)[0].set(0, 2, 3, 1);  // x+ side
+  (*polygons)[1].set(2, 6, 7, 3);  // y- side
+  (*polygons)[2].set(4, 5, 7, 6);  // x- side
+  (*polygons)[3].set(0, 1, 5, 4);  // y+ side
+  (*polygons)[4].set(1, 3, 7, 5);  // z- side
+  (*polygons)[5].set(0, 2, 6, 4);  // z+ side
 
   return Convex<Quadrilateral>(pts,  // points
                                8,    // num points

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -182,6 +182,16 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   test_serialization(distance_result);
 }
 
+template <typename T>
+void checkEqualStdVector(const std::vector<T>& v1, const std::vector<T>& v2) {
+  BOOST_CHECK(v1.size() == v2.size());
+  if (v1.size() == v2.size()) {
+    for (size_t i = 0; i < v1.size(); i++) {
+      BOOST_CHECK(v1[i] == v2[i]);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_BVHModel) {
   std::vector<Vec3f> p1, p2;
   std::vector<Triangle> t1, t2;
@@ -195,11 +205,19 @@ BOOST_AUTO_TEST_CASE(test_BVHModel) {
   m1.beginModel();
   m1.addSubModel(p1, t1);
   m1.endModel();
+  BOOST_CHECK(m1.num_vertices == p1.size());
+  BOOST_CHECK(m1.num_tris == t1.size());
+  checkEqualStdVector(*m1.vertices, p1);
+  checkEqualStdVector(*m1.tri_indices, t1);
   BOOST_CHECK(m1 == m1);
 
   m2.beginModel();
   m2.addSubModel(p2, t2);
   m2.endModel();
+  BOOST_CHECK(m2.num_vertices == p2.size());
+  BOOST_CHECK(m2.num_tris == t2.size());
+  checkEqualStdVector(*m2.vertices, p2);
+  checkEqualStdVector(*m2.tri_indices, t2);
   BOOST_CHECK(m2 == m2);
   BOOST_CHECK(m1 != m2);
 

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -478,24 +478,25 @@ Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid) {
   FCL_REAL PHI = (1 + std::sqrt(5)) / 2;
 
   // vertices
-  std::shared_ptr<Vec3f> pts(new Vec3f[12]);
-  Vec3f* pts_ = pts.get();
-  pts_[0] = Vec3f(-1, PHI, 0);
-  pts_[1] = Vec3f(1, PHI, 0);
-  pts_[2] = Vec3f(-1, -PHI, 0);
-  pts_[3] = Vec3f(1, -PHI, 0);
+  std::shared_ptr<std::vector<Vec3f>> pts(new std::vector<Vec3f>({
+      Vec3f(-1, PHI, 0),
+      Vec3f(1, PHI, 0),
+      Vec3f(-1, -PHI, 0),
+      Vec3f(1, -PHI, 0),
 
-  pts_[4] = Vec3f(0, -1, PHI);
-  pts_[5] = Vec3f(0, 1, PHI);
-  pts_[6] = Vec3f(0, -1, -PHI);
-  pts_[7] = Vec3f(0, 1, -PHI);
+      Vec3f(0, -1, PHI),
+      Vec3f(0, 1, PHI),
+      Vec3f(0, -1, -PHI),
+      Vec3f(0, 1, -PHI),
 
-  pts_[8] = Vec3f(PHI, 0, -1);
-  pts_[9] = Vec3f(PHI, 0, 1);
-  pts_[10] = Vec3f(-PHI, 0, -1);
-  pts_[11] = Vec3f(-PHI, 0, 1);
+      Vec3f(PHI, 0, -1),
+      Vec3f(PHI, 0, 1),
+      Vec3f(-PHI, 0, -1),
+      Vec3f(-PHI, 0, 1),
+  }));
 
-  for (int i = 0; i < 12; ++i) {
+  std::vector<Vec3f>& pts_ = *pts;
+  for (size_t i = 0; i < 12; ++i) {
     toEllipsoid(pts_[i], ellipsoid);
   }
 

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -501,31 +501,30 @@ Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid) {
   }
 
   // faces
-  std::shared_ptr<Triangle> tris(new Triangle[20]);
-  Triangle* tris_ = tris.get();
-  tris_[0].set(0, 11, 5);
-  tris_[1].set(0, 5, 1);
-  tris_[2].set(0, 1, 7);
-  tris_[3].set(0, 7, 10);
-  tris_[4].set(0, 10, 11);
+  std::shared_ptr<std::vector<Triangle>> tris(new std::vector<Triangle>(20));
+  (*tris)[0].set(0, 11, 5);
+  (*tris)[1].set(0, 5, 1);
+  (*tris)[2].set(0, 1, 7);
+  (*tris)[3].set(0, 7, 10);
+  (*tris)[4].set(0, 10, 11);
 
-  tris_[5].set(1, 5, 9);
-  tris_[6].set(5, 11, 4);
-  tris_[7].set(11, 10, 2);
-  tris_[8].set(10, 7, 6);
-  tris_[9].set(7, 1, 8);
+  (*tris)[5].set(1, 5, 9);
+  (*tris)[6].set(5, 11, 4);
+  (*tris)[7].set(11, 10, 2);
+  (*tris)[8].set(10, 7, 6);
+  (*tris)[9].set(7, 1, 8);
 
-  tris_[10].set(3, 9, 4);
-  tris_[11].set(3, 4, 2);
-  tris_[12].set(3, 2, 6);
-  tris_[13].set(3, 6, 8);
-  tris_[14].set(3, 8, 9);
+  (*tris)[10].set(3, 9, 4);
+  (*tris)[11].set(3, 4, 2);
+  (*tris)[12].set(3, 2, 6);
+  (*tris)[13].set(3, 6, 8);
+  (*tris)[14].set(3, 8, 9);
 
-  tris_[15].set(4, 9, 5);
-  tris_[16].set(2, 4, 11);
-  tris_[17].set(6, 2, 10);
-  tris_[18].set(8, 6, 7);
-  tris_[19].set(9, 8, 1);
+  (*tris)[15].set(4, 9, 5);
+  (*tris)[16].set(2, 4, 11);
+  (*tris)[17].set(6, 2, 10);
+  (*tris)[18].set(8, 6, 7);
+  (*tris)[19].set(9, 8, 1);
   return Convex<Triangle>(pts,   // points
                           12,    // num_points
                           tris,  // triangles


### PR DESCRIPTION
A polytope can be seen as either a set of vertices or a set of planes (normals + offsets).
The double description is normals + offsets.
In GJK/EPA we only use the vertices of polytopes. However, for computing normals/witness points, having the double description may be usefull in the future.