### PR TITLE
Fix contact counting in octree collision detection with ShapeShapeCollide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
 - Correctly calculate AABB for pruned octrees ([#741](https://github.com/coal-library/coal/pull/741))
+- Fix contact counting in octree collision detection with ShapeShapeCollide ([#746](https://github.com/coal-library/coal/pull/746))
 
 ## [3.0.1] - 2025-02-12
 

--- a/include/coal/internal/shape_shape_func.h
+++ b/include/coal/internal/shape_shape_func.h
@@ -146,7 +146,6 @@ struct ShapeShapeCollider {
     Scalar distance = internal::ShapeShapeDistance<ShapeType1, ShapeType2>(
         o1, tf1, o2, tf2, nsolver, compute_penetration, p1, p2, normal);
 
-    size_t num_contacts = 0;
     const Scalar distToCollision = distance - request.security_margin;
 
     internal::updateDistanceLowerBoundFromLeaf(request, result, distToCollision,
@@ -158,10 +157,9 @@ struct ShapeShapeCollider {
                         distance);
         result.addContact(contact);
       }
-      num_contacts = result.numContacts();
     }
 
-    return num_contacts;
+    return result.numContacts();
   }
 };
 

--- a/include/coal/internal/traversal_node_octree.h
+++ b/include/coal/internal/traversal_node_octree.h
@@ -335,8 +335,11 @@ class COAL_DLLAPI OcTreeSolver {
 
       bool contactNotAdded =
           (cresult->numContacts() >= crequest->num_max_contacts);
-      std::size_t ncontact = ShapeShapeCollide<Box, S>(
-          &box, box_tf, &s, tf2, solver, *crequest, *cresult);
+      std::size_t ncontact = cresult->numContacts();
+      // Get the number of new contacts added.
+      ncontact = ShapeShapeCollide<Box, S>(&box, box_tf, &s, tf2, solver,
+                                           *crequest, *cresult) -
+                 ncontact;
       assert(ncontact == 0 || ncontact == 1);
       if (!contactNotAdded && ncontact == 1) {
         // Update contact information.

--- a/test/octree.cpp
+++ b/test/octree.cpp
@@ -262,8 +262,7 @@ BOOST_AUTO_TEST_CASE(octree_height_field) {
                      utf::master_test_suite().argv, N);
 
   generateRandomTransforms(extents, transforms, 2 * N);
-
-  CollisionRequest request(coal::CONTACT | coal::DISTANCE_LOWER_BOUND, 1);
+  CollisionRequest request(coal::CONTACT | coal::DISTANCE_LOWER_BOUND, 3);
   for (std::size_t i = 0; i < N; ++i) {
     CollisionResult resultBox;
     CollisionResult resultHfield1, resultHfield2;


### PR DESCRIPTION
Ensure ShapeShapeCollide always returns numContacts, aligning with other
CollisionFunctionMatrix in collision_matrix.