### PR TITLE
Switch to the system dependency for octomap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix compilation warning message
 - Fix issue in Octomap.computeLocalAABB
 - Fix unsupported function for contact_patch_matrix
+- Fix Octomap dependency on ROS
 
 ## [2.4.4] - 2024-03-06
 

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>assimp</depend>
-  <depend>octomap</depend>
+  <depend>liboctomap-dev</depend>
   <depend>eigenpy</depend>
 
   <!-- The following tag is recommended by REP-136 -->


### PR DESCRIPTION
This ensures that we have a consistent ABI between this package that uses octomap, and anything else in the system that might use it.  We'll eventually be remove the octomap that we currently have vendored within ROS itself so we can ensure this.

This was enabled by the merging of https://github.com/ros/rosdistro/pull/41623