### PR TITLE
Fix compatibility with recent APPLE compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - The internal collision and distance functions of hpp-fcl now use `CollisionRequest::enable_contact` and `DistanceRequest::enable_signed_distance` to control whether or not penetration information should be computed. There are many scenarios where we don't need the penetration information and only want to know if objects are colliding and compute their distance only if they are disjoint. These flags allow the user to control the trade-off between performance vs. information of the library.
   - Fix convergence criterion of EPA; made GJK and EPA convergence criterion absolute + relative to scale to the shapes' dimensions; remove max face/vertices fields from EPA (these can be deduced from the max number of iterations)
 - Account for lateral borders in Height Fields model.
+- Fix compilation error on recent APPLE compilers ([#539](https://github.com/humanoid-path-planner/hpp-fcl/pull/539)).
 
 ## [2.4.1] - 2024-01-23
 

--- a/include/hpp/fcl/broadphase/detail/interval_tree.h
+++ b/include/hpp/fcl/broadphase/detail/interval_tree.h
@@ -91,7 +91,7 @@ class HPP_FCL_DLLAPI IntervalTree {
  protected:
   IntervalTreeNode* root;
 
-  IntervalTreeNode* nil;
+  IntervalTreeNode* invalid_node;
 
   /// @brief left rotation of tree node
   void leftRotate(IntervalTreeNode* node);

--- a/include/hpp/fcl/broadphase/detail/interval_tree_node.h
+++ b/include/hpp/fcl/broadphase/detail/interval_tree_node.h
@@ -61,8 +61,8 @@ class HPP_FCL_DLLAPI IntervalTreeNode {
 
   ~IntervalTreeNode();
 
-  /// @brief Print the interval node information: set left = nil and right =
-  /// root
+  /// @brief Print the interval node information: set left = invalid_node and
+  /// right = root
   void print(IntervalTreeNode* left, IntervalTreeNode* right) const;
 
  protected:

--- a/src/broadphase/detail/interval_tree_node.cpp
+++ b/src/broadphase/detail/interval_tree_node.cpp
@@ -67,17 +67,17 @@ IntervalTreeNode::~IntervalTreeNode() {
 }
 
 //==============================================================================
-void IntervalTreeNode::print(IntervalTreeNode* nil,
+void IntervalTreeNode::print(IntervalTreeNode* invalid_node,
                              IntervalTreeNode* root) const {
   stored_interval->print();
   std::cout << ", k = " << key << ", h = " << high << ", mH = " << max_high;
   std::cout << "  l->key = ";
-  if (left == nil)
+  if (left == invalid_node)
     std::cout << "nullptr";
   else
     std::cout << left->key;
   std::cout << "  r->key = ";
-  if (right == nil)
+  if (right == invalid_node)
     std::cout << "nullptr";
   else
     std::cout << right->key;


### PR DESCRIPTION
nil is used as macro definition on recent APPLE platforms, as shown by this compilation error: 
```bash
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/MacTypes.h:92:19: note: expanded from macro 'nil'
      #define nil nullptr
```