### PR TITLE
Fix broadphase node collide bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed malloc in COAL_ASSERT ([#687](https://github.com/coal-library/coal/pull/687))
 - Introducing `Convex16` and `Convex32` to store neighbors and polygons indices as `uint16` or `uint32` ([#682](https://github.com/coal-library/coal/pull/682), [#716](https://github.com/coal-library/coal/pull/716)).
   - Along with #665, this allows to divide by two the memory footprint of `Convex`.
+- Fixed a bug in DynamicAABBTree broadphase that missed aabb overlaps when multiple planes/halfspaces are used in a scene.
 
 ### Fixed
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))

--- a/src/broadphase/broadphase_dynamic_AABB_tree.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree.cpp
@@ -297,38 +297,6 @@ bool leafCollide(CollisionObject* o1, CollisionObject* o2,
 //==============================================================================
 bool nodeCollide(DynamicAABBTreeCollisionManager::DynamicAABBNode* node1,
                  DynamicAABBTreeCollisionManager::DynamicAABBNode* node2) {
-  // This function assumes that at least node1 or node2 is not a leaf of the
-  // tree.
-  if (node1->isLeaf()) {
-    CollisionObject* o1 = static_cast<CollisionObject*>(node1->data);
-    if (o1->getNodeType() == GEOM_HALFSPACE ||
-        o1->getNodeType() == GEOM_PLANE) {
-      if (o1->getNodeType() == GEOM_HALFSPACE) {
-        const auto& halfspace =
-            static_cast<const Halfspace&>(*(o1->collisionGeometryPtr()));
-        return node2->bv.overlap(transform(halfspace, o1->getTransform()));
-      }
-      const auto& plane =
-          static_cast<const Plane&>(*(o1->collisionGeometryPtr()));
-      return node2->bv.overlap(transform(plane, o1->getTransform()));
-    }
-  }
-
-  if (node2->isLeaf()) {
-    CollisionObject* o2 = static_cast<CollisionObject*>(node2->data);
-    if (o2->getNodeType() == GEOM_HALFSPACE ||
-        o2->getNodeType() == GEOM_PLANE) {
-      if (o2->getNodeType() == GEOM_HALFSPACE) {
-        const auto& halfspace =
-            static_cast<const Halfspace&>(*(o2->collisionGeometryPtr()));
-        return node1->bv.overlap(transform(halfspace, o2->getTransform()));
-      }
-      const auto& plane =
-          static_cast<const Plane&>(*(o2->collisionGeometryPtr()));
-      return node1->bv.overlap(transform(plane, o2->getTransform()));
-    }
-  }
-
   return node1->bv.overlap(node2->bv);
 }
 


### PR DESCRIPTION
Fixed a bug in DynamicAABBTree broadphase that missed aabbs overlaps when multiple planes/halfspaces are used in a scene.

When one node is a leaf and a plane/halfspace, if the other node contains a plane/halfspace, the `nodeCollide` "trick overlap test" returns a wrong result (it uses a support point computation but finds it at infinity due to the presence of an infinite AABB, my bad). 
Fix: we simply check for overlap of the aabbs of node1 and node2.