### PR TITLE
Contact patch: add bvh and hfield

### DIFF
--- a/include/hpp/fcl/collision_data.h
+++ b/include/hpp/fcl/collision_data.h
@@ -894,6 +894,20 @@ struct HPP_FCL_DLLAPI ContactPatchResult {
     return this->m_contact_patches.back();
   }
 
+  /// @brief Getter for the i-th contact patch of the result.
+  ContactPatch& contactPatch(const size_t i) {
+    if (this->m_contact_patches.empty()) {
+      HPP_FCL_THROW_PRETTY(
+          "The number of contact patches is zero. No ContactPatch can be "
+          "returned.",
+          std::invalid_argument);
+    }
+    if (i < this->m_contact_patches.size()) {
+      return this->m_contact_patches[i];
+    }
+    return this->m_contact_patches.back();
+  }
+
   /// @brief Clears the contact patch result.
   void clear() {
     this->m_contact_patches.clear();
@@ -947,6 +961,23 @@ struct HPP_FCL_DLLAPI ContactPatchResult {
     }
 
     return true;
+  }
+
+  /// @brief Repositions the ContactPatch when they get inverted during their
+  /// construction.
+  void swapObjects() {
+    // Create new transform: it's the reflection of `tf` along the z-axis.
+    // This corresponds to doing a PI rotation along the y-axis, i.e. the x-axis
+    // becomes -x-axis, y-axis stays the same, z-axis becomes -z-axis.
+    for (size_t i = 0; i < this->numContactPatches(); ++i) {
+      ContactPatch& patch = this->contactPatch(i);
+      patch.tf.rotation().col(0) *= -1.0;
+      patch.tf.rotation().col(2) *= -1.0;
+
+      for (size_t j = 0; j < patch.size(); ++j) {
+        patch.point(i)(0) *= -1.0;  // only invert the x-axis
+      }
+    }
   }
 };
 

