### PR TITLE
[ConvexBase] Fix neighbor copy in copy constructor.

### DIFF
--- a/src/shape/geometric_shapes.cpp
+++ b/src/shape/geometric_shapes.cpp
@@ -67,13 +67,25 @@ ConvexBase::ConvexBase(const ConvexBase& other)
   } else
     points.reset();
 
-  if (other.neighbors.get() && other.neighbors->size() > 0) {
-    neighbors.reset(new std::vector<Neighbors>(*(other.neighbors)));
-  } else
-    neighbors.reset();
-
   if (other.nneighbors_.get() && other.nneighbors_->size() > 0) {
+    // Deep copy the list of all the neighbors of all the points
     nneighbors_.reset(new std::vector<unsigned int>(*(other.nneighbors_)));
+    if (other.neighbors.get() && other.neighbors->size() > 0) {
+      // Fill each neighbors for each point in the Convex object.
+      neighbors.reset(new std::vector<Neighbors>(other.neighbors->size()));
+      assert(neighbors->size() == points->size());
+      unsigned int* p_nneighbors = nneighbors_->data();
+
+      std::vector<Neighbors>& neighbors_ = *neighbors;
+      const std::vector<Neighbors>& other_neighbors_ = *(other.neighbors);
+      for (size_t i = 0; i < neighbors->size(); ++i) {
+        Neighbors& n = neighbors_[i];
+        n.count_ = other_neighbors_[i].count_;
+        n.n_ = p_nneighbors;
+        p_nneighbors += n.count_;
+      }
+    } else
+      neighbors.reset();
   } else
     nneighbors_.reset();
 

--- a/test/convex.cpp
+++ b/test/convex.cpp
@@ -269,22 +269,28 @@ BOOST_AUTO_TEST_CASE(convex_hull_box_like) {
 }
 
 BOOST_AUTO_TEST_CASE(convex_copy_constructor) {
-  std::shared_ptr<std::vector<Vec3f>> points(new std::vector<Vec3f>({
-      Vec3f(1, 1, 1),
-      Vec3f(1, 1, -1),
-      Vec3f(1, -1, 1),
-      Vec3f(1, -1, -1),
-      Vec3f(-1, 1, 1),
-      Vec3f(-1, 1, -1),
-      Vec3f(-1, -1, 1),
-      Vec3f(-1, -1, -1),
-      Vec3f(0, 0, 0),
-  }));
+  Convex<Triangle>* convexHullTriCopy;
+  {
+    std::shared_ptr<std::vector<Vec3f>> points(new std::vector<Vec3f>({
+        Vec3f(1, 1, 1),
+        Vec3f(1, 1, -1),
+        Vec3f(1, -1, 1),
+        Vec3f(1, -1, -1),
+        Vec3f(-1, 1, 1),
+        Vec3f(-1, 1, -1),
+        Vec3f(-1, -1, 1),
+        Vec3f(-1, -1, -1),
+        Vec3f(0, 0, 0),
+    }));
 
-  Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
-      ConvexBase::convexHull(points, 9, true, NULL));
-  Convex<Triangle>* convexHullTriCopy = new Convex<Triangle>(*convexHullTri);
-  BOOST_CHECK(*convexHullTri == *convexHullTriCopy);
+    Convex<Triangle>* convexHullTri = dynamic_cast<Convex<Triangle>*>(
+        ConvexBase::convexHull(points, 9, true, NULL));
+    convexHullTriCopy = new Convex<Triangle>(*convexHullTri);
+    BOOST_CHECK(*convexHullTri == *convexHullTriCopy);
+  }
+  Convex<Triangle>* convexHullTriCopyOfCopy =
+      new Convex<Triangle>(*convexHullTriCopy);
+  BOOST_CHECK(*convexHullTriCopyOfCopy == *convexHullTriCopy);
 }
 
 BOOST_AUTO_TEST_CASE(convex_clone) {


### PR DESCRIPTION
Previously, the pointers in `neighbors` were not pointing to the data stored in `nneighbors_` but to `other.nneighbors_`.
If `other.nneighbors_` is destroyed then the neighbors point to deleted data. This PR fixes that.