### PR TITLE
Convex and BVHModel: moving from raw to std::shared_ptr

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           - {ROS_DISTRO: melodic, PRERELEASE: false}
           - {ROS_DISTRO: noetic}
-          - {ROS_DISTRO: foxy}
+          - {ROS_DISTRO: iron}
           - {ROS_DISTRO: rolling}
     env:
       # CCACHE_DIR: /github/home/.ccache # Enable ccache

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -30,5 +30,5 @@ jobs:
       #    path: ${{ env.CCACHE_DIR }}
       #    key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       # Run industrial_ci
-      - uses: 'ros-industrial/industrial_ci@6a8f546cbd31fbd5c9f77e3409265c8b39abc3d6'
+      - uses: 'ros-industrial/industrial_ci@9f963f67ebb889792175776c5ee00134d7bb569b'
         env: ${{ matrix.env }}

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -16,7 +16,7 @@ jobs:
           - {ROS_DISTRO: foxy}
           - {ROS_DISTRO: rolling}
     env:
-      CCACHE_DIR: /github/home/.ccache # Enable ccache
+      # CCACHE_DIR: /github/home/.ccache # Enable ccache
       BUILDER: colcon
       PRERELEASE: true
     runs-on: ubuntu-latest
@@ -25,10 +25,10 @@ jobs:
         with:
           submodules: recursive
       # This step will fetch/store the directory used by ccache before/after the ci run
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
+      # - uses: actions/cache@v3
+      #  with:
+      #    path: ${{ env.CCACHE_DIR }}
+      #    key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       # Run industrial_ci
       - uses: 'ros-industrial/industrial_ci@6a8f546cbd31fbd5c9f77e3409265c8b39abc3d6'
         env: ${{ matrix.env }}

--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -101,8 +101,7 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
   BVHModelBase(const BVHModelBase& other);
 
   /// @brief deconstruction, delete mesh data related.
-  virtual ~BVHModelBase() {
-  }
+  virtual ~BVHModelBase() {}
 
   /// @brief Get the object type: it is a BVH
   OBJECT_TYPE getObjectType() const { return OT_BVH; }
@@ -208,8 +207,8 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
       FCL_REAL d_six_vol =
           (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
       vol += d_six_vol;
-      com +=
-          (vertices_[tri[0]] + vertices_[tri[1]] + vertices_[tri[2]]) * d_six_vol;
+      com += (vertices_[tri[0]] + vertices_[tri[1]] + vertices_[tri[2]]) *
+             d_six_vol;
     }
 
     return com / (vol * 4);

--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -67,7 +67,7 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
   std::shared_ptr<Vec3f> vertices;
 
   /// @brief Geometry triangle index data, will be NULL for point clouds
-  Triangle* tri_indices;
+  std::shared_ptr<Triangle> tri_indices;
 
   /// @brief Geometry point data in previous frame
   std::shared_ptr<Vec3f> prev_vertices;
@@ -102,7 +102,6 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
 
   /// @brief deconstruction, delete mesh data related.
   virtual ~BVHModelBase() {
-    delete[] tri_indices;
   }
 
   /// @brief Get the object type: it is a BVH
@@ -203,8 +202,9 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
     FCL_REAL vol = 0;
     Vec3f com(0, 0, 0);
     const Vec3f* vertices_ = vertices.get();
