### PR TITLE
dockgen: init

### DIFF
--- a/.github/workflows/dockgen.yml
+++ b/.github/workflows/dockgen.yml
@@ -1,0 +1,54 @@
+name: "Publish docker image"
+
+on:
+  push:
+    branches:
+      - devel
+    tags:
+      - "v*"
+
+jobs:
+  dockgen:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+      - run: uvx dockgen
+      - run: cat Dockerfile
+
+      # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CMake: add COAL_DISABLE_HPP_FCL_WARNINGS option ([#709](https://github.com/coal-library/coal/pull/709))
 - CMake: add support for BUILD_STANDALONE_PYTHON_INTERFACE ([#658](https://github.com/coal-library/coal/pull/658))
 - broadphase: add functional API for collision and distance callbacks ([#724](https://github.com/coal-library/coal/pull/724))
+- Docker images `ghcr.io/coal-library/coal` ([#737](https://github.com/coal-library/coal/pull/737))
 
 ### Removed
 - Remove constraints on supported doxygen version to generate the python documentation ([#681](https://github.com/coal-library/coal/pull/681))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Coal can be installed from the [conda-forge channel](https://anaconda.org/conda-
 conda install coal -c conda-forge
 ```
 
+### Docker
+
+```
+docker run --rm -it ghcr.io/coal-library/coal:devel
+```
+
 ## Build
 
 You can find build instruction [here](./development/build.md).

--- a/dockgen.toml
+++ b/dockgen.toml
@@ -1,0 +1,7 @@
+[eigenpy]
+url = "github:stack-of-tasks"
+
+[coal]
+url = "."
+apt_deps = ["libassimp-dev", "liboctomap-dev"]
+src_deps = ["eigenpy"]


### PR DESCRIPTION
This require a new eigenpy release first, because:
```
0.219 + cmake -B build -DBUILD_TESTING=OFF -Wno-dev                                                                                                                                                                  
0.227 -- JRL cmakemodules found on system at /usr/local/share/jrl-cmakemodules
0.228 CMake Error at /usr/local/share/jrl-cmakemodules/base.cmake:145 (message):
0.228   JRL-CMakemodules require CMake >= 3.22.  Please update your main
0.228   'cmake_minimum_required'
0.228 Call Stack (most recent call first):
0.228   CMakeLists.txt:92 (include)