### PR TITLE
ci pip: no py 3.8 on macos arm64 for now

### DIFF
--- a/.github/workflows/macos-linux-pip.yml
+++ b/.github/workflows/macos-linux-pip.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: ["ubuntu", "macos"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: "macos"
+            python-version: "3.8"  # Not available on arm64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Hi,

github runners "macos-latest" are now arm64 machines, and the previous build system for darwin arm was not able to generate python 3.8 builds.

Let's deactivate that for now, until I get some time to publish builds for those.