### PR TITLE
Fix serialization unit test when running without Qhull support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix Fix serialization unit test when running without Qhull support ([#611](https://github.com/humanoid-path-planner/hpp-fcl/pull/611))
 - Compiler warnings ([#601](https://github.com/humanoid-path-planner/hpp-fcl/pull/601), [#605](https://github.com/humanoid-path-planner/hpp-fcl/pull/605))
 - CMake: fix assimp finder
 - Don't define GCC7 Boost serialization hack when `HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION` is defined ([#530](https://github.com/humanoid-path-planner/hpp-fcl/pull/530))

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -508,6 +508,7 @@ BOOST_AUTO_TEST_CASE(test_shapes) {
     test_serialization(plane, plane_copy);
   }
 
+#ifdef HPP_FCL_HAS_QHULL
   {
     const size_t num_points = 500;
     std::shared_ptr<std::vector<Vec3f>> points =
@@ -526,6 +527,7 @@ BOOST_AUTO_TEST_CASE(test_shapes) {
     Convex convex_copy;
     test_serialization(*convex, convex_copy);
   }
+#endif
 }
 
 #ifdef HPP_FCL_HAS_OCTOMAP


### PR DESCRIPTION
Don't run test on hpp::fcl::Convex without Qhull.

This should fix the ROS CI build.