### PR TITLE
[broadphase] Initialize NodeVecIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CachedMeshLoader checks file last modification time.
 - Fix call to clear methods for {Collision,Distance}Data inside init function ([#509](https://github.com/humanoid-path-planner/hpp-fcl/pull/509))
 - CMake: fix submodule use in bindings in ([#512](https://github.com/humanoid-path-planner/hpp-fcl/pull/512))
+- Fix bug in DynamicAABBTreeCollisionManager (see [#514](https://github.com/humanoid-path-planner/hpp-fcl/issues/514)) in ([#515](https://github.com/humanoid-path-planner/hpp-fcl/pull/515))
 
 ## [2.4.0] - 2023-11-27
 

--- a/include/hpp/fcl/broadphase/detail/hierarchy_tree-inl.h
+++ b/include/hpp/fcl/broadphase/detail/hierarchy_tree-inl.h
@@ -301,7 +301,8 @@ void HierarchyTree<BV>::bottomup(const NodeVecIterator lbeg,
                                  const NodeVecIterator lend) {
   NodeVecIterator lcur_end = lend;
   while (lbeg < lcur_end - 1) {
-    NodeVecIterator min_it1, min_it2;
+    NodeVecIterator min_it1 = lbeg;
+    NodeVecIterator min_it2 = lbeg + 1;
     FCL_REAL min_size = (std::numeric_limits<FCL_REAL>::max)();
     for (NodeVecIterator it1 = lbeg; it1 < lcur_end; ++it1) {
       for (NodeVecIterator it2 = it1 + 1; it2 < lcur_end; ++it2) {


### PR DESCRIPTION
In the case where only 2 shapes are used and one of them is a shape with infinite AABB (i.e Plane or Halfspace), `min_size` remains equal to +infinity in `HierarchyTree::bottomup` and `min_it1` and `min_it2` never got set, which was leading to a segfault when they are then dereferenced.