### PR TITLE
broadphase : add a functional API for collision and distance callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - CMake: add COAL_DISABLE_HPP_FCL_WARNINGS option ([#709](https://github.com/coal-library/coal/pull/709))
+- broadphase: add functional API for collision and distance callbacks ([#724](https://github.com/coal-library/coal/pull/724))
 
 ### Removed
 - Remove constraints on supported doxygen version to generate the python documentation ([#681](https://github.com/coal-library/coal/pull/681))

--- a/include/coal/broadphase/broadphase_collision_manager.h
+++ b/include/coal/broadphase/broadphase_collision_manager.h
@@ -41,11 +41,15 @@
 #include <set>
 #include <vector>
 #include <boost/function.hpp>
+#include <functional>
 
 #include "coal/collision_object.h"
 #include "coal/broadphase/broadphase_callbacks.h"
 
 namespace coal {
+
+using CollisionCallBackFunctor =
+    std::function<bool(CollisionObject*, CollisionObject*)>;
 
 /// @brief Base class for broad phase collision. It helps to accelerate the
 /// collision/distance between N objects. Also support self collision, self
@@ -95,6 +99,9 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   virtual void collide(CollisionObject* obj,
                        CollisionCallBackBase* callback) const = 0;
 
+  /// @copybrief collide(CollisionObject*, CollisionCallBackBase*)
+  void collide(CollisionObject* obj, const CollisionCallBackFunctor& fn) const;
+
   /// @brief perform distance computation between one object and all the objects
   /// belonging to the manager
   virtual void distance(CollisionObject* obj,
@@ -104,6 +111,9 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   /// (i.e., N^2 self collision)
   virtual void collide(CollisionCallBackBase* callback) const = 0;
 
+  /// @copybrief collide(CollisionCallBackBase*)
+  void collide(const CollisionCallBackFunctor& fn) const;
+
   /// @brief perform distance test for the objects belonging to the manager
   /// (i.e., N^2 self distance)
   virtual void distance(DistanceCallBackBase* callback) const = 0;
@@ -111,6 +121,10 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   /// @brief perform collision test with objects belonging to another manager
   virtual void collide(BroadPhaseCollisionManager* other_manager,
                        CollisionCallBackBase* callback) const = 0;
+
+  /// @copybrief collide(BroadPhaseCollisionManager*, CollisionCallBackBase*)
+  void collide(BroadPhaseCollisionManager* other_manager,
+               const CollisionCallBackFunctor& fn) const;
 
   /// @brief perform distance test with objects belonging to another manager
   virtual void distance(BroadPhaseCollisionManager* other_manager,

--- a/include/coal/broadphase/broadphase_collision_manager.h
+++ b/include/coal/broadphase/broadphase_collision_manager.h
@@ -51,6 +51,9 @@ namespace coal {
 using CollisionCallBackFunctor =
     std::function<bool(CollisionObject*, CollisionObject*)>;
 
+using DistanceCallBackFunctor =
+    std::function<bool(CollisionObject*, CollisionObject*, Scalar&)>;
+
 /// @brief Base class for broad phase collision. It helps to accelerate the
 /// collision/distance between N objects. Also support self collision, self
 /// distance and collision/distance with another M objects.
@@ -107,6 +110,10 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   virtual void distance(CollisionObject* obj,
                         DistanceCallBackBase* callback) const = 0;
 
+  /// @copybrief distance(CollisionObject*, DistanceCallBackBase*)
+  void distance(CollisionObject* obj,
+                const DistanceCallBackFunctor& callback) const;
+
   /// @brief perform collision test for the objects belonging to the manager
   /// (i.e., N^2 self collision)
   virtual void collide(CollisionCallBackBase* callback) const = 0;
@@ -117,6 +124,9 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   /// @brief perform distance test for the objects belonging to the manager
   /// (i.e., N^2 self distance)
   virtual void distance(DistanceCallBackBase* callback) const = 0;
+
+  /// @copybrief distance(DistanceCallBackBase*)
+  void distance(const DistanceCallBackFunctor& callback) const;
 
   /// @brief perform collision test with objects belonging to another manager
   virtual void collide(BroadPhaseCollisionManager* other_manager,
@@ -129,6 +139,10 @@ class COAL_DLLAPI BroadPhaseCollisionManager {
   /// @brief perform distance test with objects belonging to another manager
   virtual void distance(BroadPhaseCollisionManager* other_manager,
                         DistanceCallBackBase* callback) const = 0;
+
+  /// @copybrief distance(BroadPhaseCollisionManager*, DistanceCallBackBase*)
+  void distance(BroadPhaseCollisionManager* other_manager,
+                const DistanceCallBackFunctor& fn) const;
 
   /// @brief whether the manager is empty
   virtual bool empty() const = 0;

--- a/include/coal/broadphase/broadphase_collision_manager.h
+++ b/include/coal/broadphase/broadphase_collision_manager.h
@@ -40,7 +40,6 @@
 
 #include <set>
 #include <vector>
-#include <boost/function.hpp>
 #include <functional>
 
 #include "coal/collision_object.h"

--- a/src/broadphase/broadphase_collision_manager.cpp
+++ b/src/broadphase/broadphase_collision_manager.cpp
@@ -39,6 +39,21 @@
 
 namespace coal {
 
+namespace detail {
+struct CollisionCallBackFunctorWrapper : CollisionCallBackBase {
+  CollisionCallBackFunctorWrapper(const CollisionCallBackFunctor& functor)
+      : m_functor(&functor) {}
+
+  void init() override {}
+
+  bool collide(CollisionObject* o1, CollisionObject* o2) override {
+    return (*m_functor)(o1, o2);
+  }
+
+  CollisionCallBackFunctor const* m_functor;
+};
+}  // namespace detail
+
 //==============================================================================
 BroadPhaseCollisionManager::BroadPhaseCollisionManager()
     : enable_tested_set_(false) {
@@ -61,6 +76,28 @@ void BroadPhaseCollisionManager::update(CollisionObject* updated_obj) {
   COAL_UNUSED_VARIABLE(updated_obj);
 
   update();
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::collide(
+    CollisionObject* obj, const CollisionCallBackFunctor& fn) const {
+  detail::CollisionCallBackFunctorWrapper wrapper{fn};
+  this->collide(obj, &wrapper);
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::collide(
+    const CollisionCallBackFunctor& fn) const {
+  detail::CollisionCallBackFunctorWrapper wrapper{fn};
+  this->collide(&wrapper);
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::collide(
+    BroadPhaseCollisionManager* other_manager,
+    const CollisionCallBackFunctor& fn) const {
+  detail::CollisionCallBackFunctorWrapper wrapper{fn};
+  this->collide(other_manager, &wrapper);
 }
 
 //==============================================================================

--- a/src/broadphase/broadphase_collision_manager.cpp
+++ b/src/broadphase/broadphase_collision_manager.cpp
@@ -52,6 +52,20 @@ struct CollisionCallBackFunctorWrapper : CollisionCallBackBase {
 
   CollisionCallBackFunctor const* m_functor;
 };
+
+struct DistanceCallBackFunctorWrapper : DistanceCallBackBase {
+  DistanceCallBackFunctorWrapper(const DistanceCallBackFunctor& functor)
+      : m_functor(&functor) {}
+
+  void init() override {}
+
+  bool distance(CollisionObject* o1, CollisionObject* o2,
+                Scalar& dist) override {
+    return (*m_functor)(o1, o2, dist);
+  }
+
+  DistanceCallBackFunctor const* m_functor;
+};
 }  // namespace detail
 
 //==============================================================================
@@ -98,6 +112,28 @@ void BroadPhaseCollisionManager::collide(
     const CollisionCallBackFunctor& fn) const {
   detail::CollisionCallBackFunctorWrapper wrapper{fn};
   this->collide(other_manager, &wrapper);
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::distance(
+    CollisionObject* obj, const DistanceCallBackFunctor& fn) const {
+  detail::DistanceCallBackFunctorWrapper wrapper{fn};
+  this->distance(obj, &wrapper);
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::distance(
+    const DistanceCallBackFunctor& fn) const {
+  detail::DistanceCallBackFunctorWrapper wrapper{fn};
+  this->distance(&wrapper);
+}
+
+//==============================================================================
+void BroadPhaseCollisionManager::distance(
+    BroadPhaseCollisionManager* other_manager,
+    const DistanceCallBackFunctor& fn) const {
+  detail::DistanceCallBackFunctorWrapper wrapper{fn};
+  this->distance(other_manager, &wrapper);
 }
 
 //==============================================================================


### PR DESCRIPTION
+ can now pass std::function objects (or objects convertible to it) to the `collide()` and `distance()` functions

This enables uses like this using C++11 lambdas:
```cpp
BroadPhaseCollisionManager manager{};
// ...
manager.collide(&obj, [](auto *o1, auto *o2) {  // can also capture elements in lambda
  // logic goes here
});
```