### PR TITLE
Add tracy profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Add option to switch between (default) double precision and float precision
   - Changed all the uses of `double` to `Scalar` in Coal
   - Fixed all the compilation warnings when compiling the library using float precision
+- Tracy profiling ([#668](https://github.com/coal-library/coal/pull/668))
+  - added cmake option `COAL_BUILD_WITH_TRACY`
+  - put tracy scoped zones in broadphase and primitive shapes collision/distance queries
 
 ## [3.0.1] - 2025-02-12
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,14 +179,6 @@ if(COAL_BUILD_WITH_TRACY)
     Tracy::TracyClient
     PROPERTIES POSITION_INDEPENDENT_CODE True
   )
-  if(${Tracy_FOUND})
-    message(STATUS "Tracy found on your system at ${Tracy_DIR}")
-  else()
-    message(
-      FATAL_ERROR
-      "Coal support for tracy is enabled, but tracy was not found on your system."
-    )
-  endif()
 endif(COAL_BUILD_WITH_TRACY)
 
 if(BUILD_PYTHON_INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ option(
   "Use float precision (32-bit) instead of the default double precision (64-bit)"
   FALSE
 )
+option(
+  COAL_BUILD_WITH_TRACY
+  "Build with tracy profiler for performance analysis"
+  FALSE
+)
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -131,6 +136,7 @@ include("${JRL_CMAKE_MODULES}/boost.cmake")
 include("${JRL_CMAKE_MODULES}/python.cmake")
 include("${JRL_CMAKE_MODULES}/apple.cmake")
 include("${JRL_CMAKE_MODULES}/ide.cmake")
+include("${JRL_CMAKE_MODULES}/tracy.cmake")
 include(CMakeDependentOption)
 
 set(
@@ -164,6 +170,24 @@ cmake_dependent_option(
 )
 
 ADD_PROJECT_DEPENDENCY(Eigen3 REQUIRED PKG_CONFIG_REQUIRES "eigen3 >= 3.0.0")
+
+# -- tracy profiling (optional)
+if(COAL_BUILD_WITH_TRACY)
+  # assume it is installed somewhere
+  ADD_PROJECT_DEPENDENCY(Tracy REQUIRED)
+  set_target_properties(
+    Tracy::TracyClient
+    PROPERTIES POSITION_INDEPENDENT_CODE True
+  )
+  if(${Tracy_FOUND})
+    message(STATUS "Tracy found on your system at ${Tracy_DIR}")
+  else()
+    message(
+      FATAL_ERROR
+      "Coal support for tracy is enabled, but tracy was not found on your system."
+    )
+  endif()
+endif(COAL_BUILD_WITH_TRACY)
 
 if(BUILD_PYTHON_INTERFACE)
   set(PYTHON_COMPONENTS Interpreter Development NumPy)

--- a/include/coal/contact_patch/contact_patch_solver.hxx
+++ b/include/coal/contact_patch/contact_patch_solver.hxx
@@ -40,6 +40,8 @@
 #include "coal/data_types.h"
 #include "coal/shape/geometric_shapes_traits.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 // ============================================================================
@@ -79,6 +81,7 @@ void ContactPatchSolver::computePatch(const ShapeType1& s1,
                                       const Transform3s& tf2,
                                       const Contact& contact,
                                       ContactPatch& contact_patch) const {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ContactPatchSolver::computePatch");
   // Note: `ContactPatch` is an alias for `SupportSet`.
   // Step 1
   constructContactPatchFrameFromContact(contact, contact_patch);

--- a/include/coal/internal/shape_shape_contact_patch_func.h
+++ b/include/coal/internal/shape_shape_contact_patch_func.h
@@ -43,6 +43,8 @@
 #include "coal/contact_patch/contact_patch_solver.h"
 #include "coal/shape/geometric_shapes_traits.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 /// @brief Shape-shape contact patch computation.
@@ -140,6 +142,9 @@ void computePatchPlaneOrHalfspace(const OtherShapeType& s1,
                     const ContactPatchSolver* csolver,                        \
                     const ContactPatchRequest& request,                       \
                     ContactPatchResult& result) {                             \
+      COAL_TRACY_ZONE_SCOPED_N(                                               \
+          "coal::ComputeShapeShapeContactPatch<OtherShapeType, "              \
+          "PlaneOrHspace>::run");                                             \
       if (!collision_result.isCollision()) {                                  \
         return;                                                               \
       }                                                                       \
@@ -174,6 +179,9 @@ void computePatchPlaneOrHalfspace(const OtherShapeType& s1,
                     const ContactPatchSolver* csolver,                        \
                     const ContactPatchRequest& request,                       \
                     ContactPatchResult& result) {                             \
+      COAL_TRACY_ZONE_SCOPED_N(                                               \
+          "coal::ComputeShapeShapeContactPatch<PlaneOrHspace, "               \
+          "OtherShapeType>::run");                                            \
       if (!collision_result.isCollision()) {                                  \
         return;                                                               \
       }                                                                       \
@@ -255,6 +263,7 @@ void ShapeShapeContactPatch(const CollisionGeometry* o1, const Transform3s& tf1,
                             const ContactPatchSolver* csolver,
                             const ContactPatchRequest& request,
                             ContactPatchResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ShapeShapeContactPatch");
   return ComputeShapeShapeContactPatch<ShapeType1, ShapeType2>::run(
       o1, tf1, o2, tf2, collision_result, csolver, request, result);
 }

--- a/include/coal/internal/shape_shape_func.h
+++ b/include/coal/internal/shape_shape_func.h
@@ -45,6 +45,8 @@
 #include "coal/narrowphase/narrowphase.h"
 #include "coal/shape/geometric_shapes_traits.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 template <typename ShapeType1, typename ShapeType2>
@@ -93,6 +95,7 @@ Scalar ShapeShapeDistance(const CollisionGeometry* o1, const Transform3s& tf1,
                           const GJKSolver* nsolver,
                           const DistanceRequest& request,
                           DistanceResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ShapeShapeDistance");
   return ShapeShapeDistancer<ShapeType1, ShapeType2>::run(
       o1, tf1, o2, tf2, nsolver, request, result);
 }
@@ -169,6 +172,7 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
                               const Transform3s& tf2, const GJKSolver* nsolver,
                               const CollisionRequest& request,
                               CollisionResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ShapeShapeCollide");
   return ShapeShapeCollider<ShapeType1, ShapeType2>::run(
       o1, tf1, o2, tf2, nsolver, request, result);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -254,6 +254,11 @@ if(COAL_USE_FLOAT_PRECISION)
   target_compile_definitions(${LIBRARY_NAME} PUBLIC COAL_USE_FLOAT_PRECISION)
 endif()
 
+if(COAL_BUILD_WITH_TRACY)
+  target_compile_definitions(${LIBRARY_NAME} INTERFACE COAL_TRACY_ENABLE)
+  target_link_libraries(${LIBRARY_NAME} INTERFACE Tracy::TracyClient)
+endif()
+
 if(WIN32)
   target_link_libraries(
     ${LIBRARY_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -255,8 +255,8 @@ if(COAL_USE_FLOAT_PRECISION)
 endif()
 
 if(COAL_BUILD_WITH_TRACY)
-  target_compile_definitions(${LIBRARY_NAME} INTERFACE COAL_TRACY_ENABLE)
-  target_link_libraries(${LIBRARY_NAME} INTERFACE Tracy::TracyClient)
+  target_compile_definitions(${LIBRARY_NAME} PUBLIC COAL_TRACY_ENABLE)
+  target_link_libraries(${LIBRARY_NAME} PUBLIC Tracy::TracyClient)
 endif()
 
 if(WIN32)

--- a/src/broadphase/broadphase_SSaP.cpp
+++ b/src/broadphase/broadphase_SSaP.cpp
@@ -36,6 +36,7 @@
 /** @author Jia Pan */
 
 #include "coal/broadphase/broadphase_SSaP.h"
+#include "coal/tracy.hh"
 
 namespace coal {
 
@@ -200,6 +201,9 @@ bool SSaPCollisionManager::checkDis(
 //==============================================================================
 void SSaPCollisionManager::collide(CollisionObject* obj,
                                    CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::collide(CollisionObject*, "
+      "CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -253,6 +257,9 @@ bool SSaPCollisionManager::collide_(CollisionObject* obj,
 //==============================================================================
 void SSaPCollisionManager::distance(CollisionObject* obj,
                                     DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::distance(CollisionObject*, "
+      "DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -400,6 +407,8 @@ int SSaPCollisionManager::selectOptimalAxis(
 
 //==============================================================================
 void SSaPCollisionManager::collide(CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::collide(CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -447,6 +456,8 @@ void SSaPCollisionManager::collide(CollisionCallBackBase* callback) const {
 
 //==============================================================================
 void SSaPCollisionManager::distance(DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::distance(DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -462,6 +473,9 @@ void SSaPCollisionManager::distance(DistanceCallBackBase* callback) const {
 //==============================================================================
 void SSaPCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
                                    CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::collide(BroadPhaseCollisionManager*, "
+      "CollisionCallBackBase*)");
   callback->init();
   SSaPCollisionManager* other_manager =
       static_cast<SSaPCollisionManager*>(other_manager_);
@@ -487,6 +501,9 @@ void SSaPCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
 //==============================================================================
 void SSaPCollisionManager::distance(BroadPhaseCollisionManager* other_manager_,
                                     DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SSaPCollisionManager::distance(BroadPhaseCollisionManager*, "
+      "DistanceCallBackBase*)");
   callback->init();
   SSaPCollisionManager* other_manager =
       static_cast<SSaPCollisionManager*>(other_manager_);

--- a/src/broadphase/broadphase_SaP.cpp
+++ b/src/broadphase/broadphase_SaP.cpp
@@ -36,6 +36,7 @@
 /** @author Jia Pan */
 
 #include "coal/broadphase/broadphase_SaP.h"
+#include "coal/tracy.hh"
 
 namespace coal {
 
@@ -575,6 +576,9 @@ void SaPCollisionManager::removeFromOverlapPairs(const SaPPair& p) {
 //==============================================================================
 void SaPCollisionManager::collide(CollisionObject* obj,
                                   CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::collide(CollisionObject*, "
+      "CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -676,6 +680,9 @@ bool SaPCollisionManager::distance_(CollisionObject* obj,
 //==============================================================================
 void SaPCollisionManager::distance(CollisionObject* obj,
                                    DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::distance(CollisionObject*, "
+      "DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -686,6 +693,8 @@ void SaPCollisionManager::distance(CollisionObject* obj,
 
 //==============================================================================
 void SaPCollisionManager::collide(CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::collide(CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -700,6 +709,8 @@ void SaPCollisionManager::collide(CollisionCallBackBase* callback) const {
 
 //==============================================================================
 void SaPCollisionManager::distance(DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::distance(DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -719,6 +730,9 @@ void SaPCollisionManager::distance(DistanceCallBackBase* callback) const {
 //==============================================================================
 void SaPCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
                                   CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::collide(BroadPhaseCollisionManager*, "
+      "CollisionCallBackBase*)");
   callback->init();
   SaPCollisionManager* other_manager =
       static_cast<SaPCollisionManager*>(other_manager_);
@@ -746,6 +760,9 @@ void SaPCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
 //==============================================================================
 void SaPCollisionManager::distance(BroadPhaseCollisionManager* other_manager_,
                                    DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::SaPCollisionManager::distance(BroadPhaseCollisionManager*, "
+      "DistanceCallBackBase*)");
   callback->init();
   SaPCollisionManager* other_manager =
       static_cast<SaPCollisionManager*>(other_manager_);

--- a/src/broadphase/broadphase_bruteforce.cpp
+++ b/src/broadphase/broadphase_bruteforce.cpp
@@ -39,6 +39,7 @@
 
 #include <iterator>
 #include <algorithm>
+#include "coal/tracy.hh"
 
 namespace coal {
 
@@ -86,6 +87,9 @@ void NaiveCollisionManager::getObjects(
 //==============================================================================
 void NaiveCollisionManager::collide(CollisionObject* obj,
                                     CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::collide(CollisionObject*, "
+      "CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -97,6 +101,9 @@ void NaiveCollisionManager::collide(CollisionObject* obj,
 //==============================================================================
 void NaiveCollisionManager::distance(CollisionObject* obj,
                                      DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::distance(CollisionObject*, "
+      "DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -110,6 +117,8 @@ void NaiveCollisionManager::distance(CollisionObject* obj,
 
 //==============================================================================
 void NaiveCollisionManager::collide(CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::collide(CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -128,6 +137,8 @@ void NaiveCollisionManager::collide(CollisionCallBackBase* callback) const {
 
 //==============================================================================
 void NaiveCollisionManager::distance(DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::distance(CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
 
@@ -148,6 +159,9 @@ void NaiveCollisionManager::distance(DistanceCallBackBase* callback) const {
 //==============================================================================
 void NaiveCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
                                     CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::collide(BroadPhaseCollisionManager*, "
+      "CollisionCallBackBase*)");
   callback->init();
   NaiveCollisionManager* other_manager =
       static_cast<NaiveCollisionManager*>(other_manager_);
@@ -171,6 +185,9 @@ void NaiveCollisionManager::collide(BroadPhaseCollisionManager* other_manager_,
 //==============================================================================
 void NaiveCollisionManager::distance(BroadPhaseCollisionManager* other_manager_,
                                      DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::NaiveCollisionManager::distance(BroadPhaseCollisionManager*, "
+      "DistanceCallBackBase*)");
   callback->init();
   NaiveCollisionManager* other_manager =
       static_cast<NaiveCollisionManager*>(other_manager_);

--- a/src/broadphase/broadphase_dynamic_AABB_tree.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree.cpp
@@ -36,6 +36,7 @@
 /** @author Jia Pan */
 
 #include "coal/broadphase/broadphase_dynamic_AABB_tree.h"
+#include "coal/tracy.hh"
 
 #ifdef COAL_HAVE_OCTOMAP
 #include "coal/octree.h"
@@ -663,6 +664,9 @@ void DynamicAABBTreeCollisionManager::getObjects(
 //==============================================================================
 void DynamicAABBTreeCollisionManager::collide(
     CollisionObject* obj, CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::collide(CollisionObject*, "
+      "CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
   switch (obj->collisionGeometry()->getNodeType()) {
@@ -688,6 +692,9 @@ void DynamicAABBTreeCollisionManager::collide(
 //==============================================================================
 void DynamicAABBTreeCollisionManager::distance(
     CollisionObject* obj, DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::distance(CollisionObject*, "
+      "DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
   Scalar min_dist = (std::numeric_limits<Scalar>::max)();
@@ -714,6 +721,8 @@ void DynamicAABBTreeCollisionManager::distance(
 //==============================================================================
 void DynamicAABBTreeCollisionManager::collide(
     CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::collide(CollisionCallBackBase*)");
   callback->init();
   if (size() == 0) return;
   detail::dynamic_AABB_tree::selfCollisionRecurse(dtree.getRoot(), callback);
@@ -722,6 +731,8 @@ void DynamicAABBTreeCollisionManager::collide(
 //==============================================================================
 void DynamicAABBTreeCollisionManager::distance(
     DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::distance(DistanceCallBackBase*)");
   callback->init();
   if (size() == 0) return;
   Scalar min_dist = (std::numeric_limits<Scalar>::max)();
@@ -733,6 +744,9 @@ void DynamicAABBTreeCollisionManager::distance(
 void DynamicAABBTreeCollisionManager::collide(
     BroadPhaseCollisionManager* other_manager_,
     CollisionCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::collide("
+      "BroadPhaseCollisionManager*, CollisionCallBackBase*)");
   callback->init();
   DynamicAABBTreeCollisionManager* other_manager =
       static_cast<DynamicAABBTreeCollisionManager*>(other_manager_);
@@ -745,6 +759,9 @@ void DynamicAABBTreeCollisionManager::collide(
 void DynamicAABBTreeCollisionManager::distance(
     BroadPhaseCollisionManager* other_manager_,
     DistanceCallBackBase* callback) const {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::DynamicAABBTreeCollisionManager::distance("
+      "BroadPhaseCollisionManager*, DistanceCallBackBase*)");
   callback->init();
   DynamicAABBTreeCollisionManager* other_manager =
       static_cast<DynamicAABBTreeCollisionManager*>(other_manager_);

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -40,6 +40,8 @@
 #include "coal/collision_func_matrix.h"
 #include "coal/narrowphase/narrowphase.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 CollisionFunctionMatrix& getCollisionFunctionLookTable() {
@@ -68,6 +70,7 @@ std::size_t collide(const CollisionObject* o1, const CollisionObject* o2,
 std::size_t collide(const CollisionGeometry* o1, const Transform3s& tf1,
                     const CollisionGeometry* o2, const Transform3s& tf2,
                     const CollisionRequest& request, CollisionResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::collide");
   // If security margin is set to -infinity, return that there is no collision
   if (request.security_margin == -std::numeric_limits<Scalar>::infinity()) {
     result.clear();
@@ -160,6 +163,7 @@ std::size_t ComputeCollision::run(const Transform3s& tf1,
                                   const Transform3s& tf2,
                                   const CollisionRequest& request,
                                   CollisionResult& result) const {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ComputeCollision::run");
   // If security margin is set to -infinity, return that there is no collision
   if (request.security_margin == -std::numeric_limits<Scalar>::infinity()) {
     result.clear();

--- a/src/contact_patch.cpp
+++ b/src/contact_patch.cpp
@@ -37,6 +37,8 @@
 #include "coal/contact_patch.h"
 #include "coal/collision_utility.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 ContactPatchFunctionMatrix& getContactPatchFunctionLookTable() {
@@ -49,6 +51,7 @@ void computeContactPatch(const CollisionGeometry* o1, const Transform3s& tf1,
                          const CollisionResult& collision_result,
                          const ContactPatchRequest& request,
                          ContactPatchResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::computeContactPatch");
   if (!collision_result.isCollision() || request.max_num_patch == 0) {
     // do nothing
     return;
@@ -140,6 +143,7 @@ void ComputeContactPatch::run(const Transform3s& tf1, const Transform3s& tf2,
                               const CollisionResult& collision_result,
                               const ContactPatchRequest& request,
                               ContactPatchResult& result) const {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ComputeContactPatch::run");
   if (!collision_result.isCollision() || request.max_num_patch == 0) {
     // do nothing
     return;

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -40,6 +40,7 @@
 #include "coal/distance_func_matrix.h"
 #include "coal/narrowphase/narrowphase.h"
 
+#include "coal/tracy.hh"
 
 namespace coal {
 
@@ -58,6 +59,7 @@ Scalar distance(const CollisionObject* o1, const CollisionObject* o2,
 Scalar distance(const CollisionGeometry* o1, const Transform3s& tf1,
                 const CollisionGeometry* o2, const Transform3s& tf2,
                 const DistanceRequest& request, DistanceResult& result) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::distance");
   GJKSolver solver(request);
 
   const DistanceFunctionMatrix& looktable = getDistanceFunctionLookTable();
@@ -137,6 +139,7 @@ ComputeDistance::ComputeDistance(const CollisionGeometry* o1,
 Scalar ComputeDistance::run(const Transform3s& tf1, const Transform3s& tf2,
                             const DistanceRequest& request,
                             DistanceResult& result) const {
+  COAL_TRACY_ZONE_SCOPED_N("coal::ComputeDistance::run");
   Scalar res;
 
   if (swap_geoms) {

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -40,7 +40,6 @@
 #include "coal/distance_func_matrix.h"
 #include "coal/narrowphase/narrowphase.h"
 
-#include <iostream>
 
 namespace coal {
 

--- a/src/distance/box_halfspace.cpp
+++ b/src/distance/box_halfspace.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -54,6 +56,8 @@ Scalar ShapeShapeDistance<Box, Halfspace>(const CollisionGeometry* o1,
                                           const Transform3s& tf2,
                                           const GJKSolver*, const bool,
                                           Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Box, Halfspace>");
   const Box& s1 = static_cast<const Box&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -69,6 +73,8 @@ Scalar ShapeShapeDistance<Halfspace, Box>(const CollisionGeometry* o1,
                                           const Transform3s& tf2,
                                           const GJKSolver*, const bool,
                                           Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Box>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Box& s2 = static_cast<const Box&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/box_plane.cpp
+++ b/src/distance/box_plane.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -53,6 +55,7 @@ Scalar ShapeShapeDistance<Box, Plane>(const CollisionGeometry* o1,
                                       const Transform3s& tf2, const GJKSolver*,
                                       const bool, Vec3s& p1, Vec3s& p2,
                                       Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Box, Plane>");
   const Box& s1 = static_cast<const Box&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -68,6 +71,7 @@ Scalar ShapeShapeDistance<Plane, Box>(const CollisionGeometry* o1,
                                       const Transform3s& tf2, const GJKSolver*,
                                       const bool, Vec3s& p1, Vec3s& p2,
                                       Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Plane, Box>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Box& s2 = static_cast<const Box&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/box_sphere.cpp
+++ b/src/distance/box_sphere.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -53,6 +55,7 @@ Scalar ShapeShapeDistance<Box, Sphere>(const CollisionGeometry* o1,
                                        const Transform3s& tf2, const GJKSolver*,
                                        const bool, Vec3s& p1, Vec3s& p2,
                                        Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Box, Sphere>");
   const Box& s1 = static_cast<const Box&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   return details::boxSphereDistance(s1, tf1, s2, tf2, p1, p2, normal);
@@ -65,6 +68,7 @@ Scalar ShapeShapeDistance<Sphere, Box>(const CollisionGeometry* o1,
                                        const Transform3s& tf2, const GJKSolver*,
                                        const bool, Vec3s& p1, Vec3s& p2,
                                        Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Sphere, Box>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Box& s2 = static_cast<const Box&>(*o2);
   const Scalar distance =

--- a/src/distance/capsule_capsule.cpp
+++ b/src/distance/capsule_capsule.cpp
@@ -35,6 +35,8 @@
 #include "coal/shape/geometric_shapes.h"
 #include "coal/internal/shape_shape_func.h"
 
+#include "coal/tracy.hh"
+
 // Note that partial specialization of template functions is not allowed.
 // Therefore, two implementations with the default narrow phase solvers are
 // provided. If another narrow phase solver were to be used, the default
@@ -81,6 +83,8 @@ Scalar ShapeShapeDistance<Capsule, Capsule>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& wp1, Vec3s& wp2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Capsule, Capsule>");
   const Capsule* capsule1 = static_cast<const Capsule*>(o1);
   const Capsule* capsule2 = static_cast<const Capsule*>(o2);
 

--- a/src/distance/capsule_halfspace.cpp
+++ b/src/distance/capsule_halfspace.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Capsule, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Capsule, Halfspace>");
   const Capsule& s1 = static_cast<const Capsule&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -64,6 +68,8 @@ Scalar ShapeShapeDistance<Halfspace, Capsule>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Capsule>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Capsule& s2 = static_cast<const Capsule&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/capsule_plane.cpp
+++ b/src/distance/capsule_plane.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -53,6 +55,8 @@ Scalar ShapeShapeDistance<Capsule, Plane>(const CollisionGeometry* o1,
                                           const Transform3s& tf2,
                                           const GJKSolver*, const bool,
                                           Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Capsule, Plane>");
   const Capsule& s1 = static_cast<const Capsule&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -68,6 +72,8 @@ Scalar ShapeShapeDistance<Plane, Capsule>(const CollisionGeometry* o1,
                                           const Transform3s& tf2,
                                           const GJKSolver*, const bool,
                                           Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, Capsule>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Capsule& s2 = static_cast<const Capsule&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/cone_halfspace.cpp
+++ b/src/distance/cone_halfspace.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Cone, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Cone, Halfspace>");
   const Cone& s1 = static_cast<const Cone&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -64,6 +68,8 @@ Scalar ShapeShapeDistance<Halfspace, Cone>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Cone>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Cone& s2 = static_cast<const Cone&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/cone_plane.cpp
+++ b/src/distance/cone_plane.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -53,6 +55,7 @@ Scalar ShapeShapeDistance<Cone, Plane>(const CollisionGeometry* o1,
                                        const Transform3s& tf2, const GJKSolver*,
                                        const bool, Vec3s& p1, Vec3s& p2,
                                        Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Cone, Plane>");
   const Cone& s1 = static_cast<const Cone&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -68,6 +71,7 @@ Scalar ShapeShapeDistance<Plane, Cone>(const CollisionGeometry* o1,
                                        const Transform3s& tf2, const GJKSolver*,
                                        const bool, Vec3s& p1, Vec3s& p2,
                                        Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Plane, Cone>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Cone& s2 = static_cast<const Cone&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/convex_halfspace.cpp
+++ b/src/distance/convex_halfspace.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<ConvexBase, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<ConvexBase, Halfspace>");
   const ConvexBase& s1 = static_cast<const ConvexBase&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -60,6 +64,8 @@ Scalar ShapeShapeDistance<Halfspace, ConvexBase>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, ConvexBase>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const ConvexBase& s2 = static_cast<const ConvexBase&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/convex_plane.cpp
+++ b/src/distance/convex_plane.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<ConvexBase, Plane>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<ConvexBase, Plane>");
   const ConvexBase& s1 = static_cast<const ConvexBase&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -60,6 +64,8 @@ Scalar ShapeShapeDistance<Plane, ConvexBase>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, ConvexBase>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const ConvexBase& s2 = static_cast<const ConvexBase&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/cylinder_halfspace.cpp
+++ b/src/distance/cylinder_halfspace.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Cylinder, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Cylinder, Halfspace>");
   const Cylinder& s1 = static_cast<const Cylinder&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -64,6 +68,8 @@ Scalar ShapeShapeDistance<Halfspace, Cylinder>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Cylinder>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Cylinder& s2 = static_cast<const Cylinder&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/cylinder_plane.cpp
+++ b/src/distance/cylinder_plane.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Cylinder, Plane>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Cylinder, Plane>");
   const Cylinder& s1 = static_cast<const Cylinder&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -64,6 +68,8 @@ Scalar ShapeShapeDistance<Plane, Cylinder>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, Cylinder>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Cylinder& s2 = static_cast<const Cylinder&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/ellipsoid_halfspace.cpp
+++ b/src/distance/ellipsoid_halfspace.cpp
@@ -40,6 +40,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -49,6 +51,8 @@ Scalar ShapeShapeDistance<Ellipsoid, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Ellipsoid, Halfspace>");
   const Ellipsoid& s1 = static_cast<const Ellipsoid&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -62,6 +66,8 @@ Scalar ShapeShapeDistance<Halfspace, Ellipsoid>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Ellipsoid>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Ellipsoid& s2 = static_cast<const Ellipsoid&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/ellipsoid_plane.cpp
+++ b/src/distance/ellipsoid_plane.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -48,6 +50,8 @@ Scalar ShapeShapeDistance<Ellipsoid, Plane>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Ellipsoid, Plane>");
   const Ellipsoid& s1 = static_cast<const Ellipsoid&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -61,6 +65,8 @@ Scalar ShapeShapeDistance<Plane, Ellipsoid>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, Ellipsoid>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Ellipsoid& s2 = static_cast<const Ellipsoid&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/halfspace_halfspace.cpp
+++ b/src/distance/halfspace_halfspace.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -48,6 +50,8 @@ Scalar ShapeShapeDistance<Halfspace, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Halfspace>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   return details::halfspaceHalfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/halfspace_plane.cpp
+++ b/src/distance/halfspace_plane.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -48,6 +50,8 @@ Scalar ShapeShapeDistance<Halfspace, Plane>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Plane>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   return details::halfspacePlaneDistance(s1, tf1, s2, tf2, p1, p2, normal);
@@ -58,6 +62,8 @@ Scalar ShapeShapeDistance<Plane, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, Halfspace>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   Scalar distance =

--- a/src/distance/plane_plane.cpp
+++ b/src/distance/plane_plane.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -50,6 +52,7 @@ Scalar ShapeShapeDistance<Plane, Plane>(const CollisionGeometry* o1,
                                         const Transform3s& tf2,
                                         const GJKSolver*, const bool, Vec3s& p1,
                                         Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Plane, Plane>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   return details::planePlaneDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/sphere_capsule.cpp
+++ b/src/distance/sphere_capsule.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -48,6 +50,8 @@ Scalar ShapeShapeDistance<Sphere, Capsule>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Sphere, Capsule>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Capsule& s2 = static_cast<const Capsule&>(*o2);
   return details::sphereCapsuleDistance(s1, tf1, s2, tf2, p1, p2, normal);
@@ -58,6 +62,8 @@ Scalar ShapeShapeDistance<Capsule, Sphere>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Capsule, Sphere>");
   const Capsule& s1 = static_cast<const Capsule&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   const Scalar distance =

--- a/src/distance/sphere_cylinder.cpp
+++ b/src/distance/sphere_cylinder.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Sphere, Cylinder>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Sphere, Cylinder>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Cylinder& s2 = static_cast<const Cylinder&>(*o2);
   return details::sphereCylinderDistance(s1, tf1, s2, tf2, p1, p2, normal);
@@ -61,6 +65,8 @@ Scalar ShapeShapeDistance<Cylinder, Sphere>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Cylinder, Sphere>");
   const Cylinder& s1 = static_cast<const Cylinder&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   const Scalar distance =

--- a/src/distance/sphere_halfspace.cpp
+++ b/src/distance/sphere_halfspace.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -51,6 +53,8 @@ Scalar ShapeShapeDistance<Sphere, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Sphere, Halfspace>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -64,6 +68,8 @@ Scalar ShapeShapeDistance<Halfspace, Sphere>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, Sphere>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/sphere_plane.cpp
+++ b/src/distance/sphere_plane.cpp
@@ -42,6 +42,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 struct GJKSolver;
 
@@ -53,6 +55,7 @@ Scalar ShapeShapeDistance<Sphere, Plane>(const CollisionGeometry* o1,
                                          const Transform3s& tf2,
                                          const GJKSolver*, const bool,
                                          Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Sphere, Plane>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -68,6 +71,7 @@ Scalar ShapeShapeDistance<Plane, Sphere>(const CollisionGeometry* o1,
                                          const Transform3s& tf2,
                                          const GJKSolver*, const bool,
                                          Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::internal::ShapeShapeDistance<Plane, Sphere>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/sphere_sphere.cpp
+++ b/src/distance/sphere_sphere.cpp
@@ -40,6 +40,8 @@
 
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 // Note that partial specialization of template functions is not allowed.
 // Therefore, two implementations with the default narrow phase solvers are
 // provided. If another narrow phase solver were to be used, the default
@@ -59,6 +61,8 @@ Scalar ShapeShapeDistance<Sphere, Sphere>(const CollisionGeometry* o1,
                                           const Transform3s& tf2,
                                           const GJKSolver*, const bool,
                                           Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Sphere, Sphere>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   return details::sphereSphereDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/triangle_halfspace.cpp
+++ b/src/distance/triangle_halfspace.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<TriangleP, Halfspace>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<TriangleP, Halfspace>");
   const TriangleP& s1 = static_cast<const TriangleP&>(*o1);
   const Halfspace& s2 = static_cast<const Halfspace&>(*o2);
   const Scalar distance =
@@ -60,6 +64,8 @@ Scalar ShapeShapeDistance<Halfspace, TriangleP>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Halfspace, TriangleP>");
   const Halfspace& s1 = static_cast<const Halfspace&>(*o1);
   const TriangleP& s2 = static_cast<const TriangleP&>(*o2);
   return details::halfspaceDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/triangle_plane.cpp
+++ b/src/distance/triangle_plane.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<TriangleP, Plane>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<TriangleP, Plane>");
   const TriangleP& s1 = static_cast<const TriangleP&>(*o1);
   const Plane& s2 = static_cast<const Plane&>(*o2);
   const Scalar distance =
@@ -60,6 +64,8 @@ Scalar ShapeShapeDistance<Plane, TriangleP>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Plane, TriangleP>");
   const Plane& s1 = static_cast<const Plane&>(*o1);
   const TriangleP& s2 = static_cast<const TriangleP&>(*o2);
   return details::planeDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/triangle_sphere.cpp
+++ b/src/distance/triangle_sphere.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<TriangleP, Sphere>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<TriangleP, Sphere>");
   const TriangleP& s1 = static_cast<const TriangleP&>(*o1);
   const Sphere& s2 = static_cast<const Sphere&>(*o2);
   const Scalar distance =
@@ -60,6 +64,8 @@ Scalar ShapeShapeDistance<Sphere, TriangleP>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2, const GJKSolver*,
     const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<Sphere, TriangleP>");
   const Sphere& s1 = static_cast<const Sphere&>(*o1);
   const TriangleP& s2 = static_cast<const TriangleP&>(*o2);
   return details::sphereTriangleDistance(s1, tf1, s2, tf2, p1, p2, normal);

--- a/src/distance/triangle_triangle.cpp
+++ b/src/distance/triangle_triangle.cpp
@@ -39,6 +39,8 @@
 #include "coal/internal/shape_shape_func.h"
 #include "../narrowphase/details.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace internal {
@@ -47,6 +49,8 @@ Scalar ShapeShapeDistance<TriangleP, TriangleP>(
     const CollisionGeometry* o1, const Transform3s& tf1,
     const CollisionGeometry* o2, const Transform3s& tf2,
     const GJKSolver* solver, const bool, Vec3s& p1, Vec3s& p2, Vec3s& normal) {
+  COAL_TRACY_ZONE_SCOPED_N(
+      "coal::internal::ShapeShapeDistance<TriangleP, TriangleP>");
   // Transform the triangles in world frame
   const TriangleP& s1 = static_cast<const TriangleP&>(*o1);
   const TriangleP t1(tf1.transform(s1.a), tf1.transform(s1.b),

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -43,6 +43,8 @@
 #include "coal/shape/geometric_shapes_traits.h"
 #include "coal/narrowphase/narrowphase_defaults.h"
 
+#include "coal/tracy.hh"
+
 namespace coal {
 
 namespace details {
@@ -185,6 +187,7 @@ void GJK::getWitnessPointsAndNormal(const MinkowskiDiff& shape, Vec3s& w0,
 
 GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3s& guess,
                           const support_func_guess_t& supportHint) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::details::GJK::evaluate");
   Scalar alpha = 0;
   iterations = 0;
   const Scalar swept_sphere_radius = shape_.swept_sphere_radius.sum();
@@ -1153,6 +1156,7 @@ EPA::SimplexFace* EPA::findClosestFace() {
 }
 
 EPA::Status EPA::evaluate(GJK& gjk, const Vec3s& guess) {
+  COAL_TRACY_ZONE_SCOPED_N("coal::details::EPA::evaluate");
   GJK::Simplex& simplex = *gjk.getSimplex();
   support_hint = gjk.support_hint;
 


### PR DESCRIPTION
- added cmake option `COAL_BUILD_WITH_TRACY`
- put tracy scoped zones in broadphase and primitive shapes collision/distance queries