### PR TITLE
Fix autodoc inner class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Along with #665, this allows to divide by two the memory footprint of `Convex`.
 
 ### Fixed
-- Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678))
+- Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
 
 ## [3.0.1] - 2025-02-12
 

--- a/include/coal/BV/AABB.h
+++ b/include/coal/BV/AABB.h
@@ -229,6 +229,8 @@ class COAL_DLLAPI AABB {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
+/** @} */  // end of Bounding_Volume
+
 /// @brief translate the center of AABB by t
 static inline AABB translate(const AABB& aabb, const Vec3s& t) {
   AABB res(aabb);

--- a/include/coal/BV/OBB.h
+++ b/include/coal/BV/OBB.h
@@ -124,6 +124,8 @@ struct COAL_DLLAPI OBB {
   inline Scalar volume() const { return width() * height() * depth(); }
 };
 
+/** @} */  // end of Bounding_Volume
+
 /// @brief Translate the OBB bv
 COAL_DLLAPI OBB translate(const OBB& bv, const Vec3s& t);
 

--- a/include/coal/BV/OBBRSS.h
+++ b/include/coal/BV/OBBRSS.h
@@ -127,6 +127,8 @@ struct COAL_DLLAPI OBBRSS {
   inline Scalar volume() const { return obb.volume(); }
 };
 
+/** @} */  // end of Bounding_Volume
+
 /// @brief Check collision between two OBBRSS, b1 is in configuration (R0, T0)
 /// and b2 is in indentity
 inline bool overlap(const Matrix3s& R0, const Vec3s& T0, const OBBRSS& b1,

--- a/include/coal/BV/RSS.h
+++ b/include/coal/BV/RSS.h
@@ -148,6 +148,8 @@ struct COAL_DLLAPI RSS {
   }
 };
 
+/** @} */  // end of Bounding_Volume
+
 /// @brief distance between two RSS bounding volumes
 /// P and Q (optional return values) are the closest points in the rectangles,
 /// not the RSS. But the direction P - Q is the correct direction for cloest

--- a/include/coal/BV/kDOP.h
+++ b/include/coal/BV/kDOP.h
@@ -114,26 +114,26 @@ class COAL_DLLAPI KDOP {
   }
 
   /// @brief Check whether two KDOPs overlap.
-  bool overlap(const KDOP<N>& other) const;
+  bool overlap(const KDOP& other) const;
 
   /// @brief Check whether two KDOPs overlap.
   /// @return true if collision happens.
   /// @retval sqrDistLowerBound squared lower bound on distance between boxes if
   ///         they do not overlap.
-  bool overlap(const KDOP<N>& other, const CollisionRequest& request,
+  bool overlap(const KDOP& other, const CollisionRequest& request,
                Scalar& sqrDistLowerBound) const;
 
-  /// @brief The distance between two KDOP<N>. Not implemented.
-  Scalar distance(const KDOP<N>& other, Vec3s* P = NULL, Vec3s* Q = NULL) const;
+  /// @brief The distance between two KDOP, Not implemented.
+  Scalar distance(const KDOP& other, Vec3s* P = NULL, Vec3s* Q = NULL) const;
 
   /// @brief Merge the point and the KDOP
-  KDOP<N>& operator+=(const Vec3s& p);
+  KDOP& operator+=(const Vec3s& p);
 
   /// @brief Merge two KDOPs
-  KDOP<N>& operator+=(const KDOP<N>& other);
+  KDOP& operator+=(const KDOP& other);
 
   /// @brief Create a KDOP by mergin two KDOPs
-  KDOP<N> operator+(const KDOP<N>& other) const;
+  KDOP<N> operator+(const KDOP& other) const;
 
   /// @brief Size of the kDOP (used in BV_Splitter to order two kDOPs)
   inline Scalar size() const {

--- a/include/coal/BV/kDOP.h
+++ b/include/coal/BV/kDOP.h
@@ -94,8 +94,6 @@ class COAL_DLLAPI KDOP {
   Eigen::Array<Scalar, N, 1> dist_;
 
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
   /// @brief Creating kDOP containing nothing
   KDOP();
 
@@ -165,6 +163,9 @@ class COAL_DLLAPI KDOP {
 
   //// @brief Check whether one point is inside the KDOP
   bool inside(const Vec3s& p) const;
+
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 /** @} */  // end of Bounding_Volume

--- a/include/coal/BV/kDOP.h
+++ b/include/coal/BV/kDOP.h
@@ -167,6 +167,8 @@ class COAL_DLLAPI KDOP {
   bool inside(const Vec3s& p) const;
 };
 
+/** @} */  // end of Bounding_Volume
+
 template <short N>
 bool overlap(const Matrix3s& /*R0*/, const Vec3s& /*T0*/, const KDOP<N>& /*b1*/,
              const KDOP<N>& /*b2*/) {

--- a/include/coal/BV/kIOS.h
+++ b/include/coal/BV/kIOS.h
@@ -165,6 +165,8 @@ class COAL_DLLAPI kIOS {
   Scalar volume() const;
 };
 
+/** @} */  // end of Bounding_Volume
+
 /// @brief Translate the kIOS BV
 COAL_DLLAPI kIOS translate(const kIOS& bv, const Vec3s& t);
 

--- a/include/coal/BV/kIOS.h
+++ b/include/coal/BV/kIOS.h
@@ -93,8 +93,6 @@ class COAL_DLLAPI kIOS {
   }
 
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
   /// @brief Equality operator
   bool operator==(const kIOS& other) const {
     bool res = obb == other.obb && num_spheres == other.num_spheres;
@@ -163,6 +161,9 @@ class COAL_DLLAPI kIOS {
 
   /// @brief Volume of the kIOS
   Scalar volume() const;
+
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 /** @} */  // end of Bounding_Volume

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -1113,6 +1113,8 @@ class COAL_DLLAPI Plane : public ShapeBase {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
+/** @} */  // end of Geometric_Shapes
+
 }  // namespace coal
 
 #include "coal/shape/geometric_shapes.hxx"

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -634,6 +634,56 @@ class COAL_DLLAPI Cylinder : public ShapeBase {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
+template <typename _IndexType>
+struct ConvexBaseTplNeighbors {
+  typedef _IndexType IndexType;
+
+  unsigned char count;
+  IndexType begin_id;
+
+  bool operator==(const ConvexBaseTplNeighbors& other) const {
+    if (count != other.count) return false;
+    if (begin_id != other.begin_id) return false;
+
+    return true;
+  }
+
+  bool operator!=(const ConvexBaseTplNeighbors& other) const {
+    return !(*this == other);
+  }
+};
+
+// The support warm start polytope contains certain points of `this`
+// which are support points in specific directions of space.
+// This struct is used to warm start the support function computation for
+// large meshes (`num_points` > 32).
+template <typename _IndexType>
+struct ConvexBaseTplSupportWarmStartPolytope {
+  typedef _IndexType IndexType;
+
+  // Array of support points to warm start the support function
+  // computation.
+  std::vector<Vec3s> points;
+
+  // Indices of the support points warm starts.
+  // These are the indices of the real convex, not the indices of points in
+  // the warm start polytope.
+  std::vector<IndexType> indices;
+
+  // Cast to a different index type.
+  template <typename OtherIndexType>
+  ConvexBaseTplSupportWarmStartPolytope<OtherIndexType> cast() const {
+    typedef ConvexBaseTplSupportWarmStartPolytope<OtherIndexType> ResType;
+    ResType res;
+    res.points = this->points;
+    res.indices.clear();
+    for (size_t i = 0; i < this->indices.size(); ++i) {
+      res.indices.push_back(OtherIndexType(this->indices[i]));
+    }
+    return res;
+  }
+};
+
 /// @brief Base for convex polytope.
 /// @tparam _IndexType type of vertices indexes.
 /// @note Inherited classes are responsible for filling ConvexBase::neighbors;
@@ -723,19 +773,7 @@ class ConvexBaseTpl : public ShapeBase {
   void COAL_DLLAPI buildDoubleDescription();
 #endif
 
-  struct Neighbors {
-    unsigned char count;
-    IndexType begin_id;
-
-    bool operator==(const Neighbors& other) const {
-      if (count != other.count) return false;
-      if (begin_id != other.begin_id) return false;
-
-      return true;
-    }
-
-    bool operator!=(const Neighbors& other) const { return !(*this == other); }
-  };
+  using Neighbors = coal::ConvexBaseTplNeighbors<IndexType>;
 
   /// @brief Get the index of the j-th neighbor of the i-th vertex.
   IndexType neighbor(IndexType i, IndexType j) const {
@@ -774,35 +812,8 @@ class ConvexBaseTpl : public ShapeBase {
   /// is guaranteed in the internal of the polytope (as it is convex)
   Vec3s center;
 
-  // The support warm start polytope contains certain points of `this`
-  // which are support points in specific directions of space.
-  // This struct is used to warm start the support function computation for
-  // large meshes (`num_points` > 32).
-  struct SupportWarmStartPolytope {
-    // Array of support points to warm start the support function
-    // computation.
-    std::vector<Vec3s> points;
-
-    // Indices of the support points warm starts.
-    // These are the indices of the real convex, not the indices of points in
-    // the warm start polytope.
-    std::vector<IndexType> indices;
-
-    // Cast to a different index type.
-    template <typename OtherIndexType>
-    typename ConvexBaseTpl<OtherIndexType>::SupportWarmStartPolytope cast()
-        const {
-      typedef typename ConvexBaseTpl<OtherIndexType>::SupportWarmStartPolytope
-          ResType;
-      ResType res;
-      res.points = this->points;
-      res.indices.clear();
-      for (size_t i = 0; i < this->indices.size(); ++i) {
-        res.indices.push_back(OtherIndexType(this->indices[i]));
-      }
-      return res;
-    }
-  };
+  using SupportWarmStartPolytope =
+      ConvexBaseTplSupportWarmStartPolytope<IndexType>;
 
   /// @brief Number of support warm starts.
   static constexpr size_t num_support_warm_starts = 14;


### PR DESCRIPTION
Autodoc is not working on templated class inner class like:

```cpp
template <typename T>
struct Super
{
  struct Inner
  {
  };
};
```

Inner signature will be `Super::Inner` but should be `Super<T>::Inner`.

Also, with some doxygen version, autodoc for geometric_shapes.h is skipped.

First commit fix doxygen group definition issue and avoid autodoc issue with geometric_shapes.h.
Second commit Move Inner structure outside to avoid the main issue.