### PR TITLE
[CI] Turn off ROS2 Rolling to avoid failure

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -14,7 +14,7 @@ jobs:
           - {ROS_DISTRO: noetic}
           - {ROS_DISTRO: iron}
           - {ROS_DISTRO: humble}
-          - {ROS_DISTRO: rolling, PRERELEASE: false}  # 2024-04-02: turn off prerelease until Noble is stable
+          #- {ROS_DISTRO: rolling, PRERELEASE: false}  # 2024-04-02: turn off prerelease until Noble is stable; turned off entirely until eigenpy is available
     env:
       #CCACHE_DIR: /github/home/.ccache # Enable ccache
       BUILDER: colcon

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -14,7 +14,7 @@ jobs:
           - {ROS_DISTRO: noetic}
           - {ROS_DISTRO: iron}
           - {ROS_DISTRO: humble}
-          - {ROS_DISTRO: rolling}
+          - {ROS_DISTRO: rolling, PRERELEASE: false}  # 2024-04-02: turn off prerelease until Noble is stable
     env:
       #CCACHE_DIR: /github/home/.ccache # Enable ccache
       BUILDER: colcon


### PR DESCRIPTION
Since Noble isn't released yet, there are some hickups. Turning off prerelease should work around it for now.