### PR TITLE
Hide qhullcpp symbol

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,7 +205,9 @@ if(HPP_FCL_HAS_QHULL)
   target_compile_definitions(${LIBRARY_NAME} PRIVATE -DHPP_FCL_HAS_QHULL)
   if (HPP_FCL_USE_SYSTEM_QHULL)
     target_link_libraries(${LIBRARY_NAME} PRIVATE Qhull::qhull_r Qhull::qhullcpp)
-    if(UNIX)
+    # On Linux, don't export libqhullcpp symbols to avoid conflict with other libraries
+    # that depend on QHull
+    if(UNIX AND NOT APPLE)
       set_target_properties(
         ${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,libqhullcpp")
     endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,10 @@ if(HPP_FCL_HAS_QHULL)
   target_compile_definitions(${LIBRARY_NAME} PRIVATE -DHPP_FCL_HAS_QHULL)
   if (HPP_FCL_USE_SYSTEM_QHULL)
     target_link_libraries(${LIBRARY_NAME} PRIVATE Qhull::qhull_r Qhull::qhullcpp)
+    if(UNIX)
+      set_target_properties(
+        ${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,libqhullcpp")
+    endif()
   else()
     target_include_directories(${LIBRARY_NAME} SYSTEM PRIVATE
       ${Qhull_r_INCLUDE_DIR} ${Qhullcpp_PREFIX})


### PR DESCRIPTION
# Problem 1

qhullcpp is a static library that had been build with default symbol visibility strategies : all is visible.
When linking against this library, hpp-fcl get all libqhull symbols and also show them as visible.

If a thirdparty library is linking against hpp-fcl and qhullcpp, then a strange symbol mix-up can occur.
I have been able to reproduce it with pinocchio 3.

This can lead to binary conflicts, since there is no guarantee that pinocchio 3 and hpp-fcl are using the same version of qhullcpp with the same ABI (same compiler flags).

## Solution

I advise to hide all qhullcpp symbols when linking against it.
I only know how to do it and test it on Linux. We should find a way to fix it on MacOS and Windows if the same issue occur.

# Problem 2

hpp-fcl embed qhullcpp source code. This source code is working with some old qhull_r versions. I have not be able to build it with qhull_r 2020.2.

## Solution

Maybe we can get rid of it ? Or at least document which version of qhull_r is needed.

If we keep it, then we should find a way to not export the qhullcpp symbol either (probably by creating a static library).