### PR TITLE
Correctly calculate AABB for pruned octrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
+- Correctly calculate AABB for pruned octrees ([#741](https://github.com/coal-library/coal/pull/741))
 
 ## [3.0.1] - 2025-02-12
 

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -40,6 +40,7 @@
 #define COAL_OCTREE_H
 
 #include <algorithm>
+#include <limits>
 
 #include <octomap/octomap.h>
 #include "coal/fwd.hh"
@@ -113,10 +114,13 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
     if (it == end) return;
 
     {
-      const octomap::point3d& coord =
-          it.getCoordinate();  // getCoordinate returns a copy
-      max_extent = min_extent = Eigen::Map<const Vec3float>(&coord.x());
-      for (++it; it != end; ++it) {
+      max_extent = Vec3float(std::numeric_limits<float>::lowest(),
+                             std::numeric_limits<float>::lowest(),
+                             std::numeric_limits<float>::lowest());
+      min_extent = Vec3float(std::numeric_limits<float>::max(),
+                             std::numeric_limits<float>::max(),
+                             std::numeric_limits<float>::max());
+      for (; it != end; ++it) {
         const octomap::point3d& coord = it.getCoordinate();
         const Vec3float pos = Eigen::Map<const Vec3float>(&coord.x());
         // Account for the size of the box.

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -119,15 +119,13 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
       for (++it; it != end; ++it) {
         const octomap::point3d& coord = it.getCoordinate();
         const Vec3float pos = Eigen::Map<const Vec3float>(&coord.x());
-        max_extent = max_extent.array().max(pos.array());
-        min_extent = min_extent.array().min(pos.array());
+        // Account for the size of the box.
+        auto max_pos = pos.array() + float(it.getSize() / 2.);
+        auto min_pos = pos.array() - float(it.getSize() / 2.);
+        max_extent = max_extent.array().max(max_pos.array());
+        min_extent = min_extent.array().min(min_pos.array());
       }
     }
-
-    // Account for the size of the boxes.
-    const Scalar resolution = Scalar(tree->getResolution());
-    max_extent.array() += float(resolution / 2.);
-    min_extent.array() -= float(resolution / 2.);
 
     aabb_local = AABB(min_extent.cast<Scalar>(), max_extent.cast<Scalar>());
     aabb_center = aabb_local.center();

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -116,13 +116,15 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
     {
       max_extent.fill(std::numeric_limits<float>::lowest());
       min_extent.fill(std::numeric_limits<float>::max());
-     
+
       for (; it != end; ++it) {
         const octomap::point3d& coord = it.getCoordinate();
         const Vec3float pos = Eigen::Map<const Vec3float>(&coord.x());
         // Account for the size of the box.
-        const Vec3float max_pos = pos + Vec3float::Constant(float(it.getSize() / 2.));
-        const Vec3float min_pos = pos - Vec3float::Constant(float(it.getSize() / 2.));
+        const Vec3float max_pos =
+            pos + Vec3float::Constant(float(it.getSize() / 2.));
+        const Vec3float min_pos =
+            pos - Vec3float::Constant(float(it.getSize() / 2.));
         max_extent.array() = max_extent.array().max(max_pos.array());
         min_extent.array() = min_extent.array().min(min_pos.array());
       }

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -114,20 +114,17 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
     if (it == end) return;
 
     {
-      max_extent = Vec3float(std::numeric_limits<float>::lowest(),
-                             std::numeric_limits<float>::lowest(),
-                             std::numeric_limits<float>::lowest());
-      min_extent = Vec3float(std::numeric_limits<float>::max(),
-                             std::numeric_limits<float>::max(),
-                             std::numeric_limits<float>::max());
+      max_extent.fill(std::numeric_limits<float>::lowest());
+      min_extent.fill(std::numeric_limits<float>::max());
+     
       for (; it != end; ++it) {
         const octomap::point3d& coord = it.getCoordinate();
         const Vec3float pos = Eigen::Map<const Vec3float>(&coord.x());
         // Account for the size of the box.
-        auto max_pos = pos.array() + float(it.getSize() / 2.);
-        auto min_pos = pos.array() - float(it.getSize() / 2.);
-        max_extent = max_extent.array().max(max_pos.array());
-        min_extent = min_extent.array().min(min_pos.array());
+        const Vec3float max_pos = pos + Vec3float::Constant(float(it.getSize() / 2.));
+        const Vec3float min_pos = pos - Vec3float::Constant(float(it.getSize() / 2.));
+        max_extent.array() = max_extent.array().max(max_pos.array());
+        min_extent.array() = min_extent.array().min(min_pos.array());
       }
     }
 

--- a/test/octree.cpp
+++ b/test/octree.cpp
@@ -103,6 +103,51 @@ coal::OcTree makeOctree(const BVHModel<OBBRSS>& mesh,
   return OcTree(octree);
 }
 
+BOOST_AUTO_TEST_CASE(octree_aabb) {
+  // Create a simple octree with 8 nodes arranged in a 2x2x2 cube
+  Scalar resolution = 1.0;
+  octomap::OcTreePtr_t octree_ptr(new octomap::OcTree(resolution));
+  std::vector<octomap::point3d> points = {
+      octomap::point3d(0.5, 0.5, 0.5), octomap::point3d(1.5, 0.5, 0.5),
+      octomap::point3d(0.5, 1.5, 0.5), octomap::point3d(1.5, 1.5, 0.5),
+      octomap::point3d(0.5, 0.5, 1.5), octomap::point3d(1.5, 0.5, 1.5),
+      octomap::point3d(0.5, 1.5, 1.5), octomap::point3d(1.5, 1.5, 1.5)};
+  for (const auto& point : points) {
+    octree_ptr->updateNode(point, true);
+  }
+  octree_ptr->updateInnerOccupancy();
+  // Make sure the octree is not pruned
+  octree_ptr->expand();
+  // Check initial size
+  BOOST_CHECK_EQUAL(octree_ptr->getNumLeafNodes(), 8);
+
+  // Create coal::OcTree and compute AABB
+  coal::OcTree octree(octree_ptr);
+  octree.computeLocalAABB();
+
+  // The AABB should encompass the 2x2x2 cube from (0,0,0) to (2,2,2)
+  BOOST_CHECK(octree.aabb_local.min_.isApprox(Vec3s(0, 0, 0), 1e-6));
+  BOOST_CHECK(octree.aabb_local.max_.isApprox(Vec3s(2, 2, 2), 1e-6));
+
+  // Create a copy and prune it
+  octomap::OcTreePtr_t octree_pruned_ptr(new octomap::OcTree(*octree_ptr));
+  octree_pruned_ptr->prune();
+  // Check pruned size, the 8 leaf nodes should have been merged into 1
+  BOOST_CHECK_EQUAL(octree_pruned_ptr->getNumLeafNodes(), 1);
+
+  // Create coal::OcTree and compute AABB
+  coal::OcTree octree_pruned(octree_pruned_ptr);
+  octree_pruned.computeLocalAABB();
+
+  // The AABB should encompass the 2x2x2 cube from (0,0,0) to (2,2,2)
+  BOOST_CHECK(octree_pruned.aabb_local.min_.isApprox(Vec3s(0, 0, 0), 1e-6));
+  BOOST_CHECK(octree_pruned.aabb_local.max_.isApprox(Vec3s(2, 2, 2), 1e-6));
+
+  // The AABB should remain the same after pruning
+  BOOST_CHECK(octree.aabb_local.min_.isApprox(octree_pruned.aabb_local.min_));
+  BOOST_CHECK(octree.aabb_local.max_.isApprox(octree_pruned.aabb_local.max_));
+}
+
 BOOST_AUTO_TEST_CASE(octree_mesh) {
   Eigen::IOFormat tuple(Eigen::FullPrecision, Eigen::DontAlignCols, "", ", ",
                         "", "", "(", ")");


### PR DESCRIPTION
Pruned octrees can have merged nodes, with a larger box size. This PR lets OcTree::computeLocalAABB() correctly handle variable sized boxes in an octree.