### PR TITLE
Specify submodule branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "cmake"]
+	branch = master
 	path = cmake
 	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git
 [submodule "third-parties/qhull"]
+	branch = master
 	path = third-parties/qhull
 	url = https://github.com/qhull/qhull.git


### PR DESCRIPTION
Works around NixOS/nix#10773, allowing Nix evaluations to complete with one fewer round-trips.