### PR TITLE
Setting default parameters for the narrowphase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - CMake: fix assimp finder
 - Don't define GCC7 Boost serialization hack when `HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION` is defined ([#530](https://github.com/humanoid-path-planner/hpp-fcl/pull/530))
+- Default parameters for narrowphase algorithms (GJK and EPA).
+- Fixed assertion checks that were sometimes failing in GJK simplex projection and BVH `collide`.
 
 ## [2.4.1] - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - CMake: fix assimp finder
 - Don't define GCC7 Boost serialization hack when `HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION` is defined ([#530](https://github.com/humanoid-path-planner/hpp-fcl/pull/530))
-- Default parameters for narrowphase algorithms (GJK and EPA).
-- Fixed assertion checks that were sometimes failing in GJK simplex projection and BVH `collide`.
+- Default parameters for narrowphase algorithms (GJK and EPA); fixed assertion checks that were sometimes failing in GJK simplex projection and BVH `collide` ([#531](https://github.com/humanoid-path-planner/hpp-fcl/pull/531)).
 
 ## [2.4.1] - 2024-01-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ SET(${PROJECT_NAME}_HEADERS
   include/hpp/fcl/broadphase/detail/spatial_hash.h
   include/hpp/fcl/narrowphase/narrowphase.h
   include/hpp/fcl/narrowphase/gjk.h
+  include/hpp/fcl/narrowphase/narrowphase_defaults.h
   include/hpp/fcl/shape/convex.h
   include/hpp/fcl/shape/details/convex.hxx
   include/hpp/fcl/shape/geometric_shape_to_BVH_model.h

--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -47,6 +47,7 @@
 #include <hpp/fcl/config.hh>
 #include <hpp/fcl/data_types.h>
 #include <hpp/fcl/timings.h>
+#include <hpp/fcl/narrowphase/narrowphase_defaults.h>
 
 namespace hpp {
 namespace fcl {
@@ -224,14 +225,14 @@ struct HPP_FCL_DLLAPI QueryRequest {
         gjk_variant(GJKVariant::DefaultGJK),
         gjk_convergence_criterion(GJKConvergenceCriterion::VDB),
         gjk_convergence_criterion_type(GJKConvergenceCriterionType::Relative),
-        gjk_tolerance(1e-6),
-        gjk_max_iterations(128),
+        gjk_tolerance(GJK_DEFAULT_TOLERANCE),
+        gjk_max_iterations(GJK_DEFAULT_MAX_ITERATIONS),
         cached_gjk_guess(1, 0, 0),
         cached_support_func_guess(support_func_guess_t::Zero()),
-        epa_max_face_num(128),
-        epa_max_vertex_num(64),
-        epa_max_iterations(255),
-        epa_tolerance(1e-6),
+        epa_max_face_num(EPA_DEFAULT_MAX_FACES),
+        epa_max_vertex_num(EPA_DEFAULT_MAX_VERTICES),
+        epa_max_iterations(EPA_DEFAULT_MAX_ITERATIONS),
+        epa_tolerance(EPA_DEFAULT_TOLERANCE),
         enable_timings(false),
         collision_distance_threshold(
             Eigen::NumTraits<FCL_REAL>::dummy_precision()) {}

--- a/include/hpp/fcl/narrowphase/narrowphase_defaults.h
+++ b/include/hpp/fcl/narrowphase/narrowphase_defaults.h
@@ -1,0 +1,58 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, INRIA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// This file defines different macros used to characterize the default behavior
+/// of the narrowphase algorithms GJK and EPA.
+
+#ifndef HPP_FCL_NARROWPHASE_DEFAULTS
+#define HPP_FCL_NARROWPHASE_DEFAULTS
+
+/// GJK
+#define GJK_DEFAULT_MAX_ITERATIONS 128
+#define GJK_DEFAULT_TOLERANCE 1e-6
+/// Note: if the considered shapes are on the order of the meter, and the
+/// convergence criterion of GJK is the default VDB criterion,
+/// setting a tolerance of 1e-6 on the GJK algorithm makes it precise up to
+/// the micro-meter.
+/// The same is true for EPA.
+#define GJK_MINIMUM_TOLERANCE 1e-6
+
+/// EPA
+#define EPA_DEFAULT_MAX_ITERATIONS 255
+#define EPA_DEFAULT_TOLERANCE 1e-6
+#define EPA_MINIMUM_TOLERANCE 1e-6
+#define EPA_DEFAULT_MAX_FACES 128
+#define EPA_DEFAULT_MAX_VERTICES 64
+
+#endif  // HPP_FCL_NARROWPHASE_DEFAULTS

--- a/include/hpp/fcl/narrowphase/narrowphase_defaults.h
+++ b/include/hpp/fcl/narrowphase/narrowphase_defaults.h
@@ -38,21 +38,29 @@
 #ifndef HPP_FCL_NARROWPHASE_DEFAULTS
 #define HPP_FCL_NARROWPHASE_DEFAULTS
 
+#include <hpp/fcl/data_types.h>
+
+namespace hpp {
+namespace fcl {
+
 /// GJK
-#define GJK_DEFAULT_MAX_ITERATIONS 128
-#define GJK_DEFAULT_TOLERANCE 1e-6
+constexpr size_t GJK_DEFAULT_MAX_ITERATIONS = 128;
+constexpr FCL_REAL GJK_DEFAULT_TOLERANCE = 1e-6;
 /// Note: if the considered shapes are on the order of the meter, and the
 /// convergence criterion of GJK is the default VDB criterion,
 /// setting a tolerance of 1e-6 on the GJK algorithm makes it precise up to
 /// the micro-meter.
 /// The same is true for EPA.
-#define GJK_MINIMUM_TOLERANCE 1e-6
+constexpr FCL_REAL GJK_MINIMUM_TOLERANCE = 1e-6;
 
 /// EPA
-#define EPA_DEFAULT_MAX_ITERATIONS 255
-#define EPA_DEFAULT_TOLERANCE 1e-6
-#define EPA_MINIMUM_TOLERANCE 1e-6
-#define EPA_DEFAULT_MAX_FACES 128
-#define EPA_DEFAULT_MAX_VERTICES 64
+constexpr size_t EPA_DEFAULT_MAX_ITERATIONS = 255;
+constexpr FCL_REAL EPA_DEFAULT_TOLERANCE = 1e-6;
+constexpr FCL_REAL EPA_MINIMUM_TOLERANCE = 1e-6;
+constexpr size_t EPA_DEFAULT_MAX_FACES = 128;
+constexpr size_t EPA_DEFAULT_MAX_VERTICES = 64;
+
+}  // namespace fcl
+}  // namespace hpp
 
 #endif  // HPP_FCL_NARROWPHASE_DEFAULTS

--- a/src/collision_node.cpp
+++ b/src/collision_node.cpp
@@ -45,17 +45,13 @@ void checkResultLowerBound(const CollisionResult& result,
                            FCL_REAL sqrDistLowerBound) {
   const FCL_REAL dummy_precision =
       std::sqrt(Eigen::NumTraits<FCL_REAL>::epsilon());
+  HPP_FCL_UNUSED_VARIABLE(dummy_precision);
   if (sqrDistLowerBound == 0) {
-    if (result.distance_lower_bound > dummy_precision)
-      HPP_FCL_THROW_PRETTY("Distance lower bound should not be positive.",
-                           std::logic_error);
+    assert(result.distance_lower_bound <= dummy_precision);
   } else {
-    if (result.distance_lower_bound * result.distance_lower_bound -
-            sqrDistLowerBound >
-        dummy_precision)
-      HPP_FCL_THROW_PRETTY(
-          "Distance lower bound and sqrDistLowerBound should coincide.",
-          std::logic_error);
+    assert(result.distance_lower_bound * result.distance_lower_bound -
+               sqrDistLowerBound <
+           dummy_precision);
   }
 }
 

--- a/src/collision_node.cpp
+++ b/src/collision_node.cpp
@@ -53,13 +53,16 @@ void collide(CollisionTraversalNodeBase* node, const CollisionRequest& request,
     else
       collisionNonRecurse(node, front_list, sqrDistLowerBound);
 
+    const FCL_REAL dummy_precision =
+        std::sqrt(Eigen::NumTraits<FCL_REAL>::epsilon());
+    HPP_FCL_UNUSED_VARIABLE(dummy_precision);
     if (!std::isnan(sqrDistLowerBound)) {
       if (sqrDistLowerBound == 0) {
-        assert(result.distance_lower_bound <= 0);
+        assert(result.distance_lower_bound <= dummy_precision);
       } else {
         assert(result.distance_lower_bound * result.distance_lower_bound -
                    sqrDistLowerBound <
-               1e-8);
+               dummy_precision);
       }
     }
   }

--- a/src/collision_node.cpp
+++ b/src/collision_node.cpp
@@ -41,6 +41,24 @@
 namespace hpp {
 namespace fcl {
 
+void checkResultLowerBound(const CollisionResult& result,
+                           FCL_REAL sqrDistLowerBound) {
+  const FCL_REAL dummy_precision =
+      std::sqrt(Eigen::NumTraits<FCL_REAL>::epsilon());
+  if (sqrDistLowerBound == 0) {
+    if (result.distance_lower_bound > dummy_precision)
+      HPP_FCL_THROW_PRETTY("Distance lower bound should not be positive.",
+                           std::logic_error);
+  } else {
+    if (result.distance_lower_bound * result.distance_lower_bound -
+            sqrDistLowerBound >
+        dummy_precision)
+      HPP_FCL_THROW_PRETTY(
+          "Distance lower bound and sqrDistLowerBound should coincide.",
+          std::logic_error);
+  }
+}
+
 void collide(CollisionTraversalNodeBase* node, const CollisionRequest& request,
              CollisionResult& result, BVHFrontList* front_list,
              bool recursive) {
@@ -52,18 +70,8 @@ void collide(CollisionTraversalNodeBase* node, const CollisionRequest& request,
       collisionRecurse(node, 0, 0, front_list, sqrDistLowerBound);
     else
       collisionNonRecurse(node, front_list, sqrDistLowerBound);
-
-    const FCL_REAL dummy_precision =
-        std::sqrt(Eigen::NumTraits<FCL_REAL>::epsilon());
-    HPP_FCL_UNUSED_VARIABLE(dummy_precision);
     if (!std::isnan(sqrDistLowerBound)) {
-      if (sqrDistLowerBound == 0) {
-        assert(result.distance_lower_bound <= dummy_precision);
-      } else {
-        assert(result.distance_lower_bound * result.distance_lower_bound -
-                   sqrDistLowerBound <
-               dummy_precision);
-      }
+      checkResultLowerBound(result, sqrDistLowerBound);
     }
   }
 }

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -337,8 +337,7 @@ void getSupportFuncTpl(const MinkowskiDiff& md, const Vec3f& dir,
   assert(!NeedNormalizedDir || dirIsNormalized ||
          fabs(dir.normalized().squaredNorm() - 1) < GJK_MINIMUM_TOLERANCE);
   // Don't need normalized direction. Check that dir is not zero.
-  assert(NeedNormalizedDir ||
-         dir.cwiseAbs().maxCoeff() >= GJK_MINIMUM_TOLERANCE);
+  assert(NeedNormalizedDir || dir.norm() >= GJK_MINIMUM_TOLERANCE);
 #endif
   getSupportTpl<Shape0, Shape1, TransformIsIdentity>(
       static_cast<const Shape0*>(md.shapes[0]),

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -36,11 +36,12 @@
 
 /** \author Jia Pan */
 
-#include "hpp/fcl/shape/geometric_shapes.h"
+#include <hpp/fcl/shape/geometric_shapes.h>
 #include <hpp/fcl/narrowphase/gjk.h>
 #include <hpp/fcl/internal/intersect.h>
 #include <hpp/fcl/internal/tools.h>
 #include <hpp/fcl/shape/geometric_shapes_traits.h>
+#include <hpp/fcl/narrowphase/narrowphase_defaults.h>
 
 namespace hpp {
 namespace fcl {
@@ -331,12 +332,13 @@ void getSupportFuncTpl(const MinkowskiDiff& md, const Vec3f& dir,
 #ifndef NDEBUG
   // Need normalized direction and direction is normalized
   assert(!NeedNormalizedDir || !dirIsNormalized ||
-         fabs(dir.squaredNorm() - 1) < 1e-6);
+         fabs(dir.squaredNorm() - 1) < GJK_MINIMUM_TOLERANCE);
   // Need normalized direction but direction is not normalized.
   assert(!NeedNormalizedDir || dirIsNormalized ||
-         fabs(dir.normalized().squaredNorm() - 1) < 1e-6);
+         fabs(dir.normalized().squaredNorm() - 1) < GJK_MINIMUM_TOLERANCE);
   // Don't need normalized direction. Check that dir is not zero.
-  assert(NeedNormalizedDir || dir.cwiseAbs().maxCoeff() >= 1e-6);
+  assert(NeedNormalizedDir ||
+         dir.cwiseAbs().maxCoeff() >= GJK_MINIMUM_TOLERANCE);
 #endif
   getSupportTpl<Shape0, Shape1, TransformIsIdentity>(
       static_cast<const Shape0*>(md.shapes[0]),

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -1095,7 +1095,10 @@ bool GJK::projectTetrahedraOrigin(const Simplex& current, Simplex& next) {
   const Vec3f a_cross_b = A.cross(B);
   const Vec3f a_cross_c = A.cross(C);
 
-  const FCL_REAL dummy_precision = Eigen::NumTraits<FCL_REAL>::epsilon();
+  // dummy_precision is 1e-14 if FCL_REAL is double
+  //                    1e-5  if FCL_REAL is float
+  static const FCL_REAL dummy_precision(
+      100 * std::numeric_limits<FCL_REAL>::epsilon());
   HPP_FCL_UNUSED_VARIABLE(dummy_precision);
 
 #define REGION_INSIDE()               \
@@ -1287,8 +1290,8 @@ bool GJK::projectTetrahedraOrigin(const Simplex& current, Simplex& next) {
             }       // end of (ACD ^ AD).AO >= 0
           } else {  // not (ACD ^ AC).AO >= 0 / !a10.a11.a2.a12.!a6
             assert(!(da * ca_da + dc * da_aa - dd * ca_aa <=
-                     dummy_precision));  // Not (ACD ^ AD).AO >= 0 /
-                                         // !a10.a11.a2.a12.!a6.!a7
+                     -dummy_precision));  // Not (ACD ^ AD).AO >= 0 /
+                                          // !a10.a11.a2.a12.!a6.!a7
             if (ca * ba_ca + cb * ca_aa - cc * ba_aa <=
                 0) {  // if (ABC ^ AC).AO >= 0 / !a10.a11.a2.a12.!a6.!a7.a5
               // Region AC

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -1097,8 +1097,8 @@ bool GJK::projectTetrahedraOrigin(const Simplex& current, Simplex& next) {
 
   // dummy_precision is 1e-14 if FCL_REAL is double
   //                    1e-5  if FCL_REAL is float
-  static const FCL_REAL dummy_precision(
-      100 * std::numeric_limits<FCL_REAL>::epsilon());
+  const FCL_REAL dummy_precision(100 *
+                                 std::numeric_limits<FCL_REAL>::epsilon());
   HPP_FCL_UNUSED_VARIABLE(dummy_precision);
 
 #define REGION_INSIDE()               \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_fcl_test(security_margin security_margin.cpp)
 add_fcl_test(geometric_shapes geometric_shapes.cpp)
 add_fcl_test(shape_inflation shape_inflation.cpp)
 #add_fcl_test(shape_mesh_consistency shape_mesh_consistency.cpp)
+add_fcl_test(gjk_asserts gjk_asserts.cpp)
 add_fcl_test(frontlist frontlist.cpp)
 SET_TESTS_PROPERTIES(frontlist PROPERTIES TIMEOUT 7200)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_fcl_test(obb obb.cpp)
 add_fcl_test(convex convex.cpp)
 
 add_fcl_test(bvh_models bvh_models.cpp)
+add_fcl_test(collision_node_asserts collision_node_asserts.cpp)
 add_fcl_test(hfields hfields.cpp)
 
 add_fcl_test(profiling profiling.cpp)

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -3,13 +3,16 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <boost/test/included/unit_test.hpp>
+#include <boost/math/constants/constants.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>
 #include <hpp/fcl/collision.h>
 
 using namespace hpp::fcl;
 
+constexpr FCL_REAL pi = boost::math::constants::pi<FCL_REAL>();
+
 double DegToRad(const double& deg) {
-  static double degToRad = M_PI / 180.;
+  static double degToRad = pi / 180.;
   return deg * degToRad;
 }
 std::vector<Vec3f> dirs{Vec3f::UnitZ(),  -Vec3f::UnitZ(), Vec3f::UnitY(),

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -8,7 +8,7 @@
 
 using namespace hpp::fcl;
 
-inline double DegToRad(const double& deg) {
+double DegToRad(const double& deg) {
   static double degToRad = M_PI / 180.;
   return deg * degToRad;
 }

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE FCL_COLLISION_NODE_ASSERT
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <boost/test/included/unit_test.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE FCL_COLLISION_NODE_ASSERT
 
+#include <cmath>
 #include <boost/test/included/unit_test.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>
 #include <hpp/fcl/collision.h>

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -1,7 +1,5 @@
 #define BOOST_TEST_MODULE FCL_COLLISION_NODE_ASSERT
 
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include <boost/test/included/unit_test.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>

--- a/test/collision_node_asserts.cpp
+++ b/test/collision_node_asserts.cpp
@@ -1,0 +1,56 @@
+#define BOOST_TEST_MODULE FCL_COLLISION_NODE_ASSERT
+
+#include <boost/test/included/unit_test.hpp>
+#include <hpp/fcl/BVH/BVH_model.h>
+#include <hpp/fcl/collision.h>
+
+using namespace hpp::fcl;
+
+inline double DegToRad(const double& deg) {
+  static double degToRad = M_PI / 180.;
+  return deg * degToRad;
+}
+std::vector<Vec3f> dirs{Vec3f::UnitZ(),  -Vec3f::UnitZ(), Vec3f::UnitY(),
+                        -Vec3f::UnitY(), Vec3f::UnitX(),  -Vec3f::UnitX()};
+
+BOOST_AUTO_TEST_CASE(TestTriangles) {
+  std::vector<Vec3f> triVertices{Vec3f(1, 0, 0), Vec3f(1, 1, 0),
+                                 Vec3f(0, 1, 0)};
+  std::vector<Triangle> triangle{{0, 1, 2}};
+
+  BVHModel<OBBRSS> tri1{};
+  BVHModel<OBBRSS> tri2{};
+
+  tri1.beginModel();
+  tri1.addSubModel(triVertices, triangle);
+  tri1.endModel();
+
+  tri2.beginModel();
+  tri2.addSubModel(triVertices, triangle);
+  tri2.endModel();
+
+  CollisionRequest request(CONTACT | DISTANCE_LOWER_BOUND, 1);
+
+  ComputeCollision compute(&tri1, &tri2);
+
+  Transform3f tri1Tf{};
+  Transform3f tri2Tf{};
+
+  /// check some angles for two triangles
+  for (int i = 0; i < 360; i += 30) {
+    for (int j = 0; j < 180; j += 30) {
+      for (int k = 0; k < 180; k += 30) {
+        tri1Tf.setQuatRotation(
+            Eigen::AngleAxis<double>(0., Vec3f::UnitZ()) *
+            Eigen::AngleAxis<double>(DegToRad(k), Vec3f::UnitY()));
+        tri2Tf.setQuatRotation(
+            Eigen::AngleAxis<double>(DegToRad(i), Vec3f::UnitZ()) *
+            Eigen::AngleAxis<double>(DegToRad(j), Vec3f::UnitY()));
+        CollisionResult result;
+
+        /// assertion: src/collision_node.cpp:58
+        BOOST_CHECK_NO_THROW(compute(tri2Tf, tri1Tf, request, result));
+      }
+    }
+  }
+}

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -1,15 +1,16 @@
 #define BOOST_TEST_MODULE FCL_GJK_ASSERTS
 
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include <boost/test/included/unit_test.hpp>
+#include <boost/math/constants/constants.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>
 #include <hpp/fcl/collision.h>
 
 using namespace hpp::fcl;
 
+constexpr FCL_REAL pi = boost::math::constants::pi<FCL_REAL>();
+
 double DegToRad(const double& deg) {
-  static double degToRad = M_PI / 180.;
+  static double degToRad = pi / 180.;
   return deg * degToRad;
 }
 std::vector<Vec3f> dirs{Vec3f::UnitZ(),  -Vec3f::UnitZ(), Vec3f::UnitY(),
@@ -19,7 +20,7 @@ void CreateSphereMesh(BVHModel<OBBRSS>& model, const double& radius) {
   size_t polarSteps{32};
   size_t azimuthSteps{32};
 
-  const float PI = static_cast<float>(M_PI);
+  const float PI = static_cast<float>(pi);
 
   const float polarStep = PI / (float)(polarSteps - 1);
   const float azimuthStep = 2.0f * PI / (float)(azimuthSteps - 1);

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -68,14 +68,22 @@ BOOST_AUTO_TEST_CASE(TestSpheres) {
 
   for (int i = 0; i < 360; ++i) {
     for (int j = 0; j < 180; ++j) {
-      sphere2Tf.setQuatRotation(
-          Eigen::AngleAxis<double>(DegToRad(i), Vec3f::UnitZ()) *
-          Eigen::AngleAxis<double>(DegToRad(j), Vec3f::UnitY()));
-      for (const Vec3f& dir : dirs) {
-        sphere2Tf.setTranslation(dir);
-        CollisionResult result;
+      if (
+          /// assertion: src/narrowphase/gjk.cpp:331
+          (i == 5 && j == 48) || (i == 64 && j == 151) ||
+          (i == 98 && j == 47) || (i == 355 && j == 48) ||
+          /// assertion: src/narrowphase/gjk.cpp:1263
+          (i == 86 && j == 52) || (i == 89 && j == 17) ||
+          (i == 89 && j == 58) || (i == 89 && j == 145)) {
+        sphere2Tf.setQuatRotation(
+            Eigen::AngleAxis<double>(DegToRad(i), Vec3f::UnitZ()) *
+            Eigen::AngleAxis<double>(DegToRad(j), Vec3f::UnitY()));
+        for (const Vec3f& dir : dirs) {
+          sphere2Tf.setTranslation(dir);
+          CollisionResult result;
 
-        BOOST_CHECK_NO_THROW(compute(sphere2Tf, sphere1Tf, request, result));
+          BOOST_CHECK_NO_THROW(compute(sphere2Tf, sphere1Tf, request, result));
+        }
       }
     }
   }

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE FCL_GJK_ASSERTS
 
+#include <cmath>
 #include <boost/test/included/unit_test.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>
 #include <hpp/fcl/collision.h>

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -8,14 +8,14 @@
 
 using namespace hpp::fcl;
 
-inline double DegToRad(const double& deg) {
+double DegToRad(const double& deg) {
   static double degToRad = M_PI / 180.;
   return deg * degToRad;
 }
 std::vector<Vec3f> dirs{Vec3f::UnitZ(),  -Vec3f::UnitZ(), Vec3f::UnitY(),
                         -Vec3f::UnitY(), Vec3f::UnitX(),  -Vec3f::UnitX()};
 
-inline void CreateSphereMesh(BVHModel<OBBRSS>& model, const double& radius) {
+void CreateSphereMesh(BVHModel<OBBRSS>& model, const double& radius) {
   size_t polarSteps{32};
   size_t azimuthSteps{32};
 

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE FCL_GJK_ASSERTS
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <boost/test/included/unit_test.hpp>
 #include <hpp/fcl/BVH/BVH_model.h>

--- a/test/gjk_asserts.cpp
+++ b/test/gjk_asserts.cpp
@@ -1,0 +1,80 @@
+#define BOOST_TEST_MODULE FCL_GJK_ASSERTS
+
+#include <boost/test/included/unit_test.hpp>
+#include <hpp/fcl/BVH/BVH_model.h>
+#include <hpp/fcl/collision.h>
+
+using namespace hpp::fcl;
+
+inline double DegToRad(const double& deg) {
+  static double degToRad = M_PI / 180.;
+  return deg * degToRad;
+}
+std::vector<Vec3f> dirs{Vec3f::UnitZ(),  -Vec3f::UnitZ(), Vec3f::UnitY(),
+                        -Vec3f::UnitY(), Vec3f::UnitX(),  -Vec3f::UnitX()};
+
+inline void CreateSphereMesh(BVHModel<OBBRSS>& model, const double& radius) {
+  size_t polarSteps{32};
+  size_t azimuthSteps{32};
+
+  const float PI = static_cast<float>(M_PI);
+
+  const float polarStep = PI / (float)(polarSteps - 1);
+  const float azimuthStep = 2.0f * PI / (float)(azimuthSteps - 1);
+  std::vector<Vec3f> vertices;
+  std::vector<Triangle> triangles;
+
+  for (size_t p = 0; p < polarSteps; ++p) {
+    for (size_t a = 0; a < azimuthSteps; ++a) {
+      const float x =
+          std::sin((float)p * polarStep) * std::cos((float)a * azimuthStep);
+      const float y =
+          std::sin((float)p * polarStep) * std::sin((float)a * azimuthStep);
+      const float z = std::cos((float)p * polarStep);
+      vertices.emplace_back(radius * x, radius * y, radius * z);
+    }
+  }
+
+  for (size_t p = 0; p < polarSteps - 1; ++p) {
+    for (size_t a = 0; a < azimuthSteps - 1; ++a) {
+      size_t p0 = p * azimuthSteps + a;
+      size_t p1 = p * azimuthSteps + (a + 1);
+      size_t p2 = (p + 1) * azimuthSteps + (a + 1);
+      size_t p3 = (p + 1) * azimuthSteps + a;
+      triangles.emplace_back(p0, p2, p1);
+      triangles.emplace_back(p0, p3, p2);
+    }
+  }
+  model.beginModel();
+  model.addSubModel(vertices, triangles);
+  model.endModel();
+}
+
+BOOST_AUTO_TEST_CASE(TestSpheres) {
+  BVHModel<OBBRSS> sphere1{};
+  BVHModel<OBBRSS> sphere2{};
+
+  CreateSphereMesh(sphere1, 1.);
+  CreateSphereMesh(sphere2, 2.);
+
+  CollisionRequest request(CONTACT | DISTANCE_LOWER_BOUND, 1);
+
+  ComputeCollision compute(&sphere2, &sphere1);
+
+  Transform3f sphere1Tf = Transform3f::Identity();
+  Transform3f sphere2Tf = Transform3f::Identity();
+
+  for (int i = 0; i < 360; ++i) {
+    for (int j = 0; j < 180; ++j) {
+      sphere2Tf.setQuatRotation(
+          Eigen::AngleAxis<double>(DegToRad(i), Vec3f::UnitZ()) *
+          Eigen::AngleAxis<double>(DegToRad(j), Vec3f::UnitY()));
+      for (const Vec3f& dir : dirs) {
+        sphere2Tf.setTranslation(dir);
+        CollisionResult result;
+
+        BOOST_CHECK_NO_THROW(compute(sphere2Tf, sphere1Tf, request, result));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is related to #380 where users are sometimes experiencing assertion errors in Debug mode.
This PR is related to one of these assertion triggers:
- When the user sets a tolerance for GJK and/or EPA that is too low, the support function may work with support directions that are almost zero, which is not suitable for GJK and EPA. In hppfcl, we have hard-coded assertion checks, and these checks make the assumption that GJK's tolerance is not below `1e-6`. This PR introduces default values for GJK and EPA and places a warning in Debug mode only for users going below this tolerance.
Side note: when working with the default GJK and EPA (default `1e-6` tolerance, default convergence criterion), it is precise up to the micro-meter, which is an **extremely** low tolerance. In practice, working with `1e-4` or even `1e-3` should be more than enough.

Sorry for the long coming text.
I will use this PR to evoke the 2 main other assertions that sometimes trigger:
- When shapes of a collision pair are extremely far apart or have extremely different dimensions (i.e., a molecule vs. a plane), the projection step in GJK may be limited due to floating point error, and assertions will be triggered. We might want to implement a "pre-conditioning" system in the future. When working with "molecule vs. plane" dimensions, it would warn the user that hppfcl is not made to work with such different dimensions. When working with "molecule vs. molecule" dimensions, it would simply scale the problem "to the meter." This pre-conditioner would simply check the dimension of the AABB of each shape.
- When shapes of a collision pair are in "touching contact", i.e they are colliding but have a 0 penetration depth. In such a case, EPA tries to run, fails, and an assert triggers. Although this situation in "rare" in theory, it actually occurs quite often when using hppfcl for physics simulation. I am actively working on fixing this issue, so hopefully this assert will soon disappear.