### PR TITLE
ci: fix nix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,14 +2,12 @@ name: "CI - Nix"
 
 on:
   push:
-    paths-ignore:
-      - .gitlab-ci.yml
-      - .gitignore
-      - '**.md'
-      - CITATION.*
-      - LICENSE
-      - colcon.pkg
-      - .pre-commit-config.yaml
+    branches:
+      - devel
+  pull_request:
+    branches:
+      - devel
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
not sure why, but nix CI is not running.

@jorisv : those `paths-ignore` are not useful here, this is already handled by the filter in the sources. I'm trying without it :)

~~Edit: still nothing, so I'm trying without the concurrency setting too~~

Edit2: ok, that was a typo, my bad