### PR TITLE
Remove useless boost components direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove useless COAL_WITH_CXX11_SUPPORT guard ([#688](https://github.com/coal-library/coal/pull/688))
 - Remove qhull submodule, as ubuntu 20.04 is EoL ([#704](https://github.com/coal-library/coal/pull/704))
 - Removed support for octomap < 1.8 ([#727](https://github.com/coal-library/coal/pull/727))
+- Remove direct dependency to ([#744](https://github.com/coal-library/coal/pull/744)):
+  - Boost::system
+  - Boost::chrono
+  - Boost::date_time
+  - Boost::thread
 
 ### Added
 - Added a second set of Python bindings based on nanobind ([#659](https://github.com/coal-library/coal/pull/659))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,12 +182,7 @@ endif(COAL_BUILD_WITH_TRACY)
 # Required dependencies
 SET_BOOST_DEFAULT_OPTIONS()
 EXPORT_BOOST_DEFAULT_OPTIONS()
-ADD_PROJECT_DEPENDENCY(
-  Boost
-  REQUIRED
-  serialization
-  filesystem
-)
+ADD_PROJECT_DEPENDENCY(Boost REQUIRED serialization filesystem)
 if(COAL_ENABLE_LOGGING)
   ADD_PROJECT_DEPENDENCY(Boost REQUIRED log)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,9 +185,6 @@ EXPORT_BOOST_DEFAULT_OPTIONS()
 ADD_PROJECT_DEPENDENCY(
   Boost
   REQUIRED
-  chrono
-  thread
-  date_time
   serialization
   filesystem
 )

--- a/python-nb/CMakeLists.txt
+++ b/python-nb/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_policy(PUSH)
 cmake_policy(SET CMP0074 NEW)
 find_package(nanobind CONFIG REQUIRED)
 cmake_policy(POP)
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 # Nanoeigenpy
 find_package(nanoeigenpy CONFIG REQUIRED)
@@ -51,7 +51,7 @@ endif(COAL_HAS_OCTOMAP)
 nanobind_add_module(${PYTHON_LIB_NAME_V2} NB_STATIC LTO NB_SUPPRESS_WARNINGS ${PYTHON_LIB_SOURCES})
 target_link_libraries(
   ${PYTHON_LIB_NAME_V2}
-  PRIVATE ${PROJECT_NAME}::${PROJECT_NAME} Boost::system
+  PRIVATE ${PROJECT_NAME}::${PROJECT_NAME} Boost::boost
 )
 target_compile_definitions(
   ${PYTHON_LIB_NAME_V2}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,7 +31,7 @@
 #  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 #  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 if(GENERATE_PYTHON_STUBS)
   include(${JRL_CMAKE_MODULES}/stubs.cmake)
@@ -170,7 +170,7 @@ endif()
 
 target_link_libraries(
   ${PYTHON_LIB_NAME}
-  PUBLIC ${PROJECT_NAME}::${PROJECT_NAME} eigenpy::eigenpy Boost::system
+  PUBLIC ${PROJECT_NAME}::${PROJECT_NAME} eigenpy::eigenpy Boost::boost
 )
 
 set_target_properties(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ MODERNIZE_TARGET_LINK_LIBRARIES(
 
 target_link_libraries(
   ${LIBRARY_NAME}
-  PUBLIC Boost::serialization Boost::chrono Boost::filesystem
+  PUBLIC Boost::serialization Boost::filesystem
 )
 
 if(COAL_ENABLE_LOGGING)
@@ -198,10 +198,6 @@ if(COAL_BUILD_WITH_TRACY)
 endif()
 
 if(WIN32)
-  target_link_libraries(
-    ${LIBRARY_NAME}
-    INTERFACE Boost::thread Boost::date_time
-  )
   # There is an issue with MSVC 2017 and Eigen (due to std::aligned_storage).
   # See https://github.com/ceres-solver/ceres-solver/issues/481
   target_compile_definitions(


### PR DESCRIPTION
Some boost components had been added as a direct coal or coal binding dependency. Since these components (system, thread, date_time, chrono) are not directly used, we should leave it to the Boost CMake module.

Fix #743 

We can't test it with boost 1.89 since it's not available in conda-forge. But I think this version will be available soon.
@cho-m can you test it locally ?