### PR TITLE
Performance Patch

### DIFF
--- a/include/hpp/fcl/collision_object.h
+++ b/include/hpp/fcl/collision_object.h
@@ -305,6 +305,11 @@ class HPP_FCL_DLLAPI CollisionObject {
     return cgeom;
   }
 
+  /// @brief get geometry from the object instance, as raw pointer
+  const CollisionGeometry* collisionGeometryRaw() const {
+    return cgeom.get();
+  }
+
   /// @brief get geometry from the object instance
   const shared_ptr<CollisionGeometry>& collisionGeometry() { return cgeom; }
 

--- a/include/hpp/fcl/collision_object.h
+++ b/include/hpp/fcl/collision_object.h
@@ -306,9 +306,7 @@ class HPP_FCL_DLLAPI CollisionObject {
   }
 
   /// @brief get geometry from the object instance, as raw pointer
-  const CollisionGeometry* collisionGeometryRaw() const {
-    return cgeom.get();
-  }
+  const CollisionGeometry* collisionGeometryRaw() const { return cgeom.get(); }
 
   /// @brief get geometry from the object instance
   const shared_ptr<CollisionGeometry>& collisionGeometry() { return cgeom; }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -62,8 +62,8 @@ void CollisionResult::swapObjects() {
 
 std::size_t collide(const CollisionObject* o1, const CollisionObject* o2,
                     const CollisionRequest& request, CollisionResult& result) {
-  return collide(o1->collisionGeometry().get(), o1->getTransform(),
-                 o2->collisionGeometry().get(), o2->getTransform(), request,
+  return collide(o1->collisionGeometryRaw(), o1->getTransform(),
+                 o2->collisionGeometryRaw(), o2->getTransform(), request,
                  result);
 }
 


### PR DESCRIPTION
Hi all, I am currently profiling my application and have found a bottleneck in hpp fcl.

The collisionGeometry() function returns a copy of a shared_ptr. Unfortunately a reference is not possible, because a const cast is necessary.

So I built a function that returns a raw pointer, which solves the problem.

Im using the recent Visual Studio Compiler.


Here is the Profiler output, before the change:
<img width="1309" alt="image" src="https://github.com/humanoid-path-planner/hpp-fcl/assets/1830710/6c49e18a-bb59-4f4e-9316-43128f4b84dd">

<img width="563" alt="image" src="https://github.com/humanoid-path-planner/hpp-fcl/assets/1830710/c1e8e794-888f-40eb-9ab7-16305ac69460">


And here with it:

<img width="1069" alt="image" src="https://github.com/humanoid-path-planner/hpp-fcl/assets/1830710/691d734a-7299-47f5-aaa5-d3468317f677">





