### PR TITLE
Add metrics for gjk and epa

### DIFF
--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -39,6 +39,7 @@
 #ifndef HPP_FCL_GJK_H
 #define HPP_FCL_GJK_H
 
+#include <array>
 #include <vector>
 
 #include <hpp/fcl/shape/geometric_shapes.h>
@@ -65,6 +66,7 @@ struct HPP_FCL_DLLAPI MinkowskiDiff {
 
   struct ShapeData {
     std::vector<int8_t> visited;
+    mutable size_t num_support_dotprods;
   };
 
   /// @brief Store temporary data for the computation of the support point for
@@ -260,6 +262,9 @@ struct HPP_FCL_DLLAPI GJK {
   /// @brief Get GJK number of iterations.
   inline int getIterationsMomentumStopped() { return iterations_momentum_stop; }
 
+  /// @brief Get GJK number of iterations.
+  std::array<size_t, 2> getNumSupportDotprods() { return num_support_dotprods; }
+
   /// @brief Get GJK tolerance.
   inline FCL_REAL getTolerance() { return tolerance; }
 
@@ -276,6 +281,8 @@ struct HPP_FCL_DLLAPI GJK {
   FCL_REAL distance_upper_bound;
   size_t iterations;
   int iterations_momentum_stop;
+  // Number of dot products done in the support function for each shape
+  std::array<size_t, 2> num_support_dotprods;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -308,8 +308,8 @@ struct HPP_FCL_DLLAPI GJK {
   /// which reuse checks from edges.
   /// Finally, in addition to the voronoi procedure, checks relying on the order
   /// of construction
-  // of the simplex are added. To know more about these, visit
-  // https://caseymuratori.com/blog_0003.
+  /// of the simplex are added. To know more about these, visit
+  /// https://caseymuratori.com/blog_0003.
   bool projectLineOrigin(const Simplex& current, Simplex& next);
 
   /// @brief Project origin (0) onto triangle a-b-c

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -360,11 +360,16 @@ struct HPP_FCL_DLLAPI EPA {
     SimplexHorizon() : cf(NULL), ff(NULL), nf(0) {}
   };
 
+ public:
+  FCL_REAL getTolerance() { return tolerance; }
+  size_t getIterations() { return iterations; }
+
  private:
   unsigned int max_face_num;
   unsigned int max_vertex_num;
   unsigned int max_iterations;
   FCL_REAL tolerance;
+  size_t iterations;
 
  public:
   enum Status {

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -257,6 +257,9 @@ struct HPP_FCL_DLLAPI GJK {
   /// @brief Get GJK number of iterations.
   inline size_t getIterations() { return iterations; }
 
+  /// @brief Get GJK number of iterations.
+  inline int getIterationsMomentumStopped() { return iterations_momentum_stop; }
+
   /// @brief Get GJK tolerance.
   inline FCL_REAL getTolerance() { return tolerance; }
 
@@ -272,6 +275,7 @@ struct HPP_FCL_DLLAPI GJK {
   FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
   size_t iterations;
+  int iterations_momentum_stop;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -257,9 +257,6 @@ struct HPP_FCL_DLLAPI GJK {
                         const FCL_REAL& omega);
 
   /// @brief Get GJK number of iterations.
-  inline size_t getIterations() const { return iterations; }
-
-  /// @brief Get GJK number of iterations.
   inline int getIterationsMomentumStopped() const {
     return iterations_momentum_stop;
   }
@@ -268,9 +265,6 @@ struct HPP_FCL_DLLAPI GJK {
   inline std::array<size_t, 2> getNumSupportDotprods() const {
     return num_support_dotprods;
   }
-
-  /// @brief Get GJK tolerance.
-  inline FCL_REAL getTolerance() const { return tolerance; }
 
  private:
   SimplexV store_v[4];
@@ -281,10 +275,14 @@ struct HPP_FCL_DLLAPI GJK {
   Status status;
 
   unsigned int max_iterations;
-  FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
-  size_t iterations;
   int iterations_momentum_stop;
+
+ public:
+  FCL_REAL tolerance;
+  size_t iterations;
+
+ private:
   // Number of dot products done in the support function for each shape
   std::array<size_t, 2> num_support_dotprods;
 
@@ -375,14 +373,12 @@ struct HPP_FCL_DLLAPI EPA {
     SimplexHorizon() : cf(NULL), ff(NULL), nf(0) {}
   };
 
- public:
-  inline FCL_REAL getTolerance() const { return tolerance; }
-  inline size_t getIterations() const { return iterations; }
-
  private:
   unsigned int max_face_num;
   unsigned int max_vertex_num;
   unsigned int max_iterations;
+
+ public:
   FCL_REAL tolerance;
   size_t iterations;
 

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -39,7 +39,6 @@
 #ifndef HPP_FCL_GJK_H
 #define HPP_FCL_GJK_H
 
-#include <array>
 #include <vector>
 
 #include <hpp/fcl/shape/geometric_shapes.h>
@@ -66,7 +65,6 @@ struct HPP_FCL_DLLAPI MinkowskiDiff {
 
   struct ShapeData {
     std::vector<int8_t> visited;
-    mutable size_t num_support_dotprods;
   };
 
   /// @brief Store temporary data for the computation of the support point for
@@ -261,11 +259,6 @@ struct HPP_FCL_DLLAPI GJK {
     return iterations_momentum_stop;
   }
 
-  /// @brief Get GJK number of iterations.
-  inline std::array<size_t, 2> getNumSupportDotprods() const {
-    return num_support_dotprods;
-  }
-
  private:
   SimplexV store_v[4];
   SimplexV* free_v[4];
@@ -283,9 +276,6 @@ struct HPP_FCL_DLLAPI GJK {
   size_t iterations;
 
  private:
-  // Number of dot products done in the support function for each shape
-  std::array<size_t, 2> num_support_dotprods;
-
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);
 

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -257,16 +257,20 @@ struct HPP_FCL_DLLAPI GJK {
                         const FCL_REAL& omega);
 
   /// @brief Get GJK number of iterations.
-  inline size_t getIterations() { return iterations; }
+  inline size_t getIterations() const { return iterations; }
 
   /// @brief Get GJK number of iterations.
-  inline int getIterationsMomentumStopped() { return iterations_momentum_stop; }
+  inline int getIterationsMomentumStopped() const {
+    return iterations_momentum_stop;
+  }
 
   /// @brief Get GJK number of iterations.
-  std::array<size_t, 2> getNumSupportDotprods() { return num_support_dotprods; }
+  inline std::array<size_t, 2> getNumSupportDotprods() const {
+    return num_support_dotprods;
+  }
 
   /// @brief Get GJK tolerance.
-  inline FCL_REAL getTolerance() { return tolerance; }
+  inline FCL_REAL getTolerance() const { return tolerance; }
 
  private:
   SimplexV store_v[4];
@@ -372,8 +376,8 @@ struct HPP_FCL_DLLAPI EPA {
   };
 
  public:
-  FCL_REAL getTolerance() { return tolerance; }
-  size_t getIterations() { return iterations; }
+  inline FCL_REAL getTolerance() const { return tolerance; }
+  inline size_t getIterations() const { return iterations; }
 
  private:
   unsigned int max_face_num;

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -118,12 +118,13 @@ void exposeGJK() {
         .DEF_RW_CLASS_ATTRIB(GJK, gjk_variant)
         .DEF_RW_CLASS_ATTRIB(GJK, convergence_criterion)
         .DEF_RW_CLASS_ATTRIB(GJK, convergence_criterion_type)
+        .DEF_RW_CLASS_ATTRIB(GJK, iterations)
+        .DEF_RW_CLASS_ATTRIB(GJK, tolerance)
         .DEF_CLASS_FUNC(GJK, evaluate)
         .DEF_CLASS_FUNC(GJK, hasClosestPoints)
         .DEF_CLASS_FUNC(GJK, hasPenetrationInformation)
         .DEF_CLASS_FUNC(GJK, getClosestPoints)
         .DEF_CLASS_FUNC(GJK, setDistanceEarlyBreak)
-        .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
-        .DEF_CLASS_FUNC(GJK, getIterations);
+        .DEF_CLASS_FUNC(GJK, getGuessFromSimplex);
   }
 }

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -530,6 +530,8 @@ void GJK::initialize() {
   gjk_variant = GJKVariant::DefaultGJK;
   convergence_criterion = GJKConvergenceCriterion::VDB;
   convergence_criterion_type = GJKConvergenceCriterionType::Relative;
+  iterations = 0;
+  iterations_momentum_stop = 0;
 }
 
 Vec3f GJK::getGuessFromSimplex() const { return ray; }
@@ -657,6 +659,9 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
 
   // Momentum
   GJKVariant current_gjk_variant = gjk_variant;
+  // If at the end of gjk, iterations_stop_momentum has a value of -1,
+  // this means momentum has not been stopped.
+  if (current_gjk_variant != DefaultGJK) iterations_momentum_stop = -1;
   Vec3f w = ray;
   Vec3f dir = ray;
   Vec3f y;
@@ -737,7 +742,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
       if (frank_wolfe_duality_gap - tolerance <= 0) {
         removeVertex(simplices[current]);
         current_gjk_variant = DefaultGJK;  // move back to classic GJK
-        continue;                          // continue to next iteration
+        iterations_momentum_stop = static_cast<int>(iterations);
+        continue;  // continue to next iteration
       }
     }
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -1651,7 +1651,7 @@ EPA::Status EPA::evaluate(GJK& gjk, const Vec3f& guess) {
   // the origin.
   status = FallBack;
   // TODO: define a better normal
-  assert(simplex.rank == 1 && simplex.vertex[0]->w.isZero(gjk.getTolerance()));
+  assert(simplex.rank == 1 && simplex.vertex[0]->w.isZero(gjk.tolerance));
   normal = -guess;
   FCL_REAL nl = normal.norm();
   if (nl > 0)

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -640,6 +640,8 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
                           const support_func_guess_t& supportHint) {
   FCL_REAL alpha = 0;
   iterations = 0;
+  num_support_dotprods[0] = 0;
+  num_support_dotprods[1] = 0;
   const FCL_REAL inflation = shape_.inflation.sum();
   const FCL_REAL upper_bound = distance_upper_bound + inflation;
 

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -1458,6 +1458,7 @@ void EPA::initialize() {
   nextsv = 0;
   for (size_t i = 0; i < max_face_num; ++i)
     stock.append(&fc_store[max_face_num - i - 1]);
+  iterations = 0;
 }
 
 bool EPA::getEdgeDist(SimplexF* face, SimplexV* a, SimplexV* b,
@@ -1573,7 +1574,7 @@ EPA::Status EPA::evaluate(GJK& gjk, const Vec3f& guess) {
                                     // minimum distance to origin) to split
       SimplexF outer = *best;
       size_t pass = 0;
-      size_t iterations = 0;
+      iterations = 0;
 
       // set the face connectivity
       bind(tetrahedron[0], 0, tetrahedron[1], 0);

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -179,7 +179,6 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
   if (hint < 0 || hint >= (int)convex->num_points) hint = 0;
   FCL_REAL maxdot = pts[static_cast<size_t>(hint)].dot(dir);
   std::vector<int8_t>& visited = data->visited;
-  size_t num_support_dotprods = 0;
   visited.assign(convex->num_points, false);
   visited[static_cast<std::size_t>(hint)] = true;
   // when the first face is orthogonal to dir, all the dot products will be
@@ -193,7 +192,6 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
       if (visited[ip]) continue;
       visited[ip] = true;
       const FCL_REAL dot = pts[ip].dot(dir);
-      num_support_dotprods++;
       bool better = false;
       if (dot > maxdot) {
         better = true;
@@ -208,7 +206,6 @@ void getShapeSupportLog(const ConvexBase* convex, const Vec3f& dir,
     }
   }
 
-  data->num_support_dotprods = num_support_dotprods;
   support = pts[static_cast<size_t>(hint)];
 }
 
@@ -536,8 +533,6 @@ void GJK::initialize() {
   convergence_criterion_type = GJKConvergenceCriterionType::Relative;
   iterations = 0;
   iterations_momentum_stop = 0;
-  num_support_dotprods[0] = 0;
-  num_support_dotprods[1] = 0;
 }
 
 Vec3f GJK::getGuessFromSimplex() const { return ray; }
@@ -640,8 +635,6 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
                           const support_func_guess_t& supportHint) {
   FCL_REAL alpha = 0;
   iterations = 0;
-  num_support_dotprods[0] = 0;
-  num_support_dotprods[1] = 0;
   const FCL_REAL inflation = shape_.inflation.sum();
   const FCL_REAL upper_bound = distance_upper_bound + inflation;
 
@@ -889,8 +882,6 @@ inline void GJK::appendVertex(Simplex& simplex, const Vec3f& v,
                               bool isNormalized, support_func_guess_t& hint) {
   simplex.vertex[simplex.rank] = free_v[--nfree];  // set the memory
   getSupport(v, isNormalized, *simplex.vertex[simplex.rank++], hint);
-  num_support_dotprods[0] += shape->data[0].num_support_dotprods;
-  num_support_dotprods[1] += shape->data[1].num_support_dotprods;
 }
 
 bool GJK::encloseOrigin() {

--- a/test/accelerated_gjk.cpp
+++ b/test/accelerated_gjk.cpp
@@ -158,8 +158,8 @@ void test_accelerated_gjk(const ShapeBase& shape0, const ShapeBase& shape1) {
 
     // Make sure GJK and Nesterov accelerated GJK converges in a reasonable
     // amount of iterations
-    BOOST_CHECK(gjk.getIterations() < max_iterations);
-    BOOST_CHECK(gjk_nesterov.getIterations() < max_iterations);
+    BOOST_CHECK(gjk.iterations < max_iterations);
+    BOOST_CHECK(gjk_nesterov.iterations < max_iterations);
 
     // ------------
     // -- Polyak --
@@ -179,8 +179,8 @@ void test_accelerated_gjk(const ShapeBase& shape0, const ShapeBase& shape1) {
 
     // Make sure GJK and Polyak accelerated GJK converges in a reasonable
     // amount of iterations
-    BOOST_CHECK(gjk.getIterations() < max_iterations);
-    BOOST_CHECK(gjk_polyak.getIterations() < max_iterations);
+    BOOST_CHECK(gjk.iterations < max_iterations);
+    BOOST_CHECK(gjk_polyak.iterations < max_iterations);
   }
 }
 

--- a/test/gjk_convergence_criterion.cpp
+++ b/test/gjk_convergence_criterion.cpp
@@ -136,21 +136,21 @@ void test_gjk_cv_criterion(const ShapeBase& shape0, const ShapeBase& shape1,
     mink_diff.set(&shape0, &shape1, identity, transforms[i]);
 
     GJK::Status res1 = gjk1.evaluate(mink_diff, init_guess, init_support_guess);
-    BOOST_CHECK(gjk1.getIterations() <= max_iterations);
+    BOOST_CHECK(gjk1.iterations <= max_iterations);
     Vec3f ray1 = gjk1.ray;
     res1 = gjk1.evaluate(mink_diff, init_guess, init_support_guess);
     BOOST_CHECK(res1 != GJK::Status::Failed);
     EIGEN_VECTOR_IS_APPROX(gjk1.ray, ray1, 1e-8);
 
     GJK::Status res2 = gjk2.evaluate(mink_diff, init_guess, init_support_guess);
-    BOOST_CHECK(gjk2.getIterations() <= max_iterations);
+    BOOST_CHECK(gjk2.iterations <= max_iterations);
     Vec3f ray2 = gjk2.ray;
     res2 = gjk2.evaluate(mink_diff, init_guess, init_support_guess);
     BOOST_CHECK(res2 != GJK::Status::Failed);
     EIGEN_VECTOR_IS_APPROX(gjk2.ray, ray2, 1e-8);
 
     GJK::Status res3 = gjk3.evaluate(mink_diff, init_guess, init_support_guess);
-    BOOST_CHECK(gjk3.getIterations() <= max_iterations);
+    BOOST_CHECK(gjk3.iterations <= max_iterations);
     Vec3f ray3 = gjk3.ray;
     res3 = gjk3.evaluate(mink_diff, init_guess, init_support_guess);
     BOOST_CHECK(res3 != GJK::Status::Failed);


### PR DESCRIPTION
This PR allows to retrieve the tolerance and iterations of both EPA and GJK algos.
Also, it counts the number of dot products during the calls to the support functions in GJK.

These metrics are useful when benchmarking collision detection.