+    const Triangle* tri_indices_ = tri_indices.get();
     for (unsigned int i = 0; i < num_tris; ++i) {
-      const Triangle& tri = tri_indices[i];
+      const Triangle& tri = tri_indices_[i];
       FCL_REAL d_six_vol =
           (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
       vol += d_six_vol;
@@ -218,8 +218,9 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
   FCL_REAL computeVolume() const {
     FCL_REAL vol = 0;
     const Vec3f* vertices_ = vertices.get();
+    const Triangle* tri_indices_ = tri_indices.get();
     for (unsigned int i = 0; i < num_tris; ++i) {
-      const Triangle& tri = tri_indices[i];
+      const Triangle& tri = tri_indices_[i];
       FCL_REAL d_six_vol =
           (vertices_[tri[0]].cross(vertices_[tri[1]])).dot(vertices_[tri[2]]);
       vol += d_six_vol;
@@ -236,8 +237,9 @@ class HPP_FCL_DLLAPI BVHModelBase : public CollisionGeometry {
         1 / 120.0, 1 / 120.0, 1 / 120.0, 1 / 60.0;
 
     const Vec3f* vertices_ = vertices.get();
+    const Triangle* tri_indices_ = tri_indices.get();
     for (unsigned int i = 0; i < num_tris; ++i) {
-      const Triangle& tri = tri_indices[i];
+      const Triangle& tri = tri_indices_[i];
       const Vec3f& v1 = vertices_[tri[0]];
       const Vec3f& v2 = vertices_[tri[1]];
       const Vec3f& v3 = vertices_[tri[2]];

--- a/include/hpp/fcl/BVH/BVH_model.h
+++ b/include/hpp/fcl/BVH/BVH_model.h
@@ -296,7 +296,7 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
   virtual BVHModel<BV>* clone() const { return new BVHModel(*this); }
 
   /// @brief deconstruction, delete mesh data related.
-  ~BVHModel() { delete[] primitive_indices; }
+  ~BVHModel() {}
 
   /// @brief We provide getBV() and getNumBVs() because BVH may be compressed
   /// (in future), so we must provide some flexibility here
@@ -336,7 +336,7 @@ class HPP_FCL_DLLAPI BVHModel : public BVHModelBase {
   bool allocateBVs();
 
   unsigned int num_bvs_allocated;
-  unsigned int* primitive_indices;
+  std::shared_ptr<unsigned int> primitive_indices;
 
   /// @brief Bounding volume hierarchy
   std::shared_ptr<BVNode<BV>> bvs;

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -74,15 +74,16 @@ Convex<Quadrilateral> buildConvexQuadrilateral(const HFNode<BV>& node,
          "max_height is lower than min_height");  // Check whether the geometry
                                                   // is degenerated
 
-  Vec3f* pts = new Vec3f[8];
-  pts[0] = Vec3f(x0, y0, min_height);
-  pts[1] = Vec3f(x0, y1, min_height);
-  pts[2] = Vec3f(x1, y1, min_height);
-  pts[3] = Vec3f(x1, y0, min_height);
-  pts[4] = Vec3f(x0, y0, cell(0, 0));
-  pts[5] = Vec3f(x0, y1, cell(1, 0));
-  pts[6] = Vec3f(x1, y1, cell(1, 1));
-  pts[7] = Vec3f(x1, y0, cell(0, 1));
+  std::shared_ptr<Vec3f> pts(new Vec3f[8]);
+  Vec3f* pts_ = pts.get();
+  pts_[0] = Vec3f(x0, y0, min_height);
+  pts_[1] = Vec3f(x0, y1, min_height);
+  pts_[2] = Vec3f(x1, y1, min_height);
+  pts_[3] = Vec3f(x1, y0, min_height);
+  pts_[4] = Vec3f(x0, y0, cell(0, 0));
+  pts_[5] = Vec3f(x0, y1, cell(1, 0));
+  pts_[6] = Vec3f(x1, y1, cell(1, 1));
+  pts_[7] = Vec3f(x1, y0, cell(0, 1));
 
   Quadrilateral* polygons = new Quadrilateral[6];
   polygons[0].set(0, 3, 2, 1);  // x+ side

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -195,7 +195,7 @@ bool binCorrection(const Convex<Polygone>& convex, const Shape& shape,
                    const Transform3f& shape_pose, FCL_REAL& distance,
                    Vec3f& contact_1, Vec3f& contact_2, Vec3f& normal,
                    Vec3f& normal_top, bool& is_collision) {
-  const Polygone& top_triangle = convex.polygons[1];
+  const Polygone& top_triangle = convex.polygons.get()[1];
   const Vec3f* points = convex.points.get();
   const Vec3f pointA = points[top_triangle[0]];
   const Vec3f pointB = points[top_triangle[1]];

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -94,8 +94,7 @@ Convex<Quadrilateral> buildConvexQuadrilateral(const HFNode<BV>& node,
   polygons_[4].set(3, 0, 4, 7);  // z- side
   polygons_[5].set(4, 5, 6, 7);  // z+ side
 
-  return Convex<Quadrilateral>(true,
-                               pts,  // points
+  return Convex<Quadrilateral>(pts,  // points
                                8,    // num points
                                polygons,
                                6  // number of polygons
@@ -144,8 +143,7 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
     triangles_[6].set(0, 2, 5);
     triangles_[7].set(5, 3, 0);
 
-    convex1.set(true,
-                pts,  // points
+    convex1.set(pts,  // points
                 6,    // num points
                 triangles,
                 8  // number of polygons
@@ -173,8 +171,7 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
     triangles_[6].set(1, 5, 2);
     triangles_[7].set(4, 2, 1);
 
-    convex2.set(true,
-                pts,  // points
+    convex2.set(pts,  // points
                 6,    // num points
                 triangles,
                 8  // number of polygons

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -85,13 +85,14 @@ Convex<Quadrilateral> buildConvexQuadrilateral(const HFNode<BV>& node,
   pts_[6] = Vec3f(x1, y1, cell(1, 1));
   pts_[7] = Vec3f(x1, y0, cell(0, 1));
 
-  Quadrilateral* polygons = new Quadrilateral[6];
-  polygons[0].set(0, 3, 2, 1);  // x+ side
-  polygons[1].set(0, 1, 5, 4);  // y- side
-  polygons[2].set(1, 2, 6, 5);  // x- side
-  polygons[3].set(2, 3, 7, 6);  // y+ side
-  polygons[4].set(3, 0, 4, 7);  // z- side
-  polygons[5].set(4, 5, 6, 7);  // z+ side
+  std::shared_ptr<Quadrilateral> polygons(new Quadrilateral[6]);
+  Quadrilateral* polygons_ = polygons.get();
+  polygons_[0].set(0, 3, 2, 1);  // x+ side
+  polygons_[1].set(0, 1, 5, 4);  // y- side
+  polygons_[2].set(1, 2, 6, 5);  // x- side
+  polygons_[3].set(2, 3, 7, 6);  // y+ side
+  polygons_[4].set(3, 0, 4, 7);  // z- side
+  polygons_[5].set(4, 5, 6, 7);  // z+ side
 
   return Convex<Quadrilateral>(true,
                                pts,  // points
@@ -132,15 +133,16 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
     pts_[4] = Vec3f(x0, y1, cell(1, 0));  //
     pts_[5] = Vec3f(x1, y0, cell(0, 1));  //
 
-    Triangle* triangles = new Triangle[8];
-    triangles[0].set(0, 1, 2);  // bottom
-    triangles[1].set(3, 5, 4);  // top
-    triangles[2].set(0, 3, 1);
-    triangles[3].set(3, 4, 1);
-    triangles[4].set(1, 5, 2);
-    triangles[5].set(1, 4, 5);
-    triangles[6].set(0, 2, 5);
-    triangles[7].set(5, 3, 0);
+    std::shared_ptr<Triangle> triangles(new Triangle[8]);
+    Triangle* triangles_ = triangles.get();
+    triangles_[0].set(0, 1, 2);  // bottom
+    triangles_[1].set(3, 5, 4);  // top
+    triangles_[2].set(0, 3, 1);
+    triangles_[3].set(3, 4, 1);
+    triangles_[4].set(1, 5, 2);
+    triangles_[5].set(1, 4, 5);
+    triangles_[6].set(0, 2, 5);
+    triangles_[7].set(5, 3, 0);
 
     convex1.set(true,
                 pts,  // points
@@ -160,15 +162,16 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
     pts_[4] = Vec3f(x1, y1, cell(1, 1));
     pts_[5] = Vec3f(x1, y0, cell(0, 1));
 
-    Triangle* triangles = new Triangle[8];
-    triangles[0].set(2, 0, 1);  // bottom
-    triangles[1].set(3, 5, 4);  // top
-    triangles[2].set(0, 3, 1);
-    triangles[3].set(3, 4, 1);
-    triangles[4].set(0, 2, 5);
-    triangles[5].set(0, 5, 3);
-    triangles[6].set(1, 5, 2);
-    triangles[7].set(4, 2, 1);
+    std::shared_ptr<Triangle> triangles(new Triangle[8]);
+    Triangle* triangles_ = triangles.get();
+    triangles_[0].set(2, 0, 1);  // bottom
+    triangles_[1].set(3, 5, 4);  // top
+    triangles_[2].set(0, 3, 1);
+    triangles_[3].set(3, 4, 1);
+    triangles_[4].set(0, 2, 5);
+    triangles_[5].set(0, 5, 3);
+    triangles_[6].set(1, 5, 2);
+    triangles_[7].set(4, 2, 1);
 
     convex2.set(true,
                 pts,  // points

--- a/include/hpp/fcl/internal/traversal_node_hfield_shape.h
+++ b/include/hpp/fcl/internal/traversal_node_hfield_shape.h
@@ -123,13 +123,14 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
   HPP_FCL_UNUSED_VARIABLE(max_height);
 
   {
-    Vec3f* pts = new Vec3f[6];
-    pts[0] = Vec3f(x0, y0, min_height);  //
-    pts[1] = Vec3f(x0, y1, min_height);  //
-    pts[2] = Vec3f(x1, y0, min_height);  //
-    pts[3] = Vec3f(x0, y0, cell(0, 0));  //
-    pts[4] = Vec3f(x0, y1, cell(1, 0));  //
-    pts[5] = Vec3f(x1, y0, cell(0, 1));  //
+    std::shared_ptr<Vec3f> pts(new Vec3f[6]);
+    Vec3f* pts_ = pts.get();
+    pts_[0] = Vec3f(x0, y0, min_height);  //
+    pts_[1] = Vec3f(x0, y1, min_height);  //
+    pts_[2] = Vec3f(x1, y0, min_height);  //
+    pts_[3] = Vec3f(x0, y0, cell(0, 0));  //
+    pts_[4] = Vec3f(x0, y1, cell(1, 0));  //
+    pts_[5] = Vec3f(x1, y0, cell(0, 1));  //
 
     Triangle* triangles = new Triangle[8];
     triangles[0].set(0, 1, 2);  // bottom
@@ -150,14 +151,14 @@ void buildConvexTriangles(const HFNode<BV>& node, const HeightField<BV>& model,
   }
 
   {
-    Vec3f* pts = new Vec3f[6];
-
-    pts[0] = Vec3f(x0, y1, min_height);
-    pts[1] = Vec3f(x1, y1, min_height);
-    pts[2] = Vec3f(x1, y0, min_height);
-    pts[3] = Vec3f(x0, y1, cell(1, 0));
-    pts[4] = Vec3f(x1, y1, cell(1, 1));
-    pts[5] = Vec3f(x1, y0, cell(0, 1));
+    std::shared_ptr<Vec3f> pts(new Vec3f[6]);
+    Vec3f* pts_ = pts.get();
+    pts_[0] = Vec3f(x0, y1, min_height);
+    pts_[1] = Vec3f(x1, y1, min_height);
+    pts_[2] = Vec3f(x1, y0, min_height);
+    pts_[3] = Vec3f(x0, y1, cell(1, 0));
+    pts_[4] = Vec3f(x1, y1, cell(1, 1));
+    pts_[5] = Vec3f(x1, y0, cell(0, 1));
 
     Triangle* triangles = new Triangle[8];
     triangles[0].set(2, 0, 1);  // bottom
@@ -195,7 +196,7 @@ bool binCorrection(const Convex<Polygone>& convex, const Shape& shape,
                    Vec3f& contact_1, Vec3f& contact_2, Vec3f& normal,
                    Vec3f& normal_top, bool& is_collision) {
   const Polygone& top_triangle = convex.polygons[1];
-  const Vec3f* points = convex.points;
+  const Vec3f* points = convex.points.get();
   const Vec3f pointA = points[top_triangle[0]];
   const Vec3f pointB = points[top_triangle[1]];
   const Vec3f pointC = points[top_triangle[2]];

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -371,7 +371,7 @@ class HPP_FCL_DLLAPI OcTreeSolver {
         constructBox(bv1, tf1, box, box_tf);
 
         int primitive_id = tree2->getBV(root2).primitiveId();
-        const Triangle& tri_id = tree2->tri_indices[primitive_id];
+        const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
         const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
         const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
         const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];
@@ -484,7 +484,7 @@ class HPP_FCL_DLLAPI OcTreeSolver {
       constructBox(bv1, tf1, box, box_tf);
 
       int primitive_id = bvn2.primitiveId();
-      const Triangle& tri_id = tree2->tri_indices[primitive_id];
+      const Triangle& tri_id = tree2->tri_indices.get()[primitive_id];
       const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
       const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
       const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];

--- a/include/hpp/fcl/internal/traversal_node_octree.h
+++ b/include/hpp/fcl/internal/traversal_node_octree.h
@@ -372,9 +372,9 @@ class HPP_FCL_DLLAPI OcTreeSolver {
 
         int primitive_id = tree2->getBV(root2).primitiveId();
         const Triangle& tri_id = tree2->tri_indices[primitive_id];
-        const Vec3f& p1 = tree2->vertices[tri_id[0]];
-        const Vec3f& p2 = tree2->vertices[tri_id[1]];
-        const Vec3f& p3 = tree2->vertices[tri_id[2]];
+        const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
+        const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
+        const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];
 
         FCL_REAL dist;
         Vec3f closest_p1, closest_p2, normal;
@@ -485,9 +485,9 @@ class HPP_FCL_DLLAPI OcTreeSolver {
 
       int primitive_id = bvn2.primitiveId();
       const Triangle& tri_id = tree2->tri_indices[primitive_id];
-      const Vec3f& p1 = tree2->vertices[tri_id[0]];
-      const Vec3f& p2 = tree2->vertices[tri_id[1]];
-      const Vec3f& p3 = tree2->vertices[tri_id[2]];
+      const Vec3f& p1 = tree2->vertices.get()[tri_id[0]];
+      const Vec3f& p2 = tree2->vertices.get()[tri_id[1]];
+      const Vec3f& p3 = tree2->vertices.get()[tri_id[2]];
 
       Vec3f c1, c2, normal;
       FCL_REAL distance;

--- a/include/hpp/fcl/internal/traversal_node_setup.h
+++ b/include/hpp/fcl/internal/traversal_node_setup.h
@@ -364,7 +364,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get();
-  node.tri_indices = model1.tri_indices;
+  node.tri_indices = model1.tri_indices.get();
 
   node.result = &result;
 
@@ -392,7 +392,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S, 0>& node,
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get();
-  node.tri_indices = model1.tri_indices;
+  node.tri_indices = model1.tri_indices.get();
 
   node.result = &result;
 
@@ -449,7 +449,7 @@ static inline bool setupShapeMeshCollisionOrientedNode(
   computeBV(model1, tf1, node.model1_bv);
 
   node.vertices = model2.vertices.get();
-  node.tri_indices = model2.tri_indices;
+  node.tri_indices = model2.tri_indices.get();
 
   node.result = &result;
 
@@ -515,8 +515,8 @@ bool initialize(
   node.vertices1 = model1.vertices.get();
   node.vertices2 = model2.vertices.get();
 
-  node.tri_indices1 = model1.tri_indices;
-  node.tri_indices2 = model2.tri_indices;
+  node.tri_indices1 = model1.tri_indices.get();
+  node.tri_indices2 = model2.tri_indices.get();
 
   node.result = &result;
 
@@ -540,8 +540,8 @@ bool initialize(MeshCollisionTraversalNode<BV, 0>& node,
   node.vertices1 = model1.vertices.get();
   node.vertices2 = model2.vertices.get();
 
-  node.tri_indices1 = model1.tri_indices;
-  node.tri_indices2 = model2.tri_indices;
+  node.tri_indices1 = model1.tri_indices.get();
+  node.tri_indices2 = model2.tri_indices.get();
 
   node.model1 = &model1;
   node.tf1 = tf1;
@@ -635,8 +635,8 @@ bool initialize(
   node.vertices1 = model1.vertices.get();
   node.vertices2 = model2.vertices.get();
 
-  node.tri_indices1 = model1.tri_indices;
-  node.tri_indices2 = model2.tri_indices;
+  node.tri_indices1 = model1.tri_indices.get();
+  node.tri_indices2 = model2.tri_indices.get();
 
   return true;
 }
@@ -667,8 +667,8 @@ bool initialize(MeshDistanceTraversalNode<BV, 0>& node,
   node.vertices1 = model1.vertices.get();
   node.vertices2 = model2.vertices.get();
 
-  node.tri_indices1 = model1.tri_indices;
-  node.tri_indices2 = model2.tri_indices;
+  node.tri_indices1 = model1.tri_indices.get();
+  node.tri_indices2 = model2.tri_indices.get();
 
   relativeTransform(tf1.getRotation(), tf1.getTranslation(), tf2.getRotation(),
                     tf2.getTranslation(), node.RT.R, node.RT.T);
@@ -715,7 +715,7 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
   node.nsolver = nsolver;
 
   node.vertices = model1.vertices.get();
-  node.tri_indices = model1.tri_indices;
+  node.tri_indices = model1.tri_indices.get();
 
   computeBV(model2, tf2, node.model2_bv);
 
@@ -761,7 +761,7 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
   node.nsolver = nsolver;
 
   node.vertices = model2.vertices.get();
-  node.tri_indices = model2.tri_indices;
+  node.tri_indices = model2.tri_indices.get();
 
   computeBV(model1, tf1, node.model1_bv);
 
@@ -793,7 +793,7 @@ static inline bool setupMeshShapeDistanceOrientedNode(
   computeBV(model2, tf2, node.model2_bv);
 
   node.vertices = model1.vertices.get();
-  node.tri_indices = model1.tri_indices;
+  node.tri_indices = model1.tri_indices.get();
 
   return true;
 }
@@ -860,7 +860,7 @@ static inline bool setupShapeMeshDistanceOrientedNode(
   computeBV(model1, tf1, node.model1_bv);
 
   node.vertices = model2.vertices.get();
-  node.tri_indices = model2.tri_indices;
+  node.tri_indices = model2.tri_indices.get();
   node.R = tf2.getRotation();
   node.T = tf2.getTranslation();
 

--- a/include/hpp/fcl/internal/traversal_node_setup.h
+++ b/include/hpp/fcl/internal/traversal_node_setup.h
@@ -341,8 +341,9 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
   if (!tf1.isIdentity())  // TODO(jcarpent): vectorized version
   {
     std::vector<Vec3f> vertices_transformed(model1.num_vertices);
+    const Vec3f* model1_vertices_ = model1.vertices.get();
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
-      const Vec3f& p = model1.vertices[i];
+      const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
       vertices_transformed[i] = new_v;
     }
@@ -362,7 +363,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S>& node,
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices;
+  node.vertices = model1.vertices.get();
   node.tri_indices = model1.tri_indices;
 
   node.result = &result;
@@ -390,7 +391,7 @@ bool initialize(MeshShapeCollisionTraversalNode<BV, S, 0>& node,
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices;
+  node.vertices = model1.vertices.get();
   node.tri_indices = model1.tri_indices;
 
   node.result = &result;
@@ -447,7 +448,7 @@ static inline bool setupShapeMeshCollisionOrientedNode(
 
   computeBV(model1, tf1, node.model1_bv);
 
-  node.vertices = model2.vertices;
+  node.vertices = model2.vertices.get();
   node.tri_indices = model2.tri_indices;
 
   node.result = &result;
@@ -476,8 +477,9 @@ bool initialize(
 
   if (!tf1.isIdentity()) {
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
+    const Vec3f* model1_vertices_ = model1.vertices.get();
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
-      Vec3f& p = model1.vertices[i];
+      const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
       vertices_transformed1[i] = new_v;
     }
@@ -491,8 +493,9 @@ bool initialize(
 
   if (!tf2.isIdentity()) {
     std::vector<Vec3f> vertices_transformed2(model2.num_vertices);
+    const Vec3f* model2_vertices_ = model2.vertices.get();
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
-      Vec3f& p = model2.vertices[i];
+      const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
       vertices_transformed2[i] = new_v;
     }
@@ -509,8 +512,8 @@ bool initialize(
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices;
-  node.vertices2 = model2.vertices;
+  node.vertices1 = model1.vertices.get();
+  node.vertices2 = model2.vertices.get();
 
   node.tri_indices1 = model1.tri_indices;
   node.tri_indices2 = model2.tri_indices;
@@ -534,8 +537,8 @@ bool initialize(MeshCollisionTraversalNode<BV, 0>& node,
         "model2 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
-  node.vertices1 = model1.vertices;
-  node.vertices2 = model2.vertices;
+  node.vertices1 = model1.vertices.get();
+  node.vertices2 = model2.vertices.get();
 
   node.tri_indices1 = model1.tri_indices;
   node.tri_indices2 = model2.tri_indices;
@@ -590,9 +593,10 @@ bool initialize(
         std::invalid_argument)
 
   if (!tf1.isIdentity()) {
+    const Vec3f* model1_vertices_ = model1.vertices.get();
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
-      const Vec3f& p = model1.vertices[i];
+      const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
       vertices_transformed1[i] = new_v;
     }
@@ -605,9 +609,10 @@ bool initialize(
   }
 
   if (!tf2.isIdentity()) {
+    const Vec3f* model2_vertices_ = model2.vertices.get();
     std::vector<Vec3f> vertices_transformed2(model2.num_vertices);
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
-      const Vec3f& p = model2.vertices[i];
+      const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
       vertices_transformed2[i] = new_v;
     }
@@ -627,8 +632,8 @@ bool initialize(
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices;
-  node.vertices2 = model2.vertices;
+  node.vertices1 = model1.vertices.get();
+  node.vertices2 = model2.vertices.get();
 
   node.tri_indices1 = model1.tri_indices;
   node.tri_indices2 = model2.tri_indices;
@@ -659,8 +664,8 @@ bool initialize(MeshDistanceTraversalNode<BV, 0>& node,
   node.model2 = &model2;
   node.tf2 = tf2;
 
-  node.vertices1 = model1.vertices;
-  node.vertices2 = model2.vertices;
+  node.vertices1 = model1.vertices.get();
+  node.vertices2 = model2.vertices.get();
 
   node.tri_indices1 = model1.tri_indices;
   node.tri_indices2 = model2.tri_indices;
@@ -684,10 +689,11 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
         "model1 should be of type BVHModelType::BVH_MODEL_TRIANGLES.",
         std::invalid_argument)
 
+  const Vec3f* model1_vertices_ = model1.vertices.get();
   if (!tf1.isIdentity()) {
     std::vector<Vec3f> vertices_transformed1(model1.num_vertices);
     for (unsigned int i = 0; i < model1.num_vertices; ++i) {
-      const Vec3f& p = model1.vertices[i];
+      const Vec3f& p = model1_vertices_[i];
       Vec3f new_v = tf1.transform(p);
       vertices_transformed1[i] = new_v;
     }
@@ -708,7 +714,7 @@ bool initialize(MeshShapeDistanceTraversalNode<BV, S>& node,
   node.tf2 = tf2;
   node.nsolver = nsolver;
 
-  node.vertices = model1.vertices;
+  node.vertices = model1.vertices.get();
   node.tri_indices = model1.tri_indices;
 
   computeBV(model2, tf2, node.model2_bv);
@@ -731,8 +737,9 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
 
   if (!tf2.isIdentity()) {
     std::vector<Vec3f> vertices_transformed(model2.num_vertices);
+    const Vec3f* model2_vertices_ = model2.vertices.get();
     for (unsigned int i = 0; i < model2.num_vertices; ++i) {
-      const Vec3f& p = model2.vertices[i];
+      const Vec3f& p = model2_vertices_[i];
       Vec3f new_v = tf2.transform(p);
       vertices_transformed[i] = new_v;
     }
@@ -753,7 +760,7 @@ bool initialize(ShapeMeshDistanceTraversalNode<S, BV>& node, const S& model1,
   node.tf2 = tf2;
   node.nsolver = nsolver;
 
-  node.vertices = model2.vertices;
+  node.vertices = model2.vertices.get();
   node.tri_indices = model2.tri_indices;
 
   computeBV(model1, tf1, node.model1_bv);
@@ -785,7 +792,7 @@ static inline bool setupMeshShapeDistanceOrientedNode(
 
   computeBV(model2, tf2, node.model2_bv);
 
-  node.vertices = model1.vertices;
+  node.vertices = model1.vertices.get();
   node.tri_indices = model1.tri_indices;
 
   return true;
@@ -852,7 +859,7 @@ static inline bool setupShapeMeshDistanceOrientedNode(
 
   computeBV(model1, tf1, node.model1_bv);
 
-  node.vertices = model2.vertices;
+  node.vertices = model2.vertices.get();
   node.tri_indices = model2.tri_indices;
   node.R = tf2.getRotation();
   node.T = tf2.getTranslation();

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -56,7 +56,8 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     const Eigen::Map<const AsTriangleMatrix> tri_indices_map(
-        reinterpret_cast<const Triangle::index_type *>(bvh_model.tri_indices.get()),
+        reinterpret_cast<const Triangle::index_type *>(
+            bvh_model.tri_indices.get()),
         3, bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   }
@@ -124,8 +125,8 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     Eigen::Map<AsTriangleMatrix> tri_indices_map(
-        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices.get()), 3,
-        bvh_model.num_tris);
+        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices.get()),
+        3, bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   } else
     bvh_model.tri_indices.reset();
@@ -141,7 +142,8 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
   if (has_prev_vertices) {
     if (num_vertices != bvh_model.num_vertices) {
       bvh_model.prev_vertices.reset();
-      if (num_vertices > 0) bvh_model.prev_vertices.reset(new Vec3f[num_vertices]);
+      if (num_vertices > 0)
+        bvh_model.prev_vertices.reset(new Vec3f[num_vertices]);
     }
     if (num_vertices > 0) {
       typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> AsVertixMatrix;

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -56,7 +56,7 @@ void save(Archive &ar, const hpp::fcl::BVHModelBase &bvh_model,
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     const Eigen::Map<const AsTriangleMatrix> tri_indices_map(
-        reinterpret_cast<const Triangle::index_type *>(bvh_model.tri_indices),
+        reinterpret_cast<const Triangle::index_type *>(bvh_model.tri_indices.get()),
         3, bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   }
@@ -116,20 +116,19 @@ void load(Archive &ar, hpp::fcl::BVHModelBase &bvh_model,
   ar >> make_nvp("num_tris", num_tris);
 
   if (num_tris != bvh_model.num_tris) {
-    delete[] bvh_model.tri_indices;
-    bvh_model.tri_indices = NULL;
+    bvh_model.tri_indices.reset();
     bvh_model.num_tris = num_tris;
-    if (num_tris > 0) bvh_model.tri_indices = new Triangle[num_tris];
+    if (num_tris > 0) bvh_model.tri_indices.reset(new Triangle[num_tris]);
   }
   if (num_tris > 0) {
     typedef Eigen::Matrix<Triangle::index_type, 3, Eigen::Dynamic>
         AsTriangleMatrix;
     Eigen::Map<AsTriangleMatrix> tri_indices_map(
-        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices), 3,
+        reinterpret_cast<Triangle::index_type *>(bvh_model.tri_indices.get()), 3,
         bvh_model.num_tris);
     ar &make_nvp("tri_indices", tri_indices_map);
   } else
-    bvh_model.tri_indices = NULL;
+    bvh_model.tri_indices.reset();
 
   ar >> make_nvp("build_state", bvh_model.build_state);
 

--- a/include/hpp/fcl/serialization/BVH_model.h
+++ b/include/hpp/fcl/serialization/BVH_model.h
@@ -234,7 +234,7 @@ void save(Archive &ar, const hpp::fcl::BVHModel<BV> &bvh_model_,
     ar &make_nvp(
         "bvs",
         make_array(
-            reinterpret_cast<const char *>(bvh_model.bvs),
+            reinterpret_cast<const char *>(bvh_model.bvs.get()),
             sizeof(Node) *
                 (std::size_t)bvh_model.num_bvs));  // Assuming BVs are POD.
   } else {
@@ -280,14 +280,14 @@ void load(Archive &ar, hpp::fcl::BVHModel<BV> &bvh_model_,
     ar >> make_nvp("num_bvs", num_bvs);
 
     if (num_bvs != bvh_model.num_bvs) {
-      delete[] bvh_model.bvs;
-      bvh_model.bvs = NULL;
+      bvh_model.bvs.reset();
       bvh_model.num_bvs = num_bvs;
-      if (num_bvs > 0) bvh_model.bvs = new BVNode<BV>[num_bvs];
+      if (num_bvs > 0) bvh_model.bvs.reset(new BVNode<BV>[num_bvs]);
     }
     if (num_bvs > 0) {
-      ar >> make_nvp("bvs", make_array(reinterpret_cast<char *>(bvh_model.bvs),
-                                       sizeof(Node) * (std::size_t)num_bvs));
+      ar >> make_nvp("bvs",
+                     make_array(reinterpret_cast<char *>(bvh_model.bvs.get()),
+                                sizeof(Node) * (std::size_t)num_bvs));
     } else
       bvh_model.bvs = NULL;
   }

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -81,12 +81,11 @@ void serialize(Archive &ar, hpp::fcl::Convex<PolygonT> &convex_,
 
   if (Archive::is_loading::value) {
     if (num_polygons_previous != convex.num_polygons) {
-      delete[] convex.polygons;
-      convex.polygons = new PolygonT[convex.num_polygons];
+      convex.polygons.reset(new PolygonT[convex.num_polygons]);
     }
   }
 
-  ar &make_array<PolygonT>(convex.polygons, convex.num_polygons);
+  ar &make_array<PolygonT>(convex.polygons.get(), convex.num_polygons);
 
   if (Archive::is_loading::value) convex.fillNeighbors();
 }

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -19,7 +19,6 @@ namespace serialization {
 namespace internal {
 struct ConvexBaseAccessor : hpp::fcl::ConvexBase {
   typedef hpp::fcl::ConvexBase Base;
-  using Base::own_storage_;
 };
 
 }  // namespace internal
@@ -29,19 +28,14 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
                const unsigned int /*version*/) {
   using namespace hpp::fcl;
 
-  typedef internal::ConvexBaseAccessor Accessor;
-  Accessor &accessor = reinterpret_cast<Accessor &>(convex_base);
-
   ar &make_nvp("base", boost::serialization::base_object<hpp::fcl::ShapeBase>(
                            convex_base));
   const unsigned int num_points_previous = convex_base.num_points;
   ar &make_nvp("num_points", convex_base.num_points);
 
   if (Archive::is_loading::value) {
-    if (num_points_previous != convex_base.num_points ||
-        !accessor.own_storage_) {
+    if (num_points_previous != convex_base.num_points) {
       convex_base.points.reset(new Vec3f[convex_base.num_points]);
-      accessor.own_storage_ = true;
     }
   }
 

--- a/include/hpp/fcl/serialization/convex.h
+++ b/include/hpp/fcl/serialization/convex.h
@@ -40,8 +40,7 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
   if (Archive::is_loading::value) {
     if (num_points_previous != convex_base.num_points ||
         !accessor.own_storage_) {
-      delete[] convex_base.points;
-      convex_base.points = new hpp::fcl::Vec3f[convex_base.num_points];
+      convex_base.points.reset(new Vec3f[convex_base.num_points]);
       accessor.own_storage_ = true;
     }
   }
@@ -49,7 +48,7 @@ void serialize(Archive &ar, hpp::fcl::ConvexBase &convex_base,
   {
     typedef Eigen::Matrix<FCL_REAL, 3, Eigen::Dynamic> MatrixPoints;
     Eigen::Map<MatrixPoints> points_map(
-        reinterpret_cast<double *>(convex_base.points), 3,
+        reinterpret_cast<double *>(convex_base.points.get()), 3,
         convex_base.num_points);
     ar &make_nvp("points", points_map);
   }

--- a/include/hpp/fcl/shape/convex.h
+++ b/include/hpp/fcl/shape/convex.h
@@ -61,7 +61,7 @@ class Convex : public ConvexBase {
   /// \param polygons_ \copydoc Convex::polygons
   /// \param num_polygons_ the number of polygons.
   /// \note num_polygons_ is not the allocated size of polygons_.
-  Convex(bool ownStorage, std::shared_ptr<Vec3f> points_, unsigned int num_points_,
+  Convex(std::shared_ptr<Vec3f> points_, unsigned int num_points_,
          std::shared_ptr<PolygonT> polygons_, unsigned int num_polygons_);
 
   /// @brief Copy constructor
@@ -94,7 +94,7 @@ class Convex : public ConvexBase {
   /// \param num_polygons the number of polygons.
   /// \note num_polygons is not the allocated size of polygons.
   ///
-  void set(bool ownStorage, std::shared_ptr<Vec3f> points, unsigned int num_points,
+  void set(std::shared_ptr<Vec3f> points, unsigned int num_points,
            std::shared_ptr<PolygonT> polygons, unsigned int num_polygons);
 
   ///  @brief Clone (deep copy).

--- a/include/hpp/fcl/shape/convex.h
+++ b/include/hpp/fcl/shape/convex.h
@@ -50,7 +50,7 @@ template <typename PolygonT>
 class Convex : public ConvexBase {
  public:
   /// @brief Construct an uninitialized convex object
-  Convex() : ConvexBase(), polygons(NULL), num_polygons(0) {}
+  Convex() : ConvexBase(), num_polygons(0) {}
 
   /// @brief Constructing a convex, providing normal and offset of each polytype
   /// surface, and the points and shape topology information \param ownStorage
@@ -62,7 +62,7 @@ class Convex : public ConvexBase {
   /// \param num_polygons_ the number of polygons.
   /// \note num_polygons_ is not the allocated size of polygons_.
   Convex(bool ownStorage, std::shared_ptr<Vec3f> points_, unsigned int num_points_,
-         PolygonT* polygons_, unsigned int num_polygons_);
+         std::shared_ptr<PolygonT> polygons_, unsigned int num_polygons_);
 
   /// @brief Copy constructor
   /// Only the list of neighbors is copied.
@@ -73,7 +73,7 @@ class Convex : public ConvexBase {
   /// @brief An array of PolygonT object.
   /// PolygonT should contains a list of vertices for each polygon,
   /// in counter clockwise order.
-  PolygonT* polygons;
+  std::shared_ptr<PolygonT> polygons;
   unsigned int num_polygons;
 
   /// based on http://number-none.com/blow/inertia/bb_inertia.doc
@@ -95,7 +95,7 @@ class Convex : public ConvexBase {
   /// \note num_polygons is not the allocated size of polygons.
   ///
   void set(bool ownStorage, std::shared_ptr<Vec3f> points, unsigned int num_points,
-           PolygonT* polygons, unsigned int num_polygons);
+           std::shared_ptr<PolygonT> polygons, unsigned int num_polygons);
 
   ///  @brief Clone (deep copy).
   virtual Convex<PolygonT>* clone() const;

--- a/include/hpp/fcl/shape/convex.h
+++ b/include/hpp/fcl/shape/convex.h
@@ -61,7 +61,7 @@ class Convex : public ConvexBase {
   /// \param polygons_ \copydoc Convex::polygons
   /// \param num_polygons_ the number of polygons.
   /// \note num_polygons_ is not the allocated size of polygons_.
-  Convex(bool ownStorage, Vec3f* points_, unsigned int num_points_,
+  Convex(bool ownStorage, std::shared_ptr<Vec3f> points_, unsigned int num_points_,
          PolygonT* polygons_, unsigned int num_polygons_);
 
   /// @brief Copy constructor
@@ -94,7 +94,7 @@ class Convex : public ConvexBase {
   /// \param num_polygons the number of polygons.
   /// \note num_polygons is not the allocated size of polygons.
   ///
-  void set(bool ownStorage, Vec3f* points, unsigned int num_points,
+  void set(bool ownStorage, std::shared_ptr<Vec3f> points, unsigned int num_points,
            PolygonT* polygons, unsigned int num_polygons);
 
   ///  @brief Clone (deep copy).

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -44,11 +44,11 @@ namespace hpp {
 namespace fcl {
 
 template <typename PolygonT>
-Convex<PolygonT>::Convex(bool own_storage, std::shared_ptr<Vec3f> points_,
+Convex<PolygonT>::Convex(std::shared_ptr<Vec3f> points_,
                          unsigned int num_points_, std::shared_ptr<PolygonT> polygons_,
                          unsigned int num_polygons_)
     : ConvexBase(), polygons(polygons_), num_polygons(num_polygons_) {
-  initialize(own_storage, points_, num_points_);
+  initialize(points_, num_points_);
   fillNeighbors();
 }
 
@@ -68,10 +68,10 @@ Convex<PolygonT>::~Convex() {
 }
 
 template <typename PolygonT>
-void Convex<PolygonT>::set(bool own_storage, std::shared_ptr<Vec3f> points_,
+void Convex<PolygonT>::set(std::shared_ptr<Vec3f> points_,
                            unsigned int num_points_, std::shared_ptr<PolygonT> polygons_,
                            unsigned int num_polygons_) {
-  ConvexBase::set(own_storage, points_, num_points_);
+  ConvexBase::set(points_, num_points_);
 
   num_polygons = num_polygons_;
   polygons = polygons_;
@@ -87,7 +87,7 @@ Convex<PolygonT>* Convex<PolygonT>::clone() const {
   std::shared_ptr<PolygonT> cloned_polygons(new PolygonT[num_polygons]);
   std::copy(polygons.get(), polygons.get() + num_polygons, cloned_polygons.get());
 
-  Convex* copy_ptr = new Convex(true, cloned_points, num_points,
+  Convex* copy_ptr = new Convex(cloned_points, num_points,
                                 cloned_polygons, num_polygons);
 
   copy_ptr->ShapeBase::operator=(*this);

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -81,17 +81,7 @@ void Convex<PolygonT>::set(std::shared_ptr<Vec3f> points_,
 
 template <typename PolygonT>
 Convex<PolygonT>* Convex<PolygonT>::clone() const {
-  std::shared_ptr<Vec3f> cloned_points(new Vec3f[num_points]);
-  std::copy(points.get(), points.get() + num_points, cloned_points.get());
-
-  std::shared_ptr<PolygonT> cloned_polygons(new PolygonT[num_polygons]);
-  std::copy(polygons.get(), polygons.get() + num_polygons, cloned_polygons.get());
-
-  Convex* copy_ptr = new Convex(cloned_points, num_points,
-                                cloned_polygons, num_polygons);
-
-  copy_ptr->ShapeBase::operator=(*this);
-  return copy_ptr;
+  return new Convex(*this);
 }
 
 template <typename PolygonT>

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -45,7 +45,8 @@ namespace fcl {
 
 template <typename PolygonT>
 Convex<PolygonT>::Convex(std::shared_ptr<Vec3f> points_,
-                         unsigned int num_points_, std::shared_ptr<PolygonT> polygons_,
+                         unsigned int num_points_,
+                         std::shared_ptr<PolygonT> polygons_,
                          unsigned int num_polygons_)
     : ConvexBase(), polygons(polygons_), num_polygons(num_polygons_) {
   initialize(points_, num_points_);
@@ -54,22 +55,22 @@ Convex<PolygonT>::Convex(std::shared_ptr<Vec3f> points_,
 
 template <typename PolygonT>
 Convex<PolygonT>::Convex(const Convex<PolygonT>& other)
-    : ConvexBase(other),
-      num_polygons(other.num_polygons) {
+    : ConvexBase(other), num_polygons(other.num_polygons) {
   if (other.polygons.get()) {
     polygons.reset(new PolygonT[num_polygons]);
-    std::copy(other.polygons.get(), other.polygons.get() + num_polygons, polygons.get());
-  } else 
+    std::copy(other.polygons.get(), other.polygons.get() + num_polygons,
+              polygons.get());
+  } else
     polygons.reset();
 }
 
 template <typename PolygonT>
-Convex<PolygonT>::~Convex() {
-}
+Convex<PolygonT>::~Convex() {}
 
 template <typename PolygonT>
 void Convex<PolygonT>::set(std::shared_ptr<Vec3f> points_,
-                           unsigned int num_points_, std::shared_ptr<PolygonT> polygons_,
+                           unsigned int num_points_,
+                           std::shared_ptr<PolygonT> polygons_,
                            unsigned int num_polygons_) {
   ConvexBase::set(points_, num_points_);
 

--- a/include/hpp/fcl/shape/details/convex.hxx
+++ b/include/hpp/fcl/shape/details/convex.hxx
@@ -206,8 +206,7 @@ FCL_REAL Convex<PolygonT>::computeVolume() const {
 
 template <typename PolygonT>
 void Convex<PolygonT>::fillNeighbors() {
-  if (neighbors) delete[] neighbors;
-  neighbors = new Neighbors[num_points];
+  neighbors.reset(new Neighbors[num_points]);
 
   typedef typename PolygonT::size_type size_type;
   typedef typename PolygonT::index_type index_type;
@@ -236,12 +235,12 @@ void Convex<PolygonT>::fillNeighbors() {
     }
   }
 
-  if (nneighbors_) delete[] nneighbors_;
-  nneighbors_ = new unsigned int[c_nneighbors];
+  nneighbors_.reset(new unsigned int[c_nneighbors]);
 
-  unsigned int* p_nneighbors = nneighbors_;
+  unsigned int* p_nneighbors = nneighbors_.get();
+  Neighbors* neighbors_ = neighbors.get();
   for (unsigned int i = 0; i < num_points; ++i) {
-    Neighbors& n = neighbors[i];
+    Neighbors& n = neighbors_[i];
     if (nneighbors[i].size() >= (std::numeric_limits<unsigned char>::max)())
       HPP_FCL_THROW_PRETTY("Too many neighbors.", std::logic_error);
     n.count_ = (unsigned char)nneighbors[i].size();
@@ -249,7 +248,7 @@ void Convex<PolygonT>::fillNeighbors() {
     p_nneighbors =
         std::copy(nneighbors[i].begin(), nneighbors[i].end(), p_nneighbors);
   }
-  assert(p_nneighbors == nneighbors_ + c_nneighbors);
+  assert(p_nneighbors == nneighbors_.get() + c_nneighbors);
 }
 
 }  // namespace fcl

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -614,7 +614,6 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
     copy.points.reset(new Vec3f[num_points]);
     std::copy(points.get(), points.get() + num_points, copy.points.get());
 
-    copy.own_storage_ = true;
     copy.ShapeBase::operator=(*this);
 
     return copy_ptr;
@@ -671,8 +670,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// Initialization is done with ConvexBase::initialize.
   ConvexBase()
       : ShapeBase(),
-        num_points(0),
-        own_storage_(false) {}
+        num_points(0) {}
 
   /// @brief Initialize the points of the convex shape
   /// This also initializes the ConvexBase::center.
@@ -680,22 +678,20 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
-  void initialize(bool ownStorage, std::shared_ptr<Vec3f> points_, unsigned int num_points_);
+  void initialize(std::shared_ptr<Vec3f> points_, unsigned int num_points_);
 
   /// @brief Set the points of the convex shape.
   ///
   /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
-  void set(bool ownStorage, std::shared_ptr<Vec3f> points_, unsigned int num_points_);
+  void set(std::shared_ptr<Vec3f> points_, unsigned int num_points_);
 
   /// @brief Copy constructor
   /// Only the list of neighbors is copied.
   ConvexBase(const ConvexBase& other);
 
   std::shared_ptr<unsigned int> nneighbors_;
-
-  bool own_storage_;
 
  private:
   void computeCenter();

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -603,20 +603,11 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
 
   virtual ~ConvexBase();
 
-  ///  @brief Clone (deep copy).
-  /// TODO(louis): to be consistent with BVHModel, clone and copy constructor
-  /// should have the same behavior and duplicate the data.
-  /// So we need to copy neighbors here.
+  /// @brief Clone (deep copy).
+  /// This method is consistent with BVHModel `clone` method.
+  /// The copy constructor is called, which duplicates the data.
   virtual ConvexBase* clone() const {
-    ConvexBase* copy_ptr = new ConvexBase(*this);
-    ConvexBase& copy = *copy_ptr;
-
-    copy.points.reset(new Vec3f[num_points]);
-    std::copy(points.get(), points.get() + num_points, copy.points.get());
-
-    copy.ShapeBase::operator=(*this);
-
-    return copy_ptr;
+    return new ConvexBase(*this);
   }
 
   /// @brief Compute AABB

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -606,9 +606,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// @brief Clone (deep copy).
   /// This method is consistent with BVHModel `clone` method.
   /// The copy constructor is called, which duplicates the data.
-  virtual ConvexBase* clone() const {
-    return new ConvexBase(*this);
-  }
+  virtual ConvexBase* clone() const { return new ConvexBase(*this); }
 
   /// @brief Compute AABB
   void computeLocalAABB();
@@ -659,9 +657,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
  protected:
   /// @brief Construct an uninitialized convex object
   /// Initialization is done with ConvexBase::initialize.
-  ConvexBase()
-      : ShapeBase(),
-        num_points(0) {}
+  ConvexBase() : ShapeBase(), num_points(0) {}
 
   /// @brief Initialize the points of the convex shape
   /// This also initializes the ConvexBase::center.

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -656,10 +656,11 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
 
     bool operator!=(const Neighbors& other) const { return !(*this == other); }
   };
+
   /// Neighbors of each vertex.
   /// It is an array of size num_points. For each vertex, it contains the number
   /// of neighbors and a list of indices to them.
-  Neighbors* neighbors;
+  std::shared_ptr<Neighbors> neighbors;
 
   /// @brief center of the convex polytope, this is used for collision: center
   /// is guaranteed in the internal of the polytope (as it is convex)
@@ -671,8 +672,6 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   ConvexBase()
       : ShapeBase(),
         num_points(0),
-        neighbors(NULL),
-        nneighbors_(NULL),
         own_storage_(false) {}
 
   /// @brief Initialize the points of the convex shape
@@ -694,7 +693,7 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   /// Only the list of neighbors is copied.
   ConvexBase(const ConvexBase& other);
 
-  unsigned int* nneighbors_;
+  std::shared_ptr<unsigned int> nneighbors_;
 
   bool own_storage_;
 
@@ -715,8 +714,10 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
       if (points_[i] != (other_points_)[i]) return false;
     }
 
+    const Neighbors* neighbors_ = neighbors.get();
+    const Neighbors* other_neighbors_ = other.neighbors.get();
     for (unsigned int i = 0; i < num_points; ++i) {
-      if (neighbors[i] != other.neighbors[i]) return false;
+      if (neighbors_[i] != other_neighbors_[i]) return false;
     }
 
     return center == other.center;

--- a/include/hpp/fcl/shape/geometric_shapes.h
+++ b/include/hpp/fcl/shape/geometric_shapes.h
@@ -593,13 +593,14 @@ class HPP_FCL_DLLAPI ConvexBase : public ShapeBase {
   ///          Qhull.
   /// \note hpp-fcl must have been compiled with option \c HPP_FCL_HAS_QHULL set
   ///       to \c ON.
-  static ConvexBase* convexHull(const std::shared_ptr<Vec3f> points, unsigned int num_points,
-                                bool keepTriangles,
+  static ConvexBase* convexHull(const std::shared_ptr<const Vec3f> points,
+                                unsigned int num_points, bool keepTriangles,
                                 const char* qhullCommand = NULL);
 
-  static ConvexBase* _convexHull(const Vec3f* points, unsigned int num_points,
-                                bool keepTriangles,
-                                const char* qhullCommand = NULL);
+  // TODO(louis): put this method in private sometime in the future.
+  HPP_FCL_DEPRECATED static ConvexBase* convexHull(
+      const Vec3f* points, unsigned int num_points, bool keepTriangles,
+      const char* qhullCommand = NULL);
 
   virtual ~ConvexBase();
 

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -191,7 +191,7 @@ struct ConvexWrapper {
   static PolygonT polygons(const Convex_t& convex, unsigned int i) {
     if (i >= convex.num_polygons)
       throw std::out_of_range("index is out of range");
-    return convex.polygons[i];
+    return convex.polygons.get()[i];
   }
 
   static shared_ptr<Convex_t> constructor(const Vec3fs& _points,
@@ -199,8 +199,10 @@ struct ConvexWrapper {
     std::shared_ptr<Vec3f> points(new Vec3f[_points.size()]);
     Vec3f* points_ = points.get();
     for (std::size_t i = 0; i < _points.size(); ++i) points_[i] = _points[i];
-    Triangle* tris = new Triangle[_tris.size()];
-    for (std::size_t i = 0; i < _tris.size(); ++i) tris[i] = _tris[i];
+
+    std::shared_ptr<Triangle> tris(new Triangle[_tris.size()]);
+    Triangle* tris_ = tris.get();
+    for (std::size_t i = 0; i < _tris.size(); ++i) tris_[i] = _tris[i];
     return shared_ptr<Convex_t>(new Convex_t(true, points,
                                              (unsigned int)_points.size(), tris,
                                              (unsigned int)_tris.size()));

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -92,7 +92,7 @@ struct BVHModelBaseWrapper {
 
   static Triangle tri_indices(const BVHModelBase& bvh, unsigned int i) {
     if (i >= bvh.num_tris) throw std::out_of_range("index is out of range");
-    return bvh.tri_indices[i];
+    return bvh.tri_indices.get()[i];
   }
 };
 

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -172,8 +172,9 @@ struct ConvexBaseWrapper {
     if (i >= convex.num_points)
       throw std::out_of_range("index is out of range");
     list n;
-    for (unsigned char j = 0; j < convex.neighbors[i].count(); ++j)
-      n.append(convex.neighbors[i][j]);
+    const ConvexBase::Neighbors* neighbors_ = convex.neighbors.get();
+    for (unsigned char j = 0; j < neighbors_[i].count(); ++j)
+      n.append(neighbors_[i][j]);
     return n;
   }
 

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -181,8 +181,8 @@ struct ConvexBaseWrapper {
 
   static ConvexBase* convexHull(const Vec3fs& points, bool keepTri,
                                 const char* qhullCommand) {
-    return ConvexBase::_convexHull(points.data(), (unsigned int)points.size(),
-                                   keepTri, qhullCommand);
+    return ConvexBase::convexHull(points.data(), (unsigned int)points.size(),
+                                  keepTri, qhullCommand);
   }
 };
 
@@ -290,7 +290,7 @@ void exposeShapes() {
       //                   "Points of the convex.")
       .def("neighbors", &ConvexBaseWrapper::neighbors)
       .def("convexHull", &ConvexBaseWrapper::convexHull,
-           doxygen::member_func_doc(&ConvexBase::_convexHull),
+           // doxygen::member_func_doc(&ConvexBase::convexHull),
            return_value_policy<manage_new_object>())
       .staticmethod("convexHull")
       .def("clone", &ConvexBase::clone,

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -161,11 +161,11 @@ struct ConvexBaseWrapper {
   static Vec3f& point(const ConvexBase& convex, unsigned int i) {
     if (i >= convex.num_points)
       throw std::out_of_range("index is out of range");
-    return convex.points[i];
+    return (convex.points.get())[i];
   }
 
   static RefRowMatrixX3 points(const ConvexBase& convex) {
-    return MapRowMatrixX3(convex.points[0].data(), convex.num_points, 3);
+    return MapRowMatrixX3((convex.points.get())[0].data(), convex.num_points, 3);
   }
 
   static list neighbors(const ConvexBase& convex, unsigned int i) {
@@ -179,7 +179,7 @@ struct ConvexBaseWrapper {
 
   static ConvexBase* convexHull(const Vec3fs& points, bool keepTri,
                                 const char* qhullCommand) {
-    return ConvexBase::convexHull(points.data(), (unsigned int)points.size(),
+    return ConvexBase::_convexHull(points.data(), (unsigned int)points.size(),
                                   keepTri, qhullCommand);
   }
 };
@@ -196,8 +196,9 @@ struct ConvexWrapper {
 
   static shared_ptr<Convex_t> constructor(const Vec3fs& _points,
                                           const Triangles& _tris) {
-    Vec3f* points = new Vec3f[_points.size()];
-    for (std::size_t i = 0; i < _points.size(); ++i) points[i] = _points[i];
+    std::shared_ptr<Vec3f> points(new Vec3f[_points.size()]);
+    Vec3f* points_ = points.get();
+    for (std::size_t i = 0; i < _points.size(); ++i) points_[i] = _points[i];
     Triangle* tris = new Triangle[_tris.size()];
     for (std::size_t i = 0; i < _tris.size(); ++i) tris[i] = _tris[i];
     return shared_ptr<Convex_t>(new Convex_t(true, points,
@@ -285,7 +286,7 @@ void exposeShapes() {
       //                   "Points of the convex.")
       .def("neighbors", &ConvexBaseWrapper::neighbors)
       .def("convexHull", &ConvexBaseWrapper::convexHull,
-           doxygen::member_func_doc(&ConvexBase::convexHull),
+           doxygen::member_func_doc(&ConvexBase::_convexHull),
            return_value_policy<manage_new_object>())
       .staticmethod("convexHull")
       .def("clone", &ConvexBase::clone,

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -83,11 +83,11 @@ struct BVHModelBaseWrapper {
 
   static Vec3f& vertex(BVHModelBase& bvh, unsigned int i) {
     if (i >= bvh.num_vertices) throw std::out_of_range("index is out of range");
-    return bvh.vertices[i];
+    return bvh.vertices.get()[i];
   }
 
   static RefRowMatrixX3 vertices(BVHModelBase& bvh) {
-    return MapRowMatrixX3(bvh.vertices[0].data(), bvh.num_vertices, 3);
+    return MapRowMatrixX3(bvh.vertices.get()[0].data(), bvh.num_vertices, 3);
   }
 
   static Triangle tri_indices(const BVHModelBase& bvh, unsigned int i) {

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -165,7 +165,8 @@ struct ConvexBaseWrapper {
   }
 
   static RefRowMatrixX3 points(const ConvexBase& convex) {
-    return MapRowMatrixX3((convex.points.get())[0].data(), convex.num_points, 3);
+    return MapRowMatrixX3((convex.points.get())[0].data(), convex.num_points,
+                          3);
   }
 
   static list neighbors(const ConvexBase& convex, unsigned int i) {
@@ -181,7 +182,7 @@ struct ConvexBaseWrapper {
   static ConvexBase* convexHull(const Vec3fs& points, bool keepTri,
                                 const char* qhullCommand) {
     return ConvexBase::_convexHull(points.data(), (unsigned int)points.size(),
-                                  keepTri, qhullCommand);
+                                   keepTri, qhullCommand);
   }
 };
 
@@ -205,8 +206,8 @@ struct ConvexWrapper {
     Triangle* tris_ = tris.get();
     for (std::size_t i = 0; i < _tris.size(); ++i) tris_[i] = _tris[i];
     return shared_ptr<Convex_t>(new Convex_t(points,
-                                            (unsigned int)_points.size(), tris,
-                                            (unsigned int)_tris.size()));
+                                             (unsigned int)_points.size(), tris,
+                                             (unsigned int)_tris.size()));
   }
 };
 

--- a/python/collision-geometries.cc
+++ b/python/collision-geometries.cc
@@ -204,9 +204,9 @@ struct ConvexWrapper {
     std::shared_ptr<Triangle> tris(new Triangle[_tris.size()]);
     Triangle* tris_ = tris.get();
     for (std::size_t i = 0; i < _tris.size(); ++i) tris_[i] = _tris[i];
-    return shared_ptr<Convex_t>(new Convex_t(true, points,
-                                             (unsigned int)_points.size(), tris,
-                                             (unsigned int)_tris.size()));
+    return shared_ptr<Convex_t>(new Convex_t(points,
+                                            (unsigned int)_points.size(), tris,
+                                            (unsigned int)_tris.size()));
   }
 };
 

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -814,10 +814,8 @@ int BVHModel<BV>::memUsage(const bool msg) const {
 template <typename BV>
 int BVHModel<BV>::buildTree() {
   // set BVFitter
-  // TODO(louis): bv_fitter shared_ptr?
   bv_fitter->set(vertices.get(), tri_indices.get(), getModelType());
   // set SplitRule
-  // TODO(louis): bv_splitter shared_ptr?
   bv_splitter->set(vertices.get(), tri_indices.get(), getModelType());
 
   num_bvs = 1;
@@ -949,7 +947,6 @@ int BVHModel<BV>::recursiveRefitTree_bottomup(int bv_id) {
         v[1] = vertices.get()[primitive_id];
         fit(v, 2, bv);
       } else
-        // TODO(louis): does fit need shared_ptr?
         fit(vertices.get() + primitive_id, 1, bv);
 
       bvnode->bv = bv;

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -127,7 +127,7 @@ void BVHModelBase::buildConvexRepresentation(bool share_memory) {
       polygons.reset(new Triangle[num_tris]);
       std::copy(tri_indices.get(), tri_indices.get() + num_tris, polygons.get());
     }
-    convex.reset(new Convex<Triangle>(!share_memory, points, num_vertices,
+    convex.reset(new Convex<Triangle>(points, num_vertices,
                                       polygons, num_tris));
   }
 }

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -67,20 +67,22 @@ BVHModelBase::BVHModelBase(const BVHModelBase& other)
       num_vertices_allocated(other.num_vertices) {
   if (other.vertices.get()) {
     vertices.reset(new Vec3f[num_vertices]);
-    std::copy(other.vertices.get(), other.vertices.get() + num_vertices, vertices.get());
+    std::copy(other.vertices.get(), other.vertices.get() + num_vertices,
+              vertices.get());
   } else
     vertices.reset();
 
   if (other.tri_indices.get()) {
     tri_indices.reset(new Triangle[num_tris]);
-    std::copy(other.tri_indices.get(), other.tri_indices.get() + num_tris, tri_indices.get());
+    std::copy(other.tri_indices.get(), other.tri_indices.get() + num_tris,
+              tri_indices.get());
   } else
     tri_indices.reset();
 
   if (other.prev_vertices.get()) {
     prev_vertices.reset(new Vec3f[num_vertices]);
-    std::copy(other.prev_vertices.get(), other.prev_vertices.get() + num_vertices,
-              prev_vertices.get());
+    std::copy(other.prev_vertices.get(),
+              other.prev_vertices.get() + num_vertices, prev_vertices.get());
   } else
     prev_vertices.reset();
 }
@@ -125,10 +127,11 @@ void BVHModelBase::buildConvexRepresentation(bool share_memory) {
       std::copy(vertices.get(), vertices.get() + num_vertices, points.get());
 
       polygons.reset(new Triangle[num_tris]);
-      std::copy(tri_indices.get(), tri_indices.get() + num_tris, polygons.get());
+      std::copy(tri_indices.get(), tri_indices.get() + num_tris,
+                polygons.get());
     }
-    convex.reset(new Convex<Triangle>(points, num_vertices,
-                                      polygons, num_tris));
+    convex.reset(
+        new Convex<Triangle>(points, num_vertices, polygons, num_tris));
   }
 }
 
@@ -275,9 +278,10 @@ int BVHModelBase::addTriangles(const Matrixx3i& triangles) {
   Triangle* tri_indices_ = tri_indices.get();
   for (Eigen::DenseIndex i = 0; i < triangles.rows(); ++i) {
     const Matrixx3i::ConstRowXpr triangle = triangles.row(i);
-    tri_indices_[num_tris++].set(static_cast<Triangle::index_type>(triangle[0]),
-                                 static_cast<Triangle::index_type>(triangle[1]),
-                                 static_cast<Triangle::index_type>(triangle[2]));
+    tri_indices_[num_tris++].set(
+        static_cast<Triangle::index_type>(triangle[0]),
+        static_cast<Triangle::index_type>(triangle[1]),
+        static_cast<Triangle::index_type>(triangle[2]));
   }
 
   return BVH_OK;
@@ -460,7 +464,7 @@ int BVHModelBase::addSubModel(const std::vector<Vec3f>& ps,
   for (size_t i = 0; i < (size_t)num_tris_to_add; ++i) {
     const Triangle& t = ts[i];
     tri_indices_[num_tris].set(t[0] + (size_t)offset, t[1] + (size_t)offset,
-                              t[2] + (size_t)offset);
+                               t[2] + (size_t)offset);
     num_tris++;
   }
 
@@ -994,7 +998,8 @@ int BVHModel<BV>::recursiveRefitTree_bottomup(int bv_id) {
 
 template <typename BV>
 int BVHModel<BV>::refitTree_topdown() {
-  bv_fitter->set(vertices.get(), prev_vertices.get(), tri_indices.get(), getModelType());
+  bv_fitter->set(vertices.get(), prev_vertices.get(), tri_indices.get(),
+                 getModelType());
   for (unsigned int i = 0; i < num_bvs; ++i) {
     BV bv = bv_fitter->fit(primitive_indices + bvs[i].first_primitive,
                            bvs[i].num_primitives);

--- a/src/BVH/BVH_utility.cpp
+++ b/src/BVH/BVH_utility.cpp
@@ -62,6 +62,7 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   std::vector<bool> keep_vertex(model.num_vertices, false);
   std::vector<bool> keep_tri(model.num_tris, false);
   unsigned int ntri = 0;
+  const Vec3f* model_vertices_ = model.vertices.get();
   for (unsigned int i = 0; i < model.num_tris; ++i) {
     const Triangle& t = model.tri_indices[i];
 
@@ -70,14 +71,14 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
 
     if (!keep_this_tri) {
       for (unsigned int j = 0; j < 3; ++j) {
-        if (aabb.contain(q * model.vertices[t[j]])) {
+        if (aabb.contain(q * model_vertices_[t[j]])) {
           keep_this_tri = true;
           break;
         }
       }
-      const Vec3f& p0 = model.vertices[t[0]];
-      const Vec3f& p1 = model.vertices[t[1]];
-      const Vec3f& p2 = model.vertices[t[2]];
+      const Vec3f& p0 = model_vertices_[t[0]];
+      const Vec3f& p1 = model_vertices_[t[1]];
+      const Vec3f& p2 = model_vertices_[t[2]];
       Vec3f c1, c2, normal;
       FCL_REAL distance;
       if (!keep_this_tri &&
@@ -99,10 +100,11 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   new_model->beginModel(ntri, std::min(ntri * 3, model.num_vertices));
   std::vector<unsigned int> idxConversion(model.num_vertices);
   assert(new_model->num_vertices == 0);
+  Vec3f* new_model_vertices_ = new_model->vertices.get();
   for (unsigned int i = 0; i < keep_vertex.size(); ++i) {
     if (keep_vertex[i]) {
       idxConversion[i] = new_model->num_vertices;
-      new_model->vertices[new_model->num_vertices] = model.vertices[i];
+      new_model_vertices_[new_model->num_vertices] = model_vertices_[i];
       new_model->num_vertices++;
     }
   }

--- a/src/BVH/BVH_utility.cpp
+++ b/src/BVH/BVH_utility.cpp
@@ -63,8 +63,9 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
   std::vector<bool> keep_tri(model.num_tris, false);
   unsigned int ntri = 0;
   const Vec3f* model_vertices_ = model.vertices.get();
+  const Triangle* model_tri_indices_ = model.tri_indices.get();
   for (unsigned int i = 0; i < model.num_tris; ++i) {
-    const Triangle& t = model.tri_indices[i];
+    const Triangle& t = model_tri_indices_[i];
 
     bool keep_this_tri =
         keep_vertex[t[0]] || keep_vertex[t[1]] || keep_vertex[t[2]];
@@ -109,12 +110,13 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3f& pose,
     }
   }
   assert(new_model->num_tris == 0);
+  Triangle* new_model_tri_indices_ = new_model->tri_indices.get();
   for (unsigned int i = 0; i < keep_tri.size(); ++i) {
     if (keep_tri[i]) {
-      new_model->tri_indices[new_model->num_tris].set(
-          idxConversion[model.tri_indices[i][0]],
-          idxConversion[model.tri_indices[i][1]],
-          idxConversion[model.tri_indices[i][2]]);
+      new_model_tri_indices_[new_model->num_tris].set(
+          idxConversion[model_tri_indices_[i][0]],
+          idxConversion[model_tri_indices_[i][1]],
+          idxConversion[model_tri_indices_[i][2]]);
       new_model->num_tris++;
     }
   }

--- a/src/narrowphase/details.h
+++ b/src/narrowphase/details.h
@@ -1618,8 +1618,9 @@ inline bool convexHalfspaceIntersect(
   Vec3f v;
   FCL_REAL depth = (std::numeric_limits<FCL_REAL>::max)();
 
+  const Vec3f* points_ = s1.points.get();
   for (unsigned int i = 0; i < s1.num_points; ++i) {
-    Vec3f p = tf1.transform(s1.points[i]);
+    Vec3f p = tf1.transform(points_[i]);
 
     FCL_REAL d = new_s2.signedDistance(p);
     if (d < depth) {
@@ -2271,8 +2272,9 @@ inline bool convexPlaneIntersect(const ConvexBase& s1, const Transform3f& tf1,
   FCL_REAL d_min = (std::numeric_limits<FCL_REAL>::max)(),
            d_max = -(std::numeric_limits<FCL_REAL>::max)();
 
+  const Vec3f* points_ = s1.points.get();
   for (unsigned int i = 0; i < s1.num_points; ++i) {
-    Vec3f p = tf1.transform(s1.points[i]);
+    Vec3f p = tf1.transform(points_[i]);
 
     FCL_REAL d = new_s2.signedDistance(p);
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -174,7 +174,7 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
   assert(data != NULL);
 
   const Vec3f* pts = convex->points.get();
-  const ConvexBase::Neighbors* nn = convex->neighbors;
+  const ConvexBase::Neighbors* nn = convex->neighbors.get();
 
   if (hint < 0 || hint >= (int)convex->num_points) hint = 0;
   FCL_REAL maxdot = pts[hint].dot(dir);

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -173,7 +173,7 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
                         MinkowskiDiff::ShapeData* data) {
   assert(data != NULL);
 
-  const Vec3f* pts = convex->points;
+  const Vec3f* pts = convex->points.get();
   const ConvexBase::Neighbors* nn = convex->neighbors;
 
   if (hint < 0 || hint >= (int)convex->num_points) hint = 0;
@@ -212,7 +212,7 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
 void getShapeSupportLinear(const ConvexBase* convex, const Vec3f& dir,
                            Vec3f& support, int& hint,
                            MinkowskiDiff::ShapeData*) {
-  const Vec3f* pts = convex->points;
+  const Vec3f* pts = convex->points.get();
 
   hint = 0;
   FCL_REAL maxdot = pts[0].dot(dir);

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -13,7 +13,6 @@ using orgQhull::Qhull;
 using orgQhull::QhullFacet;
 using orgQhull::QhullPoint;
 using orgQhull::QhullRidgeSet;
-using orgQhull::QhullVertex;
 using orgQhull::QhullVertexList;
 using orgQhull::QhullVertexSet;
 #endif
@@ -166,7 +165,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
       }
     }
   }
-  assert(!keepTriangles || i_polygon == qh.facetCount());
+  assert(!keepTriangles || static_cast<int>(i_polygon) == qh.facetCount());
 
   // Fill the neighbor attribute of the returned object.
   convex->nneighbors_ = new unsigned int[c_nneighbors];

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -100,7 +100,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
   convex->initialize(true, vertices, static_cast<unsigned int>(nvertex));
 
   // Build the neighbors
-  convex->neighbors = new Neighbors[size_t(nvertex)];
+  convex->neighbors.reset(new Neighbors[size_t(nvertex)]);
   std::vector<std::set<index_type> > nneighbors(static_cast<size_t>(nvertex));
   if (keepTriangles) {
     convex_tri->num_polygons = static_cast<unsigned int>(qh.facetCount());
@@ -168,10 +168,11 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
   assert(!keepTriangles || static_cast<int>(i_polygon) == qh.facetCount());
 
   // Fill the neighbor attribute of the returned object.
-  convex->nneighbors_ = new unsigned int[c_nneighbors];
-  unsigned int* p_nneighbors = convex->nneighbors_;
+  convex->nneighbors_.reset(new unsigned int[c_nneighbors]);
+  unsigned int* p_nneighbors = convex->nneighbors_.get();
+  Neighbors* neighbors_ = convex->neighbors.get();
   for (size_t i = 0; i < static_cast<size_t>(nvertex); ++i) {
-    Neighbors& n = convex->neighbors[i];
+    Neighbors& n = neighbors_[i];
     if (nneighbors[i].size() >= (std::numeric_limits<unsigned char>::max)())
       throw std::logic_error("Too many neighbors.");
     n.count_ = (unsigned char)nneighbors[i].size();
@@ -179,7 +180,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
     p_nneighbors =
         std::copy(nneighbors[i].begin(), nneighbors[i].end(), p_nneighbors);
   }
-  assert(p_nneighbors == convex->nneighbors_ + c_nneighbors);
+  assert(p_nneighbors == convex->nneighbors_.get() + c_nneighbors);
   return convex;
 #else
   throw std::logic_error(

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -42,16 +42,16 @@ void reorderTriangle(const Convex<Triangle>* convex_tri, Triangle& tri) {
   }
 }
 
-ConvexBase* ConvexBase::convexHull(const std::shared_ptr<Vec3f> pts, unsigned int num_points,
-                                   bool keepTriangles,
+ConvexBase* ConvexBase::convexHull(const std::shared_ptr<const Vec3f> pts,
+                                   unsigned int num_points, bool keepTriangles,
                                    const char* qhullCommand) {
-  return ConvexBase::_convexHull(pts.get(), num_points, keepTriangles, qhullCommand);
+  return ConvexBase::convexHull(pts.get(), num_points, keepTriangles,
+                                qhullCommand);
 }
 
-ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
+ConvexBase* ConvexBase::convexHull(const Vec3f* pts, unsigned int num_points,
                                    bool keepTriangles,
-                                   const char* qhullCommand) 
-{
+                                   const char* qhullCommand) {
 #ifdef HPP_FCL_HAS_QHULL
   if (num_points <= 3) {
     throw std::invalid_argument(

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -104,7 +104,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
   std::vector<std::set<index_type> > nneighbors(static_cast<size_t>(nvertex));
   if (keepTriangles) {
     convex_tri->num_polygons = static_cast<unsigned int>(qh.facetCount());
-    convex_tri->polygons = new Triangle[convex_tri->num_polygons];
+    convex_tri->polygons.reset(new Triangle[convex_tri->num_polygons]);
     convex_tri->computeCenter();
   }
 
@@ -128,7 +128,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
               f_vertices[2].point().id())]));
       if (keepTriangles) {
         reorderTriangle(convex_tri, tri);
-        convex_tri->polygons[i_polygon++] = tri;
+        convex_tri->polygons.get()[i_polygon++] = tri;
       }
       for (size_t j = 0; j < n; ++j) {
         size_t i = (j == 0) ? n - 1 : j - 1;

--- a/src/shape/convex.cpp
+++ b/src/shape/convex.cpp
@@ -97,7 +97,7 @@ ConvexBase* ConvexBase::_convexHull(const Vec3f* pts, unsigned int num_points,
     convex = convex_tri = new Convex<Triangle>();
   else
     convex = new ConvexBase;
-  convex->initialize(true, vertices, static_cast<unsigned int>(nvertex));
+  convex->initialize(vertices, static_cast<unsigned int>(nvertex));
 
   // Build the neighbors
   convex->neighbors.reset(new Neighbors[size_t(nvertex)]);

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -59,8 +59,6 @@ ConvexBase::ConvexBase(const ConvexBase& other)
       num_points(other.num_points),
       center(other.center),
       own_storage_(other.own_storage_) {
-  if (neighbors) delete[] neighbors;
-  if (nneighbors_) delete[] nneighbors_;
 
   if (other.points.get()) {
     points.reset(new Vec3f[num_points]);
@@ -68,21 +66,26 @@ ConvexBase::ConvexBase(const ConvexBase& other)
   } else 
     points.reset();
 
-  neighbors = new Neighbors[num_points];
-  std::copy(other.neighbors, other.neighbors + num_points, neighbors);
+  if (other.neighbors.get()) {
+    neighbors.reset(new Neighbors[num_points]);
+    std::copy(other.neighbors.get(), other.neighbors.get() + num_points, neighbors.get());
+  } else 
+    neighbors.reset();
 
-  std::size_t c_nneighbors = 0;
-  for (std::size_t i = 0; i < num_points; ++i)
-    c_nneighbors += neighbors[i].count();
-  nneighbors_ = new unsigned int[c_nneighbors];
-  std::copy(other.nneighbors_, other.nneighbors_ + c_nneighbors, nneighbors_);
+  if (other.nneighbors_.get()) {
+    std::size_t c_nneighbors = 0;
+    const Neighbors* neighbors_ = neighbors.get();
+    for (std::size_t i = 0; i < num_points; ++i)
+      c_nneighbors += neighbors_[i].count();
+    nneighbors_.reset(new unsigned int[c_nneighbors]);
+    std::copy(other.nneighbors_.get(), other.nneighbors_.get() + c_nneighbors, nneighbors_.get());
+  } else
+    nneighbors_.reset();
 
   ShapeBase::operator=(*this);
 }
 
 ConvexBase::~ConvexBase() {
-  if (neighbors) delete[] neighbors;
-  if (nneighbors_) delete[] nneighbors_;
 }
 
 void ConvexBase::computeCenter() {

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -48,26 +48,24 @@ void ConvexBase::initialize(std::shared_ptr<Vec3f> points_,
   computeCenter();
 }
 
-void ConvexBase::set(std::shared_ptr<Vec3f> points_,
-                     unsigned int num_points_) {
+void ConvexBase::set(std::shared_ptr<Vec3f> points_, unsigned int num_points_) {
   initialize(points_, num_points_);
 }
 
 ConvexBase::ConvexBase(const ConvexBase& other)
-    : ShapeBase(other),
-      num_points(other.num_points),
-      center(other.center) {
-
+    : ShapeBase(other), num_points(other.num_points), center(other.center) {
   if (other.points.get()) {
     points.reset(new Vec3f[num_points]);
-    std::copy(other.points.get(), other.points.get() + num_points, points.get());
-  } else 
+    std::copy(other.points.get(), other.points.get() + num_points,
+              points.get());
+  } else
     points.reset();
 
   if (other.neighbors.get()) {
     neighbors.reset(new Neighbors[num_points]);
-    std::copy(other.neighbors.get(), other.neighbors.get() + num_points, neighbors.get());
-  } else 
+    std::copy(other.neighbors.get(), other.neighbors.get() + num_points,
+              neighbors.get());
+  } else
     neighbors.reset();
 
   if (other.nneighbors_.get()) {
@@ -76,15 +74,15 @@ ConvexBase::ConvexBase(const ConvexBase& other)
     for (std::size_t i = 0; i < num_points; ++i)
       c_nneighbors += neighbors_[i].count();
     nneighbors_.reset(new unsigned int[c_nneighbors]);
-    std::copy(other.nneighbors_.get(), other.nneighbors_.get() + c_nneighbors, nneighbors_.get());
+    std::copy(other.nneighbors_.get(), other.nneighbors_.get() + c_nneighbors,
+              nneighbors_.get());
   } else
     nneighbors_.reset();
 
   ShapeBase::operator=(*this);
 }
 
-ConvexBase::~ConvexBase() {
-}
+ConvexBase::~ConvexBase() {}
 
 void ConvexBase::computeCenter() {
   center.setZero();

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -41,24 +41,22 @@
 namespace hpp {
 namespace fcl {
 
-void ConvexBase::initialize(bool own_storage, std::shared_ptr<Vec3f> points_,
+void ConvexBase::initialize(std::shared_ptr<Vec3f> points_,
                             unsigned int num_points_) {
   points = points_;
   num_points = num_points_;
-  own_storage_ = own_storage;
   computeCenter();
 }
 
-void ConvexBase::set(bool own_storage_, std::shared_ptr<Vec3f> points_,
+void ConvexBase::set(std::shared_ptr<Vec3f> points_,
                      unsigned int num_points_) {
-  initialize(own_storage_, points_, num_points_);
+  initialize(points_, num_points_);
 }
 
 ConvexBase::ConvexBase(const ConvexBase& other)
     : ShapeBase(other),
       num_points(other.num_points),
-      center(other.center),
-      own_storage_(other.own_storage_) {
+      center(other.center) {
 
   if (other.points.get()) {
     points.reset(new Vec3f[num_points]);

--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -41,7 +41,7 @@
 namespace hpp {
 namespace fcl {
 
-void ConvexBase::initialize(bool own_storage, Vec3f* points_,
+void ConvexBase::initialize(bool own_storage, std::shared_ptr<Vec3f> points_,
                             unsigned int num_points_) {
   points = points_;
   num_points = num_points_;
@@ -49,9 +49,8 @@ void ConvexBase::initialize(bool own_storage, Vec3f* points_,
   computeCenter();
 }
 
-void ConvexBase::set(bool own_storage_, Vec3f* points_,
+void ConvexBase::set(bool own_storage_, std::shared_ptr<Vec3f> points_,
                      unsigned int num_points_) {
-  if (own_storage_ && points) delete[] points;
   initialize(own_storage_, points_, num_points_);
 }
 
@@ -62,13 +61,12 @@ ConvexBase::ConvexBase(const ConvexBase& other)
       own_storage_(other.own_storage_) {
   if (neighbors) delete[] neighbors;
   if (nneighbors_) delete[] nneighbors_;
-  if (own_storage_) {
-    if (own_storage_ && points) delete[] points;
 
-    points = new Vec3f[num_points];
-    std::copy(other.points, other.points + num_points, points);
-  } else
-    points = other.points;
+  if (other.points.get()) {
+    points.reset(new Vec3f[num_points]);
+    std::copy(other.points.get(), other.points.get() + num_points, points.get());
+  } else 
+    points.reset();
 
   neighbors = new Neighbors[num_points];
   std::copy(other.neighbors, other.neighbors + num_points, neighbors);
@@ -85,13 +83,13 @@ ConvexBase::ConvexBase(const ConvexBase& other)
 ConvexBase::~ConvexBase() {
   if (neighbors) delete[] neighbors;
   if (nneighbors_) delete[] nneighbors_;
-  if (own_storage_ && points) delete[] points;
 }
 
 void ConvexBase::computeCenter() {
   center.setZero();
+  const Vec3f* points_ = points.get();
   for (std::size_t i = 0; i < num_points; ++i)
-    center += points[i];  // TODO(jcarpent): vectorization
+    center += points_[i];  // TODO(jcarpent): vectorization
   center /= num_points;
 }
 

--- a/src/shape/geometric_shapes_utility.cpp
+++ b/src/shape/geometric_shapes_utility.cpp
@@ -226,8 +226,9 @@ std::vector<Vec3f> getBoundVertices(const Cylinder& cylinder,
 std::vector<Vec3f> getBoundVertices(const ConvexBase& convex,
                                     const Transform3f& tf) {
   std::vector<Vec3f> result(convex.num_points);
+  const Vec3f* points_ = convex.points.get();
   for (std::size_t i = 0; i < convex.num_points; ++i) {
-    result[i] = tf.transform(convex.points[i]);
+    result[i] = tf.transform(points_[i]);
   }
 
   return result;
@@ -354,8 +355,9 @@ void computeBV<AABB, ConvexBase>(const ConvexBase& s, const Transform3f& tf,
   const Vec3f& T = tf.getTranslation();
 
   AABB bv_;
+  const Vec3f* points_ = s.points.get();
   for (std::size_t i = 0; i < s.num_points; ++i) {
-    Vec3f new_p = R * s.points[i] + T;
+    Vec3f new_p = R * points_[i] + T;
     bv_ += new_p;
   }
 
@@ -492,7 +494,7 @@ void computeBV<OBB, ConvexBase>(const ConvexBase& s, const Transform3f& tf,
   const Matrix3f& R = tf.getRotation();
   const Vec3f& T = tf.getTranslation();
 
-  fit(s.points, s.num_points, bv);
+  fit(s.points.get(), s.num_points, bv);
 
   bv.axes.applyOnTheLeft(R);
 

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -80,39 +80,39 @@ BOOST_AUTO_TEST_CASE(convex) {
 
   // Check neighbors
   for (int i = 0; i < 8; ++i) {
-    BOOST_CHECK_EQUAL(box.neighbors[i].count(), 3);
+    BOOST_CHECK_EQUAL(box.neighbors.get()[i].count(), 3);
   }
-  BOOST_CHECK_EQUAL(box.neighbors[0][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors[0][1], 2);
-  BOOST_CHECK_EQUAL(box.neighbors[0][2], 4);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[0][0], 1);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[0][1], 2);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[0][2], 4);
 
-  BOOST_CHECK_EQUAL(box.neighbors[1][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors[1][1], 3);
-  BOOST_CHECK_EQUAL(box.neighbors[1][2], 5);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[1][0], 0);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[1][1], 3);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[1][2], 5);
 
-  BOOST_CHECK_EQUAL(box.neighbors[2][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors[2][1], 3);
-  BOOST_CHECK_EQUAL(box.neighbors[2][2], 6);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[2][0], 0);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[2][1], 3);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[2][2], 6);
 
-  BOOST_CHECK_EQUAL(box.neighbors[3][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors[3][1], 2);
-  BOOST_CHECK_EQUAL(box.neighbors[3][2], 7);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[3][0], 1);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[3][1], 2);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[3][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors[4][0], 0);
-  BOOST_CHECK_EQUAL(box.neighbors[4][1], 5);
-  BOOST_CHECK_EQUAL(box.neighbors[4][2], 6);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[4][0], 0);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[4][1], 5);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[4][2], 6);
 
-  BOOST_CHECK_EQUAL(box.neighbors[5][0], 1);
-  BOOST_CHECK_EQUAL(box.neighbors[5][1], 4);
-  BOOST_CHECK_EQUAL(box.neighbors[5][2], 7);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[5][0], 1);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[5][1], 4);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[5][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors[6][0], 2);
-  BOOST_CHECK_EQUAL(box.neighbors[6][1], 4);
-  BOOST_CHECK_EQUAL(box.neighbors[6][2], 7);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[6][0], 2);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[6][1], 4);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[6][2], 7);
 
-  BOOST_CHECK_EQUAL(box.neighbors[7][0], 3);
-  BOOST_CHECK_EQUAL(box.neighbors[7][1], 5);
-  BOOST_CHECK_EQUAL(box.neighbors[7][2], 6);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[7][0], 3);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[7][1], 5);
+  BOOST_CHECK_EQUAL(box.neighbors.get()[7][2], 6);
 }
 
 template <typename Sa, typename Sb>
@@ -231,9 +231,9 @@ BOOST_AUTO_TEST_CASE(convex_hull_quad) {
       points, 4, false, NULL);
 
   BOOST_REQUIRE_EQUAL(convexHull->num_points, 4);
-  BOOST_CHECK_EQUAL(convexHull->neighbors[0].count(), 3);
-  BOOST_CHECK_EQUAL(convexHull->neighbors[1].count(), 3);
-  BOOST_CHECK_EQUAL(convexHull->neighbors[2].count(), 3);
+  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[0].count(), 3);
+  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[1].count(), 3);
+  BOOST_CHECK_EQUAL(convexHull->neighbors.get()[2].count(), 3);
   delete convexHull;
 }
 
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
   const Vec3f* cvxhull_points = convexHull->points.get();
   for (int i = 0; i < 8; ++i) {
     BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
-    BOOST_CHECK_EQUAL(convexHull->neighbors[i].count(), 3);
+    BOOST_CHECK_EQUAL(convexHull->neighbors.get()[i].count(), 3);
   }
   delete convexHull;
 
@@ -271,8 +271,8 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
   cvxhull_points = convexHull->points.get();
   for (int i = 0; i < 8; ++i) {
     BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
-    BOOST_CHECK(convexHull->neighbors[i].count() >= 3);
-    BOOST_CHECK(convexHull->neighbors[i].count() <= 6);
+    BOOST_CHECK(convexHull->neighbors.get()[i].count() >= 3);
+    BOOST_CHECK(convexHull->neighbors.get()[i].count() <= 6);
   }
   delete convexHull;
 }

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -226,8 +226,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_quad) {
   points_[2] = Vec3f(1, 0, 0);
   points_[3] = Vec3f(0, 0, 1);
 
-  ConvexBase* convexHull = ConvexBase::convexHull(
-      points, 4, false, NULL);
+  ConvexBase* convexHull = ConvexBase::convexHull(points, 4, false, NULL);
 
   BOOST_REQUIRE_EQUAL(convexHull->num_points, 4);
   BOOST_CHECK_EQUAL(convexHull->neighbors.get()[0].count(), 3);
@@ -250,8 +249,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
   points_[8] = Vec3f(0, 0, 0);
   points_[9] = Vec3f(0, 0, 0.99);
 
-  ConvexBase* convexHull = ConvexBase::convexHull(
-      points, 9, false, NULL);
+  ConvexBase* convexHull = ConvexBase::convexHull(points, 9, false, NULL);
 
   BOOST_REQUIRE_EQUAL(8, convexHull->num_points);
   const Vec3f* cvxhull_points = convexHull->points.get();
@@ -261,8 +259,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
   }
   delete convexHull;
 
-  convexHull = ConvexBase::convexHull(points,
-                                      9, true, NULL);
+  convexHull = ConvexBase::convexHull(points, 9, true, NULL);
   Convex<Triangle>* convex_tri = dynamic_cast<Convex<Triangle>*>(convexHull);
   BOOST_CHECK(convex_tri != NULL);
 
@@ -290,7 +287,8 @@ BOOST_AUTO_TEST_CASE(convex_copy_constructor) {
   points_[8] = Vec3f(0, 0, 0);
   points_[9] = Vec3f(0, 0, 0.99);
 
-  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(ConvexBase::convexHull(points, 9, true, NULL));
+  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
+      ConvexBase::convexHull(points, 9, true, NULL));
   Convex<Triangle>* convexHullTriCopy = new Convex<Triangle>(*convexHullTri);
   BOOST_CHECK(*convexHullTri == *convexHullTriCopy);
 }
@@ -309,7 +307,8 @@ BOOST_AUTO_TEST_CASE(convex_clone) {
   points_[8] = Vec3f(0, 0, 0);
   points_[9] = Vec3f(0, 0, 0.99);
 
-  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(ConvexBase::convexHull(points, 9, true, NULL));
+  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
+      ConvexBase::convexHull(points, 9, true, NULL));
   Convex<Triangle>* convexHullTriCopy;
   convexHullTriCopy = convexHullTri->clone();
   BOOST_CHECK(*convexHullTri == *convexHullTriCopy);

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -46,15 +46,16 @@
 using namespace hpp::fcl;
 
 Convex<Quadrilateral> buildBox(FCL_REAL l, FCL_REAL w, FCL_REAL d) {
-  Vec3f* pts = new Vec3f[8];
-  pts[0] = Vec3f(l, w, d);
-  pts[1] = Vec3f(l, w, -d);
-  pts[2] = Vec3f(l, -w, d);
-  pts[3] = Vec3f(l, -w, -d);
-  pts[4] = Vec3f(-l, w, d);
-  pts[5] = Vec3f(-l, w, -d);
-  pts[6] = Vec3f(-l, -w, d);
-  pts[7] = Vec3f(-l, -w, -d);
+  std::shared_ptr<Vec3f> pts(new Vec3f[8]);
+  Vec3f* pts_ = pts.get();
+  pts_[0] = Vec3f(l, w, d);
+  pts_[1] = Vec3f(l, w, -d);
+  pts_[2] = Vec3f(l, -w, d);
+  pts_[3] = Vec3f(l, -w, -d);
+  pts_[4] = Vec3f(-l, w, d);
+  pts_[5] = Vec3f(-l, w, -d);
+  pts_[6] = Vec3f(-l, -w, d);
+  pts_[7] = Vec3f(-l, -w, -d);
 
   Quadrilateral* polygons = new Quadrilateral[6];
   polygons[0].set(0, 2, 3, 1);  // x+ side
@@ -201,32 +202,32 @@ BOOST_AUTO_TEST_CASE(compare_convex_box) {
 
 #ifdef HPP_FCL_HAS_QHULL
 BOOST_AUTO_TEST_CASE(convex_hull_throw) {
-  std::vector<Vec3f> points({
-      Vec3f(1, 1, 1),
-      Vec3f(0, 0, 0),
-      Vec3f(1, 0, 0),
-  });
+  std::shared_ptr<Vec3f> points(new Vec3f[3]);
+  Vec3f* points_ = points.get();
+  points_[0] = Vec3f(1, 1, 1);
+  points_[1] = Vec3f(0, 0, 0);
+  points_[2] = Vec3f(1, 0, 0);
 
-  BOOST_CHECK_THROW(ConvexBase::convexHull(points.data(), 0, false, NULL),
+  BOOST_CHECK_THROW(ConvexBase::convexHull(points, 0, false, NULL),
                     std::invalid_argument);
-  BOOST_CHECK_THROW(ConvexBase::convexHull(points.data(), 1, false, NULL),
+  BOOST_CHECK_THROW(ConvexBase::convexHull(points, 1, false, NULL),
                     std::invalid_argument);
-  BOOST_CHECK_THROW(ConvexBase::convexHull(points.data(), 2, false, NULL),
+  BOOST_CHECK_THROW(ConvexBase::convexHull(points, 2, false, NULL),
                     std::invalid_argument);
-  BOOST_CHECK_THROW(ConvexBase::convexHull(points.data(), 3, false, NULL),
+  BOOST_CHECK_THROW(ConvexBase::convexHull(points, 3, false, NULL),
                     std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(convex_hull_quad) {
-  std::vector<Vec3f> points({
-      Vec3f(1, 1, 1),
-      Vec3f(0, 0, 0),
-      Vec3f(1, 0, 0),
-      Vec3f(0, 0, 1),
-  });
+  std::shared_ptr<Vec3f> points(new Vec3f[4]);
+  Vec3f* points_ = points.get();
+  points_[0] = Vec3f(1, 1, 1);
+  points_[1] = Vec3f(0, 0, 0);
+  points_[2] = Vec3f(1, 0, 0);
+  points_[3] = Vec3f(0, 0, 1);
 
   ConvexBase* convexHull = ConvexBase::convexHull(
-      points.data(), (unsigned int)points.size(), false, NULL);
+      points, 4, false, NULL);
 
   BOOST_REQUIRE_EQUAL(convexHull->num_points, 4);
   BOOST_CHECK_EQUAL(convexHull->neighbors[0].count(), 3);
@@ -236,37 +237,39 @@ BOOST_AUTO_TEST_CASE(convex_hull_quad) {
 }
 
 BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
-  std::vector<Vec3f> points({
-      Vec3f(1, 1, 1),
-      Vec3f(1, 1, -1),
-      Vec3f(1, -1, 1),
-      Vec3f(1, -1, -1),
-      Vec3f(-1, 1, 1),
-      Vec3f(-1, 1, -1),
-      Vec3f(-1, -1, 1),
-      Vec3f(-1, -1, -1),
-      Vec3f(0, 0, 0),
-      Vec3f(0, 0, 0.99),
-  });
+  std::shared_ptr<Vec3f> points(new Vec3f[9]);
+  Vec3f* points_ = points.get();
+  points_[0] = Vec3f(1, 1, 1);
+  points_[1] = Vec3f(1, 1, -1);
+  points_[2] = Vec3f(1, -1, 1);
+  points_[3] = Vec3f(1, -1, -1);
+  points_[4] = Vec3f(-1, 1, 1);
+  points_[5] = Vec3f(-1, 1, -1);
+  points_[6] = Vec3f(-1, -1, 1);
+  points_[7] = Vec3f(-1, -1, -1);
+  points_[8] = Vec3f(0, 0, 0);
+  points_[9] = Vec3f(0, 0, 0.99);
 
   ConvexBase* convexHull = ConvexBase::convexHull(
-      points.data(), (unsigned int)points.size(), false, NULL);
+      points, 9, false, NULL);
 
   BOOST_REQUIRE_EQUAL(8, convexHull->num_points);
+  const Vec3f* cvxhull_points = convexHull->points.get();
   for (int i = 0; i < 8; ++i) {
-    BOOST_CHECK(convexHull->points[i].cwiseAbs() == Vec3f(1, 1, 1));
+    BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
     BOOST_CHECK_EQUAL(convexHull->neighbors[i].count(), 3);
   }
   delete convexHull;
 
-  convexHull = ConvexBase::convexHull(points.data(),
-                                      (unsigned int)points.size(), true, NULL);
+  convexHull = ConvexBase::convexHull(points,
+                                      9, true, NULL);
   Convex<Triangle>* convex_tri = dynamic_cast<Convex<Triangle>*>(convexHull);
   BOOST_CHECK(convex_tri != NULL);
 
   BOOST_REQUIRE_EQUAL(8, convexHull->num_points);
+  cvxhull_points = convexHull->points.get();
   for (int i = 0; i < 8; ++i) {
-    BOOST_CHECK(convexHull->points[i].cwiseAbs() == Vec3f(1, 1, 1));
+    BOOST_CHECK(cvxhull_points[i].cwiseAbs() == Vec3f(1, 1, 1));
     BOOST_CHECK(convexHull->neighbors[i].count() >= 3);
     BOOST_CHECK(convexHull->neighbors[i].count() <= 6);
   }

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -66,8 +66,7 @@ Convex<Quadrilateral> buildBox(FCL_REAL l, FCL_REAL w, FCL_REAL d) {
   polygons_[4].set(1, 3, 7, 5);  // z- side
   polygons_[5].set(0, 2, 6, 4);  // z+ side
 
-  return Convex<Quadrilateral>(true,
-                               pts,  // points
+  return Convex<Quadrilateral>(pts,  // points
                                8,    // num points
                                polygons,
                                6  // number of polygons

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -275,4 +275,44 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
   }
   delete convexHull;
 }
+
+BOOST_AUTO_TEST_CASE(convex_copy_constructor) {
+  std::shared_ptr<Vec3f> points(new Vec3f[9]);
+  Vec3f* points_ = points.get();
+  points_[0] = Vec3f(1, 1, 1);
+  points_[1] = Vec3f(1, 1, -1);
+  points_[2] = Vec3f(1, -1, 1);
+  points_[3] = Vec3f(1, -1, -1);
+  points_[4] = Vec3f(-1, 1, 1);
+  points_[5] = Vec3f(-1, 1, -1);
+  points_[6] = Vec3f(-1, -1, 1);
+  points_[7] = Vec3f(-1, -1, -1);
+  points_[8] = Vec3f(0, 0, 0);
+  points_[9] = Vec3f(0, 0, 0.99);
+
+  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(ConvexBase::convexHull(points, 9, true, NULL));
+  Convex<Triangle>* convexHullTriCopy = new Convex<Triangle>(*convexHullTri);
+  BOOST_CHECK(*convexHullTri == *convexHullTriCopy);
+}
+
+BOOST_AUTO_TEST_CASE(convex_clone) {
+  std::shared_ptr<Vec3f> points(new Vec3f[9]);
+  Vec3f* points_ = points.get();
+  points_[0] = Vec3f(1, 1, 1);
+  points_[1] = Vec3f(1, 1, -1);
+  points_[2] = Vec3f(1, -1, 1);
+  points_[3] = Vec3f(1, -1, -1);
+  points_[4] = Vec3f(-1, 1, 1);
+  points_[5] = Vec3f(-1, 1, -1);
+  points_[6] = Vec3f(-1, -1, 1);
+  points_[7] = Vec3f(-1, -1, -1);
+  points_[8] = Vec3f(0, 0, 0);
+  points_[9] = Vec3f(0, 0, 0.99);
+
+  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(ConvexBase::convexHull(points, 9, true, NULL));
+  Convex<Triangle>* convexHullTriCopy;
+  convexHullTriCopy = convexHullTri->clone();
+  BOOST_CHECK(*convexHullTri == *convexHullTriCopy);
+}
+
 #endif

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(convex_hull_quad) {
 }
 
 BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
-  std::shared_ptr<Vec3f> points(new Vec3f[9]);
+  std::shared_ptr<Vec3f> points(new Vec3f[10]);
   Vec3f* points_ = points.get();
   points_[0] = Vec3f(1, 1, 1);
   points_[1] = Vec3f(1, 1, -1);
@@ -285,7 +285,6 @@ BOOST_AUTO_TEST_CASE(convex_copy_constructor) {
   points_[6] = Vec3f(-1, -1, 1);
   points_[7] = Vec3f(-1, -1, -1);
   points_[8] = Vec3f(0, 0, 0);
-  points_[9] = Vec3f(0, 0, 0.99);
 
   Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
       ConvexBase::convexHull(points, 9, true, NULL));
@@ -305,7 +304,6 @@ BOOST_AUTO_TEST_CASE(convex_clone) {
   points_[6] = Vec3f(-1, -1, 1);
   points_[7] = Vec3f(-1, -1, -1);
   points_[8] = Vec3f(0, 0, 0);
-  points_[9] = Vec3f(0, 0, 0.99);
 
   Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
       ConvexBase::convexHull(points, 9, true, NULL));

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -57,13 +57,14 @@ Convex<Quadrilateral> buildBox(FCL_REAL l, FCL_REAL w, FCL_REAL d) {
   pts_[6] = Vec3f(-l, -w, d);
   pts_[7] = Vec3f(-l, -w, -d);
 
-  Quadrilateral* polygons = new Quadrilateral[6];
-  polygons[0].set(0, 2, 3, 1);  // x+ side
-  polygons[1].set(2, 6, 7, 3);  // y- side
-  polygons[2].set(4, 5, 7, 6);  // x- side
-  polygons[3].set(0, 1, 5, 4);  // y+ side
-  polygons[4].set(1, 3, 7, 5);  // z- side
-  polygons[5].set(0, 2, 6, 4);  // z+ side
+  std::shared_ptr<Quadrilateral> polygons(new Quadrilateral[6]);
+  Quadrilateral* polygons_ = polygons.get();
+  polygons_[0].set(0, 2, 3, 1);  // x+ side
+  polygons_[1].set(2, 6, 7, 3);  // y- side
+  polygons_[2].set(4, 5, 7, 6);  // x- side
+  polygons_[3].set(0, 1, 5, 4);  // y+ side
+  polygons_[4].set(1, 3, 7, 5);  // z- side
+  polygons_[5].set(0, 2, 6, 4);  // z+ side
 
   return Convex<Quadrilateral>(true,
                                pts,  // points

--- a/test/normal_and_nearest_points.cpp
+++ b/test/normal_and_nearest_points.cpp
@@ -231,10 +231,10 @@ BOOST_AUTO_TEST_CASE(test_normal_and_nearest_points_mesh_mesh) {
   FCL_REAL r = 0.5;
   Convex<Triangle> o1_ = constructPolytopeFromEllipsoid(Ellipsoid(r, r, r));
   shared_ptr<Convex<Triangle>> o1(new Convex<Triangle>(
-      false, o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
+      o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
   Convex<Triangle> o2_ = constructPolytopeFromEllipsoid(Ellipsoid(r, r, r));
   shared_ptr<Convex<Triangle>> o2(new Convex<Triangle>(
-      false, o2_.points, o2_.num_points, o2_.polygons, o2_.num_polygons));
+      o2_.points, o2_.num_points, o2_.polygons, o2_.num_polygons));
 
   test_normal_and_nearest_points(*o1.get(), *o2.get());
 }
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(test_normal_and_nearest_points_mesh_box) {
   FCL_REAL rbox = 2 * 0.5;
   Convex<Triangle> o1_ = constructPolytopeFromEllipsoid(Ellipsoid(r, r, r));
   shared_ptr<Convex<Triangle>> o1(new Convex<Triangle>(
-      false, o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
+      o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
   shared_ptr<Box> o2(new Box(rbox, rbox, rbox));
 
   test_normal_and_nearest_points(*o1.get(), *o2.get());
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_normal_and_nearest_points_mesh_ellipsoid) {
   FCL_REAL r = 0.5;
   Convex<Triangle> o1_ = constructPolytopeFromEllipsoid(Ellipsoid(r, r, r));
   shared_ptr<Convex<Triangle>> o1(new Convex<Triangle>(
-      false, o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
+      o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
   shared_ptr<Ellipsoid> o2(new Ellipsoid(0.5 * r, 1.3 * r, 0.8 * r));
 
   test_normal_and_nearest_points(*o1.get(), *o2.get());
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(test_normal_and_nearest_points_mesh_halfspace) {
   FCL_REAL r = 0.5;
   Convex<Triangle> o1_ = constructPolytopeFromEllipsoid(Ellipsoid(r, r, r));
   shared_ptr<Convex<Triangle>> o1(new Convex<Triangle>(
-      false, o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
+      o1_.points, o1_.num_points, o1_.polygons, o1_.num_polygons));
   FCL_REAL offset = 0.1;
   Vec3f n = Vec3f::Random();
   n.normalize();

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -525,8 +525,7 @@ Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid) {
   tris_[17].set(6, 2, 10);
   tris_[18].set(8, 6, 7);
   tris_[19].set(9, 8, 1);
-  return Convex<Triangle>(true,
-                          pts,   // points
+  return Convex<Triangle>(pts,   // points
                           12,    // num_points
                           tris,  // triangles
                           20     // number of triangles

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -478,24 +478,25 @@ Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid) {
   FCL_REAL PHI = (1 + std::sqrt(5)) / 2;
 
   // vertices
-  Vec3f* pts = new Vec3f[12];
-  pts[0] = Vec3f(-1, PHI, 0);
-  pts[1] = Vec3f(1, PHI, 0);
-  pts[2] = Vec3f(-1, -PHI, 0);
-  pts[3] = Vec3f(1, -PHI, 0);
+  std::shared_ptr<Vec3f> pts(new Vec3f[12]);
+  Vec3f* pts_ = pts.get();
+  pts_[0] = Vec3f(-1, PHI, 0);
+  pts_[1] = Vec3f(1, PHI, 0);
+  pts_[2] = Vec3f(-1, -PHI, 0);
+  pts_[3] = Vec3f(1, -PHI, 0);
 
-  pts[4] = Vec3f(0, -1, PHI);
-  pts[5] = Vec3f(0, 1, PHI);
-  pts[6] = Vec3f(0, -1, -PHI);
-  pts[7] = Vec3f(0, 1, -PHI);
+  pts_[4] = Vec3f(0, -1, PHI);
+  pts_[5] = Vec3f(0, 1, PHI);
+  pts_[6] = Vec3f(0, -1, -PHI);
+  pts_[7] = Vec3f(0, 1, -PHI);
 
-  pts[8] = Vec3f(PHI, 0, -1);
-  pts[9] = Vec3f(PHI, 0, 1);
-  pts[10] = Vec3f(-PHI, 0, -1);
-  pts[11] = Vec3f(-PHI, 0, 1);
+  pts_[8] = Vec3f(PHI, 0, -1);
+  pts_[9] = Vec3f(PHI, 0, 1);
+  pts_[10] = Vec3f(-PHI, 0, -1);
+  pts_[11] = Vec3f(-PHI, 0, 1);
 
   for (int i = 0; i < 12; ++i) {
-    toEllipsoid(pts[i], ellipsoid);
+    toEllipsoid(pts_[i], ellipsoid);
   }
 
   // faces

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -500,30 +500,31 @@ Convex<Triangle> constructPolytopeFromEllipsoid(const Ellipsoid& ellipsoid) {
   }
 
   // faces
-  Triangle* tris = new Triangle[20];
-  tris[0].set(0, 11, 5);
-  tris[1].set(0, 5, 1);
-  tris[2].set(0, 1, 7);
-  tris[3].set(0, 7, 10);
-  tris[4].set(0, 10, 11);
+  std::shared_ptr<Triangle> tris(new Triangle[20]);
+  Triangle* tris_ = tris.get();
+  tris_[0].set(0, 11, 5);
+  tris_[1].set(0, 5, 1);
+  tris_[2].set(0, 1, 7);
+  tris_[3].set(0, 7, 10);
+  tris_[4].set(0, 10, 11);
 
-  tris[5].set(1, 5, 9);
-  tris[6].set(5, 11, 4);
-  tris[7].set(11, 10, 2);
-  tris[8].set(10, 7, 6);
-  tris[9].set(7, 1, 8);
+  tris_[5].set(1, 5, 9);
+  tris_[6].set(5, 11, 4);
+  tris_[7].set(11, 10, 2);
+  tris_[8].set(10, 7, 6);
+  tris_[9].set(7, 1, 8);
 
-  tris[10].set(3, 9, 4);
-  tris[11].set(3, 4, 2);
-  tris[12].set(3, 2, 6);
-  tris[13].set(3, 6, 8);
-  tris[14].set(3, 8, 9);
+  tris_[10].set(3, 9, 4);
+  tris_[11].set(3, 4, 2);
+  tris_[12].set(3, 2, 6);
+  tris_[13].set(3, 6, 8);
+  tris_[14].set(3, 8, 9);
 
-  tris[15].set(4, 9, 5);
-  tris[16].set(2, 4, 11);
-  tris[17].set(6, 2, 10);
-  tris[18].set(8, 6, 7);
-  tris[19].set(9, 8, 1);
+  tris_[15].set(4, 9, 5);
+  tris_[16].set(2, 4, 11);
+  tris_[17].set(6, 2, 10);
+  tris_[18].set(8, 6, 7);
+  tris_[19].set(9, 8, 1);
   return Convex<Triangle>(true,
                           pts,   // points
                           12,    // num_points


### PR DESCRIPTION
Related to #450.

Since we remove the concept of `own_storage` to use `std::shared_ptr` instead of raw pointers, this PR introduces a breaking change in the API, when creating `Convex` objects from scratch:
```cpp
// previously:
Vec3f* pts = new Vec3f[n_vertices];
Triangle* tris = new Vec3f[n_tris];
bool own_storage = true;
// fill pts and tris...
// then call the `Convex` constructor:
Convex<Triangle> cvx(own_storage, points, n_vertices, tris, n_tris);

// now:
std::shared_ptr<Vec3f> pts(new Vec3f[n_vertices]);
std::shared_ptr<Triangle> tris(new Vec3f[n_tris]);
// fill pts and tris...
// then call the `Convex` constructor:
Convex<Triangle> cvx = convexHull(points, n_vertices, tris, n_tris);
```