### PR TITLE
ROS: silent ci errors about nanoeigenpy for now

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -32,8 +32,9 @@
   <depend>assimp</depend>
   <depend>liboctomap-dev</depend>
   <depend>eigenpy</depend>
-  <depend>nanobind-dev</depend>
-  <depend>nanoeigenpy</depend>
+  <!-- TODO: finish release of nanoeigenpy on ROS -->
+  <!-- <depend>nanobind-dev</depend> -->
+  <!-- <depend>nanoeigenpy</depend> -->
 
   <!-- The following tag is recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>


### PR DESCRIPTION
I'm tired of the mails.

For now, this is blocked by https://github.com/ros2-gbp/ros2-gbp-github-org/pull/805