### PR TITLE
Fix autodoc generation on Windows

### DIFF
--- a/include/coal/shape/convex.h
+++ b/include/coal/shape/convex.h
@@ -63,9 +63,7 @@ class ConvexTpl : public ConvexBaseTpl<typename PolygonT::IndexType> {
   ~ConvexTpl() {}
 
   /// @brief Constructing a convex, providing normal and offset of each polytype
-  /// surface, and the points and shape topology information \param ownStorage
-  /// whether this class owns the pointers of points and
-  ///                    polygons. If owned, they are deleted upon destruction.
+  /// surface, and the points and shape topology information
   /// \param points_ list of 3D points
   /// \param num_points_ number of 3D points
   /// \param polygons_ \copydoc Convex::polygons
@@ -125,8 +123,6 @@ class ConvexTpl : public ConvexBaseTpl<typename PolygonT::IndexType> {
   ///
   /// @brief Set the current Convex from a list of points and polygons.
   ///
-  /// \param ownStorage whether this class owns the pointers of points and
-  ///                    polygons. If owned, they are deleted upon destruction.
   /// \param points list of 3D points
   /// \param num_points number of 3D points
   /// \param polygons \copydoc Convex::polygons

--- a/include/coal/shape/convex.h
+++ b/include/coal/shape/convex.h
@@ -96,7 +96,7 @@ class ConvexTpl : public ConvexBaseTpl<typename PolygonT::IndexType> {
 
   // Clone (deep copy).
   COAL_DEPRECATED_MESSAGE(Use deepcopy instead.)
-  ConvexTpl<PolygonT> *clone() const override { return this->deepcopy(); };
+  ConvexTpl *clone() const override { return this->deepcopy(); };
 
   // Deep copy of a Convex.
   // This method deep copies every field of the class.

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -822,7 +822,6 @@ class ConvexBaseTpl : public ShapeBase {
   /// @brief Initialize the points of the convex shape
   /// This also initializes the ConvexBase::center.
   ///
-  /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
   void initialize(std::shared_ptr<std::vector<Vec3s>> points_,
@@ -830,7 +829,6 @@ class ConvexBaseTpl : public ShapeBase {
 
   /// @brief Set the points of the convex shape.
   ///
-  /// \param ownStorage weither the ConvexBase owns the data.
   /// \param points_ list of 3D points  ///
   /// \param num_points_ number of 3D points
   void set(std::shared_ptr<std::vector<Vec3s>> points_,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -57,21 +57,12 @@ set(
   serializable.hh
 )
 
-if(NOT WIN32)
-  set(
-    ENABLE_PYTHON_DOXYGEN_AUTODOC
-    TRUE
-    CACHE BOOL
-    "Enable automatic documentation of Python bindings from Doxygen documentation"
-  )
-else()
-  set(
-    ENABLE_PYTHON_DOXYGEN_AUTODOC
-    FALSE
-    CACHE BOOL
-    "Enable automatic documentation of Python bindings from Doxygen documentation"
-  )
-endif()
+set(
+  ENABLE_PYTHON_DOXYGEN_AUTODOC
+  TRUE
+  CACHE BOOL
+  "Enable automatic documentation of Python bindings from Doxygen documentation"
+)
 
 if(NOT ENABLE_PYTHON_DOXYGEN_AUTODOC OR NOT DOXYGEN_FOUND)
   set(ENABLE_DOXYGEN_AUTODOC FALSE)


### PR DESCRIPTION
Windows build with python autodoc was not working because two function with the same signature were generated.

By using the same return type this PR fix this issue.