### PR TITLE
PyPI: coal-library -> coal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use double precision for GJK/EPA when coal is compiled in float ([#674](https://github.com/coal-library/coal/pull/674))
   - Everything is in float in coal (including the support functions), except the computations inside GJK/EPA
   - Allows GJK/EPA to avoid limitation of float precision
+- Renamed PyPI package from coal-library to coal ([#675])(https://github.com/coal-library/coal/pull/675))
 
 ## [3.0.1] - 2025-02-12
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="http://projects.laas.fr/gepetto/doc/humanoid-path-planner/hpp-fcl/master/coverage/"><img src="https://gepgitlab.laas.fr/humanoid-path-planner/hpp-fcl/badges/master/coverage.svg?job=doc-coverage" alt="Coverage report"/></a>
   <a href="https://anaconda.org/conda-forge/hpp-fcl"><img src="https://img.shields.io/conda/dn/conda-forge/hpp-fcl.svg" alt="Conda Downloads"/></a>
   <a href="https://anaconda.org/conda-forge/hpp-fcl"><img src="https://img.shields.io/conda/vn/conda-forge/hpp-fcl.svg" alt="Conda Version"/></a>
-  <a href="https://badge.fury.io/py/hpp-fcl"><img src="https://badge.fury.io/py/hpp-fcl.svg" alt="PyPI version"></a>
+  <a href="https://badge.fury.io/py/coal"><img src="https://badge.fury.io/py/coal.svg" alt="PyPI version"></a>
   <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
   <a href="https://github.com/astral-sh/ruff"><img alt="ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
 </p>


### PR DESCRIPTION
Hi,

This package was previously distributed on https://pypi.org/project/coal-library/, and it is now available on https://pypi.org/project/coal/.

Thanks a lot to @apparentlymart who owned that name and kindly gave it :)

This fix a concern raised by @traversaro in https://github.com/coal-library/coal/issues/593#issuecomment-2165871315

For now, on PyPI, coal-library v3.0.1 == coal v3.0.1, and packages which depend on coal-library will gradually switch to coal.