--- a/include/hpp/fcl/contact_patch.h
+++ b/include/hpp/fcl/contact_patch.h
@@ -107,6 +107,7 @@ class HPP_FCL_DLLAPI ComputeContactPatch {
   mutable ContactPatchSolver csolver;
 
   ContactPatchFunctionMatrix::ContactPatchFunc func;
+  bool swap_geoms;
 
   virtual void run(const Transform3f& tf1, const Transform3f& tf2,
                    const CollisionResult& collision_result,

--- a/src/contact_patch.cpp
+++ b/src/contact_patch.cpp
@@ -148,11 +148,13 @@ void ComputeContactPatch::run(const Transform3f& tf1, const Transform3f& tf2,
 
   // Before doing any computation, we initialize and clear the input result.
   result.set(request);
-  this->func(this->o1, tf1, this->o2, tf2, collision_result, &(this->csolver),
-             request, result);
-
   if (this->swap_geoms) {
+    this->func(this->o2, tf2, this->o1, tf1, collision_result, &(this->csolver),
+               request, result);
     result.swapObjects();
+  } else {
+    this->func(this->o1, tf1, this->o2, tf2, collision_result, &(this->csolver),
+               request, result);
   }
 }
 

--- a/src/contact_patch.cpp
+++ b/src/contact_patch.cpp
@@ -55,26 +55,34 @@ void computeContactPatch(const CollisionGeometry* o1, const Transform3f& tf1,
     return;
   }
 
+  // Before doing any computation, we initialize and clear the input result.
+  result.set(request);
+  ContactPatchSolver csolver(request);
+
   OBJECT_TYPE object_type1 = o1->getObjectType();
   OBJECT_TYPE object_type2 = o2->getObjectType();
   NODE_TYPE node_type1 = o1->getNodeType();
   NODE_TYPE node_type2 = o2->getNodeType();
-  // TODO(louis): add support for BVH (leaf is a triangle) and Hfield (leaf is a
-  // convex)
-  if (object_type1 != OBJECT_TYPE::OT_GEOM ||
-      object_type2 != OBJECT_TYPE::OT_GEOM) {
-    HPP_FCL_THROW_PRETTY("Computing contact patches between node type "
-                             << std::string(get_node_type_name(node_type1))
-                             << " and node type "
-                             << std::string(get_node_type_name(node_type2))
-                             << " is not yet supported. Only primitive shapes "
-                                "are supported for now.",
-                         std::invalid_argument);
-    return;
-  }
 
   const ContactPatchFunctionMatrix& looktable =
       getContactPatchFunctionLookTable();
+
+  if (object_type1 == OT_GEOM &&
+      (object_type2 == OT_BVH || object_type2 == OT_HFIELD)) {
+    if (!looktable.contact_patch_matrix[node_type2][node_type1]) {
+      HPP_FCL_THROW_PRETTY("Computing contact patches between node type "
+                               << std::string(get_node_type_name(node_type1))
+                               << " and node type "
+                               << std::string(get_node_type_name(node_type2))
+                               << " is not yet supported.",
+                           std::invalid_argument);
+    }
+    looktable.contact_patch_matrix[node_type2][node_type1](
+        o2, tf2, o1, tf1, collision_result, &csolver, request, result);
+    result.swapObjects();
+    return;
+  }
+
   if (!looktable.contact_patch_matrix[node_type1][node_type2]) {
     HPP_FCL_THROW_PRETTY("Contact patch computation between node type "
                              << std::string(get_node_type_name(node_type1))
@@ -84,9 +92,6 @@ void computeContactPatch(const CollisionGeometry* o1, const Transform3f& tf1,
                          std::invalid_argument);
   }
 
-  // Before doing any computation, we initialize and clear the input result.
-  result.set(request);
-  ContactPatchSolver csolver(request);
   return looktable.contact_patch_matrix[node_type1][node_type2](
       o1, tf1, o2, tf2, collision_result, &csolver, request, result);
 }
@@ -111,19 +116,13 @@ ComputeContactPatch::ComputeContactPatch(const CollisionGeometry* o1,
   OBJECT_TYPE object_type2 = this->o2->getObjectType();
   NODE_TYPE node_type2 = this->o2->getNodeType();
 
-  if (object_type1 != OBJECT_TYPE::OT_GEOM ||
-      object_type2 != OBJECT_TYPE::OT_GEOM) {
-    HPP_FCL_THROW_PRETTY("Computing contact patches between node type "
-                             << std::string(get_node_type_name(node_type1))
-                             << " and node type "
-                             << std::string(get_node_type_name(node_type2))
-                             << " is not yet supported. Only primitive shapes "
-                                "are supported for now.",
-                         std::invalid_argument);
-  }
-
-  if (!looktable.contact_patch_matrix[node_type1][node_type2]) {
-    HPP_FCL_THROW_PRETTY("Contact patch computation between node type "
+  this->swap_geoms = object_type1 == OT_GEOM &&
+                     (object_type2 == OT_BVH || object_type2 == OT_HFIELD);
+  if ((this->swap_geoms &&
+       !looktable.contact_patch_matrix[node_type2][node_type1]) ||
+      (!this->swap_geoms &&
+       !looktable.contact_patch_matrix[node_type1][node_type2])) {
+    HPP_FCL_THROW_PRETTY("Collision function between node type "
                              << std::string(get_node_type_name(node_type1))
                              << " and node type "
                              << std::string(get_node_type_name(node_type2))
@@ -131,7 +130,11 @@ ComputeContactPatch::ComputeContactPatch(const CollisionGeometry* o1,
                          std::invalid_argument);
   }
 
-  this->func = looktable.contact_patch_matrix[node_type1][node_type2];
+  if (this->swap_geoms) {
+    this->func = looktable.contact_patch_matrix[node_type2][node_type1];
+  } else {
+    this->func = looktable.contact_patch_matrix[node_type1][node_type2];
+  }
 }
 
 void ComputeContactPatch::run(const Transform3f& tf1, const Transform3f& tf2,
@@ -147,6 +150,10 @@ void ComputeContactPatch::run(const Transform3f& tf1, const Transform3f& tf2,
   result.set(request);
   this->func(this->o1, tf1, this->o2, tf2, collision_result, &(this->csolver),
              request, result);
+
+  if (this->swap_geoms) {
+    result.swapObjects();
+  }
 }
 
 void ComputeContactPatch::operator()(const Transform3f& tf1,

--- a/src/contact_patch_func_matrix.cpp
+++ b/src/contact_patch_func_matrix.cpp
@@ -44,7 +44,7 @@ namespace hpp {
 namespace fcl {
 
 template <typename T_BVH, typename T_SH>
-struct HPP_FCL_LOCAL BVHShapeComputeContactPatch {
+struct BVHShapeComputeContactPatch {
   static void run(const CollisionGeometry* o1, const Transform3f& tf1,
                   const CollisionGeometry* o2, const Transform3f& tf2,
                   const CollisionResult& collision_result,
@@ -69,7 +69,7 @@ struct HPP_FCL_LOCAL BVHShapeComputeContactPatch {
 };
 
 template <typename BV, typename Shape>
-struct HPP_FCL_LOCAL HeightFieldShapeComputeContactPatch {
+struct HeightFieldShapeComputeContactPatch {
   static void run(const CollisionGeometry* o1, const Transform3f& tf1,
                   const CollisionGeometry* o2, const Transform3f& tf2,
                   const CollisionResult& collision_result,
@@ -94,7 +94,7 @@ struct HPP_FCL_LOCAL HeightFieldShapeComputeContactPatch {
 };
 
 template <typename BV>
-struct HPP_FCL_LOCAL BVHComputeContactPatch {
+struct BVHComputeContactPatch {
   static void run(const CollisionGeometry* o1, const Transform3f& tf1,
                   const CollisionGeometry* o2, const Transform3f& tf2,
                   const CollisionResult& collision_result,

--- a/src/contact_patch_func_matrix.cpp
+++ b/src/contact_patch_func_matrix.cpp
@@ -38,8 +38,85 @@
 #include "hpp/fcl/shape/geometric_shapes.h"
 #include "hpp/fcl/internal/shape_shape_contact_patch_func.h"
 
+#include "hpp/fcl/BV/BV.h"
+
 namespace hpp {
 namespace fcl {
+
+template <typename T_BVH, typename T_SH>
+struct HPP_FCL_LOCAL BVHShapeComputeContactPatch {
+  static void run(const CollisionGeometry* o1, const Transform3f& tf1,
+                  const CollisionGeometry* o2, const Transform3f& tf2,
+                  const CollisionResult& collision_result,
+                  const ContactPatchSolver* csolver,
+                  const ContactPatchRequest& request,
+                  ContactPatchResult& result) {
+    HPP_FCL_UNUSED_VARIABLE(o1);
+    HPP_FCL_UNUSED_VARIABLE(tf1);
+    HPP_FCL_UNUSED_VARIABLE(o2);
+    HPP_FCL_UNUSED_VARIABLE(tf2);
+    HPP_FCL_UNUSED_VARIABLE(csolver);
+    for (size_t i = 0; i < collision_result.numContacts(); ++i) {
+      if (i >= request.max_num_patch) {
+        break;
+      }
+      const Contact& contact = collision_result.getContact(i);
+      ContactPatch& contact_patch = result.getUnusedContactPatch();
+      constructContactPatchFrameFromContact(contact, contact_patch);
+      contact_patch.addPoint(contact.pos);
+    }
+  }
+};
+
+template <typename BV, typename Shape>
+struct HPP_FCL_LOCAL HeightFieldShapeComputeContactPatch {
+  static void run(const CollisionGeometry* o1, const Transform3f& tf1,
+                  const CollisionGeometry* o2, const Transform3f& tf2,
+                  const CollisionResult& collision_result,
+                  const ContactPatchSolver* csolver,
+                  const ContactPatchRequest& request,
+                  ContactPatchResult& result) {
+    HPP_FCL_UNUSED_VARIABLE(o1);
+    HPP_FCL_UNUSED_VARIABLE(tf1);
+    HPP_FCL_UNUSED_VARIABLE(o2);
+    HPP_FCL_UNUSED_VARIABLE(tf2);
+    HPP_FCL_UNUSED_VARIABLE(csolver);
+    for (size_t i = 0; i < collision_result.numContacts(); ++i) {
+      if (i >= request.max_num_patch) {
+        break;
+      }
+      const Contact& contact = collision_result.getContact(i);
+      ContactPatch& contact_patch = result.getUnusedContactPatch();
+      constructContactPatchFrameFromContact(contact, contact_patch);
+      contact_patch.addPoint(contact.pos);
+    }
+  }
+};
+
+template <typename BV>
+struct HPP_FCL_LOCAL BVHComputeContactPatch {
+  static void run(const CollisionGeometry* o1, const Transform3f& tf1,
+                  const CollisionGeometry* o2, const Transform3f& tf2,
+                  const CollisionResult& collision_result,
+                  const ContactPatchSolver* csolver,
+                  const ContactPatchRequest& request,
+                  ContactPatchResult& result) {
+    HPP_FCL_UNUSED_VARIABLE(o1);
+    HPP_FCL_UNUSED_VARIABLE(tf1);
+    HPP_FCL_UNUSED_VARIABLE(o2);
+    HPP_FCL_UNUSED_VARIABLE(tf2);
+    HPP_FCL_UNUSED_VARIABLE(csolver);
+    for (size_t i = 0; i < collision_result.numContacts(); ++i) {
+      if (i >= request.max_num_patch) {
+        break;
+      }
+      const Contact& contact = collision_result.getContact(i);
+      ContactPatch& contact_patch = result.getUnusedContactPatch();
+      constructContactPatchFrameFromContact(contact, contact_patch);
+      contact_patch.addPoint(contact.pos);
+    }
+  }
+};
 
 ContactPatchFunctionMatrix::ContactPatchFunctionMatrix() {
   for (int i = 0; i < NODE_COUNT; ++i) {
@@ -156,6 +233,120 @@ ContactPatchFunctionMatrix::ContactPatchFunctionMatrix() {
   contact_patch_matrix[GEOM_TRIANGLE][GEOM_HALFSPACE]  = &ShapeShapeContactPatch<TriangleP, Halfspace>;
   contact_patch_matrix[GEOM_TRIANGLE][GEOM_ELLIPSOID]  = &ShapeShapeContactPatch<TriangleP, Ellipsoid>;
   contact_patch_matrix[GEOM_TRIANGLE][GEOM_TRIANGLE]   = &ShapeShapeContactPatch<TriangleP, TriangleP>;
+
+  // TODO(louis): properly handle non-convex shapes like BVH, Octrees and Hfields.
+  // The following functions work. However apart from the contact frame, these functions don't
+  // compute more information than a call to `collide`.
+  contact_patch_matrix[BV_AABB][GEOM_BOX]         = &BVHShapeComputeContactPatch<AABB, Box>::run;
+  contact_patch_matrix[BV_AABB][GEOM_SPHERE]      = &BVHShapeComputeContactPatch<AABB, Sphere>::run;
+  contact_patch_matrix[BV_AABB][GEOM_CAPSULE]     = &BVHShapeComputeContactPatch<AABB, Capsule>::run;
+  contact_patch_matrix[BV_AABB][GEOM_CONE]        = &BVHShapeComputeContactPatch<AABB, Cone>::run;
+  contact_patch_matrix[BV_AABB][GEOM_CYLINDER]    = &BVHShapeComputeContactPatch<AABB, Cylinder>::run;
+  contact_patch_matrix[BV_AABB][GEOM_CONVEX]      = &BVHShapeComputeContactPatch<AABB, ConvexBase>::run;
+  contact_patch_matrix[BV_AABB][GEOM_PLANE]       = &BVHShapeComputeContactPatch<AABB, Plane>::run;
+  contact_patch_matrix[BV_AABB][GEOM_HALFSPACE]   = &BVHShapeComputeContactPatch<AABB, Halfspace>::run;
+  contact_patch_matrix[BV_AABB][GEOM_ELLIPSOID]   = &BVHShapeComputeContactPatch<AABB, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_OBB][GEOM_BOX]          = &BVHShapeComputeContactPatch<OBB, Box>::run;
+  contact_patch_matrix[BV_OBB][GEOM_SPHERE]       = &BVHShapeComputeContactPatch<OBB, Sphere>::run;
+  contact_patch_matrix[BV_OBB][GEOM_CAPSULE]      = &BVHShapeComputeContactPatch<OBB, Capsule>::run;
+  contact_patch_matrix[BV_OBB][GEOM_CONE]         = &BVHShapeComputeContactPatch<OBB, Cone>::run;
+  contact_patch_matrix[BV_OBB][GEOM_CYLINDER]     = &BVHShapeComputeContactPatch<OBB, Cylinder>::run;
+  contact_patch_matrix[BV_OBB][GEOM_CONVEX]       = &BVHShapeComputeContactPatch<OBB, ConvexBase>::run;
+  contact_patch_matrix[BV_OBB][GEOM_PLANE]        = &BVHShapeComputeContactPatch<OBB, Plane>::run;
+  contact_patch_matrix[BV_OBB][GEOM_HALFSPACE]    = &BVHShapeComputeContactPatch<OBB, Halfspace>::run;
+  contact_patch_matrix[BV_OBB][GEOM_ELLIPSOID]    = &BVHShapeComputeContactPatch<OBB, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_RSS][GEOM_BOX]          = &BVHShapeComputeContactPatch<RSS, Box>::run;
+  contact_patch_matrix[BV_RSS][GEOM_SPHERE]       = &BVHShapeComputeContactPatch<RSS, Sphere>::run;
+  contact_patch_matrix[BV_RSS][GEOM_CAPSULE]      = &BVHShapeComputeContactPatch<RSS, Capsule>::run;
+  contact_patch_matrix[BV_RSS][GEOM_CONE]         = &BVHShapeComputeContactPatch<RSS, Cone>::run;
+  contact_patch_matrix[BV_RSS][GEOM_CYLINDER]     = &BVHShapeComputeContactPatch<RSS, Cylinder>::run;
+  contact_patch_matrix[BV_RSS][GEOM_CONVEX]       = &BVHShapeComputeContactPatch<RSS, ConvexBase>::run;
+  contact_patch_matrix[BV_RSS][GEOM_PLANE]        = &BVHShapeComputeContactPatch<RSS, Plane>::run;
+  contact_patch_matrix[BV_RSS][GEOM_HALFSPACE]    = &BVHShapeComputeContactPatch<RSS, Halfspace>::run;
+  contact_patch_matrix[BV_RSS][GEOM_ELLIPSOID]    = &BVHShapeComputeContactPatch<RSS, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_KDOP16][GEOM_BOX]       = &BVHShapeComputeContactPatch<KDOP<16>, Box>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_SPHERE]    = &BVHShapeComputeContactPatch<KDOP<16>, Sphere>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_CAPSULE]   = &BVHShapeComputeContactPatch<KDOP<16>, Capsule>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_CONE]      = &BVHShapeComputeContactPatch<KDOP<16>, Cone>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_CYLINDER]  = &BVHShapeComputeContactPatch<KDOP<16>, Cylinder>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_CONVEX]    = &BVHShapeComputeContactPatch<KDOP<16>, ConvexBase>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_PLANE]     = &BVHShapeComputeContactPatch<KDOP<16>, Plane>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_HALFSPACE] = &BVHShapeComputeContactPatch<KDOP<16>, Halfspace>::run;
+  contact_patch_matrix[BV_KDOP16][GEOM_ELLIPSOID] = &BVHShapeComputeContactPatch<KDOP<16>, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_KDOP18][GEOM_BOX]       = &BVHShapeComputeContactPatch<KDOP<18>, Box>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_SPHERE]    = &BVHShapeComputeContactPatch<KDOP<18>, Sphere>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_CAPSULE]   = &BVHShapeComputeContactPatch<KDOP<18>, Capsule>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_CONE]      = &BVHShapeComputeContactPatch<KDOP<18>, Cone>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_CYLINDER]  = &BVHShapeComputeContactPatch<KDOP<18>, Cylinder>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_CONVEX]    = &BVHShapeComputeContactPatch<KDOP<18>, ConvexBase>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_PLANE]     = &BVHShapeComputeContactPatch<KDOP<18>, Plane>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_HALFSPACE] = &BVHShapeComputeContactPatch<KDOP<18>, Halfspace>::run;
+  contact_patch_matrix[BV_KDOP18][GEOM_ELLIPSOID] = &BVHShapeComputeContactPatch<KDOP<18>, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_KDOP24][GEOM_BOX]       = &BVHShapeComputeContactPatch<KDOP<24>, Box>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_SPHERE]    = &BVHShapeComputeContactPatch<KDOP<24>, Sphere>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_CAPSULE]   = &BVHShapeComputeContactPatch<KDOP<24>, Capsule>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_CONE]      = &BVHShapeComputeContactPatch<KDOP<24>, Cone>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_CYLINDER]  = &BVHShapeComputeContactPatch<KDOP<24>, Cylinder>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_CONVEX]    = &BVHShapeComputeContactPatch<KDOP<24>, ConvexBase>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_PLANE]     = &BVHShapeComputeContactPatch<KDOP<24>, Plane>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_HALFSPACE] = &BVHShapeComputeContactPatch<KDOP<24>, Halfspace>::run;
+  contact_patch_matrix[BV_KDOP24][GEOM_ELLIPSOID] = &BVHShapeComputeContactPatch<KDOP<24>, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_kIOS][GEOM_BOX]         = &BVHShapeComputeContactPatch<kIOS, Box>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_SPHERE]      = &BVHShapeComputeContactPatch<kIOS, Sphere>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_CAPSULE]     = &BVHShapeComputeContactPatch<kIOS, Capsule>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_CONE]        = &BVHShapeComputeContactPatch<kIOS, Cone>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_CYLINDER]    = &BVHShapeComputeContactPatch<kIOS, Cylinder>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_CONVEX]      = &BVHShapeComputeContactPatch<kIOS, ConvexBase>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_PLANE]       = &BVHShapeComputeContactPatch<kIOS, Plane>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_HALFSPACE]   = &BVHShapeComputeContactPatch<kIOS, Halfspace>::run;
+  contact_patch_matrix[BV_kIOS][GEOM_ELLIPSOID]   = &BVHShapeComputeContactPatch<kIOS, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_OBBRSS][GEOM_BOX]       = &BVHShapeComputeContactPatch<OBBRSS, Box>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_SPHERE]    = &BVHShapeComputeContactPatch<OBBRSS, Sphere>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_CAPSULE]   = &BVHShapeComputeContactPatch<OBBRSS, Capsule>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_CONE]      = &BVHShapeComputeContactPatch<OBBRSS, Cone>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_CYLINDER]  = &BVHShapeComputeContactPatch<OBBRSS, Cylinder>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_CONVEX]    = &BVHShapeComputeContactPatch<OBBRSS, ConvexBase>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_PLANE]     = &BVHShapeComputeContactPatch<OBBRSS, Plane>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_HALFSPACE] = &BVHShapeComputeContactPatch<OBBRSS, Halfspace>::run;
+  contact_patch_matrix[BV_OBBRSS][GEOM_ELLIPSOID] = &BVHShapeComputeContactPatch<OBBRSS, Ellipsoid>::run;
+
+  contact_patch_matrix[HF_AABB][GEOM_BOX]         = &HeightFieldShapeComputeContactPatch<AABB, Box>::run;
+  contact_patch_matrix[HF_AABB][GEOM_SPHERE]      = &HeightFieldShapeComputeContactPatch<AABB, Sphere>::run;
+  contact_patch_matrix[HF_AABB][GEOM_CAPSULE]     = &HeightFieldShapeComputeContactPatch<AABB, Capsule>::run;
+  contact_patch_matrix[HF_AABB][GEOM_CONE]        = &HeightFieldShapeComputeContactPatch<AABB, Cone>::run;
+  contact_patch_matrix[HF_AABB][GEOM_CYLINDER]    = &HeightFieldShapeComputeContactPatch<AABB, Cylinder>::run;
+  contact_patch_matrix[HF_AABB][GEOM_CONVEX]      = &HeightFieldShapeComputeContactPatch<AABB, ConvexBase>::run;
+  contact_patch_matrix[HF_AABB][GEOM_PLANE]       = &HeightFieldShapeComputeContactPatch<AABB, Plane>::run;
+  contact_patch_matrix[HF_AABB][GEOM_HALFSPACE]   = &HeightFieldShapeComputeContactPatch<AABB, Halfspace>::run;
+  contact_patch_matrix[HF_AABB][GEOM_ELLIPSOID]   = &HeightFieldShapeComputeContactPatch<AABB, Ellipsoid>::run;
+
+  contact_patch_matrix[HF_OBBRSS][GEOM_BOX]       = &HeightFieldShapeComputeContactPatch<OBBRSS, Box>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_SPHERE]    = &HeightFieldShapeComputeContactPatch<OBBRSS, Sphere>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_CAPSULE]   = &HeightFieldShapeComputeContactPatch<OBBRSS, Capsule>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_CONE]      = &HeightFieldShapeComputeContactPatch<OBBRSS, Cone>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_CYLINDER]  = &HeightFieldShapeComputeContactPatch<OBBRSS, Cylinder>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_CONVEX]    = &HeightFieldShapeComputeContactPatch<OBBRSS, ConvexBase>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_PLANE]     = &HeightFieldShapeComputeContactPatch<OBBRSS, Plane>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_HALFSPACE] = &HeightFieldShapeComputeContactPatch<OBBRSS, Halfspace>::run;
+  contact_patch_matrix[HF_OBBRSS][GEOM_ELLIPSOID] = &HeightFieldShapeComputeContactPatch<OBBRSS, Ellipsoid>::run;
+
+  contact_patch_matrix[BV_AABB][BV_AABB]          = &BVHComputeContactPatch<AABB>::run;
+  contact_patch_matrix[BV_OBB][BV_OBB]            = &BVHComputeContactPatch<OBB>::run;
+  contact_patch_matrix[BV_RSS][BV_RSS]            = &BVHComputeContactPatch<RSS>::run;
+  contact_patch_matrix[BV_KDOP16][BV_KDOP16]      = &BVHComputeContactPatch<KDOP<16>>::run;
+  contact_patch_matrix[BV_KDOP18][BV_KDOP18]      = &BVHComputeContactPatch<KDOP<18>>::run;
+  contact_patch_matrix[BV_KDOP24][BV_KDOP24]      = &BVHComputeContactPatch<KDOP<24>>::run;
+  contact_patch_matrix[BV_kIOS][BV_kIOS]          = &BVHComputeContactPatch<kIOS>::run;
+  contact_patch_matrix[BV_OBBRSS][BV_OBBRSS]      = &BVHComputeContactPatch<OBBRSS>::run;
+
+  // TODO(louis): octrees
   // clang-format on
 }
 


### PR DESCRIPTION
In the future, we might want to compute bvh and fields contact patch in a more satisfying way. For now this PR simply removes the throw due to BVH-BVH, BVH-Shape, Hfield-Shape contact patches.