### PR TITLE
Fix ContactPatchResult falling back to native exception for excessive…

### DIFF
--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -916,6 +916,19 @@ struct COAL_DLLAPI ContactPatchResult {
 
   /// @brief Set up a `ContactPatchResult` from a `ContactPatchRequest`
   void set(const ContactPatchRequest& request) {
+    // In practice there may be better constants, and coal may have one. But for
+    // contact points, this should suffice for memory limits on most systems.
+    const size_t max_reasonable_patches = 100000;
+
+    // Check if the request exceeds reasonable limits before attempting resize
+    if (request.max_num_patch > max_reasonable_patches) {
+      COAL_THROW_PRETTY(
+          "Requested too many contact patches: " +
+              std::to_string(request.max_num_patch) +
+              ". Maximum supported: " + std::to_string(max_reasonable_patches),
+          std::invalid_argument);
+    }
+
     if (this->m_contact_patches_data.size() < request.max_num_patch) {
       this->m_contact_patches_data.resize(request.max_num_patch);
     }

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -918,7 +918,8 @@ struct COAL_DLLAPI ContactPatchResult {
   void set(const ContactPatchRequest& request) {
     // In practice there may be better constants, and coal may have one. But for
     // contact points, this should suffice for memory limits on most systems.
-    const size_t max_reasonable_patches = 100000;
+    const size_t max_reasonable_patches =
+        this->m_contact_patches_data.max_size();
 
     // Check if the request exceeds reasonable limits before attempting resize
     if (request.max_num_patch > max_reasonable_patches) {

--- a/test/contact_patch.cpp
+++ b/test/contact_patch.cpp
@@ -1034,10 +1034,19 @@ BOOST_AUTO_TEST_CASE(contact_path_excessive_requests) {
     ContactPatchResult patch_res(patch_req);
   }
 
+  // Test with a large, but reasonable number of contacts
+  {
+    const size_t midsize_contacts = 100000;
+    CollisionRequest midsize_req(CONTACT, midsize_contacts);
+    ContactPatchRequest patch_req(midsize_req);
+
+    BOOST_CHECK_NO_THROW(ContactPatchResult patch_res(patch_req));
+  }
+
   // This should throw a clear error, not get to the point where std::vector
   // needs to throw a std::length_error with an unclear message
   {
-    const size_t excessive_contacts = 1000000;
+    const size_t excessive_contacts = std::numeric_limits<size_t>::max();
     CollisionRequest excessive_req(CONTACT, excessive_contacts);
     ContactPatchRequest patch_req(excessive_req);
 
@@ -1058,8 +1067,9 @@ BOOST_AUTO_TEST_CASE(contact_path_excessive_requests) {
       std::string error_msg(e.what());
       BOOST_CHECK(error_msg.find("Requested too many contact patches") !=
                   std::string::npos);
-      BOOST_CHECK(error_msg.find("Maximum supported: 100000") !=
-                  std::string::npos);
+      // Check that the error message contains "Maximum supported:" followed by
+      // the actual max_size value
+      BOOST_CHECK(error_msg.find("Maximum supported:") != std::string::npos);
     }
   }
 }

--- a/test/contact_patch.cpp
+++ b/test/contact_patch.cpp
@@ -1022,3 +1022,44 @@ BOOST_AUTO_TEST_CASE(edge_case_segment_face) {
     }
   }
 }
+
+BOOST_AUTO_TEST_CASE(contact_path_excessive_requests) {
+  // This test handles contact patch requests with excessively large sizes, to
+  // ensure that the program gracefully handles them above some set threshold
+
+  // This should not throw
+  {
+    CollisionRequest reasonable_req(CONTACT, 1000);
+    ContactPatchRequest patch_req(reasonable_req);
+    ContactPatchResult patch_res(patch_req);
+  }
+
+  // This should throw a clear error, not get to the point where std::vector
+  // needs to throw a std::length_error with an unclear message
+  {
+    const size_t excessive_contacts = 1000000;
+    CollisionRequest excessive_req(CONTACT, excessive_contacts);
+    ContactPatchRequest patch_req(excessive_req);
+
+    BOOST_CHECK_THROW(ContactPatchResult patch_res(patch_req),
+                      std::invalid_argument);
+  }
+
+  // Test the specific error message content
+  {
+    const size_t excessive_contacts = std::numeric_limits<size_t>::max();
+    CollisionRequest excessive_req(CONTACT, excessive_contacts);
+    ContactPatchRequest patch_req(excessive_req);
+
+    try {
+      ContactPatchResult patch_res(patch_req);
+      BOOST_FAIL("Should have thrown an exception");
+    } catch (const std::invalid_argument &e) {
+      std::string error_msg(e.what());
+      BOOST_CHECK(error_msg.find("Requested too many contact patches") !=
+                  std::string::npos);
+      BOOST_CHECK(error_msg.find("Maximum supported: 100000") !=
+                  std::string::npos);
+    }
+  }
+}


### PR DESCRIPTION
… contact request size

  Addresses #725 which produces `std::length_error` instead of a clear error for when a user exceeds a reasonable
  size for contact points in a collision request.

  Modifies `ContactPatchResult::set(const ContactPatchRequest& request)` to check according to a const.

  Added `contact_path_excessive_requests` test case to verify proper exception handling for both reasonable and
  excessive contact patch requests.