### PR TITLE
Add helper for contact patch simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a second set of Python bindings based on nanobind ([#659](https://github.com/coal-library/coal/pull/659))
 - ROS: jrl_cmakemodules dependency + kilted CI ([#769](https://github.com/coal-library/coal/pull/769))
 - Added `SUFFIX_SO_VERSION` CMake option, default `OFF` ([#770](https://github.com/coal-library/coal/pull/770))
+- contact patches: add helpers to reduce the size of a contact patch by keeping points that minimize the difference between the area of the original patch and the area of the new patch
 
 ### Removed
 - Remove direct dependency to ([#744](https://github.com/coal-library/coal/pull/744)):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ set(
   include/coal/contact_patch_func_matrix.h
   include/coal/contact_patch/contact_patch_solver.h
   include/coal/contact_patch/contact_patch_solver.hxx
+  include/coal/contact_patch/contact_patch_simplifier.h
   include/coal/distance.h
   include/coal/math/matrix_3f.h
   include/coal/math/vec_3f.h

--- a/include/coal/contact_patch.h
+++ b/include/coal/contact_patch.h
@@ -41,6 +41,7 @@
 #include "coal/collision_data.h"
 #include "coal/contact_patch/contact_patch_solver.h"
 #include "coal/contact_patch_func_matrix.h"
+#include "coal/contact_patch/contact_patch_simplifier.h"
 
 namespace coal {
 

--- a/include/coal/contact_patch/contact_patch_simplifier.h
+++ b/include/coal/contact_patch/contact_patch_simplifier.h
@@ -1,0 +1,107 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, INRIA
+ *  All rights reserved.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of INRIA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Louis Montaut */
+
+#ifndef COAL_CONTACT_PATCH_SIMPLIFIER_H
+#define COAL_CONTACT_PATCH_SIMPLIFIER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "coal/collision_data.h"
+
+namespace coal {
+
+/// @brief Dynamic-programming simplifier that preserves the largest possible
+/// polygon area with `target_vertices` points.
+class COAL_DLLAPI ContactPatchSimplifierMaxArea {
+ public:
+  using Index = std::size_t;
+
+  ContactPatchSimplifierMaxArea() = default;
+
+  /// @brief Compute the maximum-area subset of `patch_in` with
+  /// `target_vertices` points and store it in `patch_out`.
+  void compute(const ContactPatch& patch_in, std::size_t target_vertices,
+               ContactPatch& patch_out);
+
+  /// @brief In-place simplification helper that replaces the polygon with the
+  /// max-area subset.
+  void simplify(ContactPatch& patch, std::size_t target_vertices);
+
+ private:
+  ContactPatch::Polygon simplified_buffer_;
+  std::vector<Index> ordered_indices_;
+  std::vector<Scalar> dp_area_;
+  std::vector<int> dp_prev_;
+  std::vector<Index> selection_indices_temp_;
+  std::vector<Index> best_indices_;
+  std::vector<uint8_t> keep_;
+};
+
+/// @brief Greedy contact patch simplifier based on the Visvalingam–Whyatt rule.
+class COAL_DLLAPI ContactPatchSimplifierGreedy {
+ public:
+  using Index = typename ContactPatchSimplifierMaxArea::Index;
+
+  ContactPatchSimplifierGreedy() = default;
+
+  /// @brief Compute a simplified approximation of `patch_in` and write it into
+  /// `patch_out` while preserving the supporting frame metadata.
+  void compute(const ContactPatch& patch_in, std::size_t target_vertices,
+               ContactPatch& patch_out);
+
+  /// @brief In-place simplification helper that replaces the polygon with a
+  /// greedy approximation.
+  void simplify(ContactPatch& patch, std::size_t target_vertices);
+
+ private:
+  struct HeapEntry {
+    Index idx;
+    Scalar area;
+    Index version;
+  };
+
+  ContactPatch::Polygon simplified_buffer_;
+  std::vector<int> prev_;
+  std::vector<int> next_;
+  std::vector<bool> removed_;
+  std::vector<Index> versions_;
+  std::vector<HeapEntry> heap_storage_;
+};
+
+}  // namespace coal
+
+#endif  // COAL_CONTACT_PATCH_SIMPLIFIER_H

--- a/python/contact_patch.cc
+++ b/python/contact_patch.cc
@@ -158,4 +158,30 @@ void exposeContactPatchAPI() {
                  const ContactPatchRequest&, ContactPatchResult&) const>(
                  &ComputeContactPatch::operator()));
   }
+
+  if (!eigenpy::register_symbolic_link_to_registered_type<
+          ContactPatchSimplifierGreedy>()) {
+    class_<ContactPatchSimplifierGreedy>("ContactPatchSimplifierGreedy",
+                                         "Greedy contact patch simplifier.",
+                                         init<>())
+        .def("compute", &ContactPatchSimplifierGreedy::compute,
+             (arg("self"), arg("patch_in"), arg("target_vertices"),
+              arg("patch_out")),
+             "Simplify `patch_in` into `patch_out` using the greedy heuristic.")
+        .def("simplify", &ContactPatchSimplifierGreedy::simplify,
+             (arg("self"), arg("patch"), arg("target_vertices")));
+  }
+
+  if (!eigenpy::register_symbolic_link_to_registered_type<
+          ContactPatchSimplifierMaxArea>()) {
+    class_<ContactPatchSimplifierMaxArea>(
+        "ContactPatchSimplifierMaxArea",
+        "Max-area dynamic-programming contact patch simplifier.", init<>())
+        .def("compute", &ContactPatchSimplifierMaxArea::compute,
+             (arg("self"), arg("patch_in"), arg("target_vertices"),
+              arg("patch_out")),
+             "Simplify `patch_in` into `patch_out` using the max-area DP.")
+        .def("simplify", &ContactPatchSimplifierMaxArea::simplify,
+             (arg("self"), arg("patch"), arg("target_vertices")));
+  }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
   collision.cpp
   contact_patch.cpp
   contact_patch/contact_patch_solver.cpp
+  contact_patch/contact_patch_simplifier.cpp
   contact_patch_func_matrix.cpp
   distance_func_matrix.cpp
   collision_data.cpp

--- a/src/contact_patch/contact_patch_simplifier.cpp
+++ b/src/contact_patch/contact_patch_simplifier.cpp
@@ -1,0 +1,331 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2025, INRIA
+ *  All rights reserved.
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of INRIA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Louis Montaut */
+
+#include "coal/contact_patch/contact_patch_simplifier.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+namespace coal {
+namespace {
+
+using Index = typename ContactPatchSimplifierMaxArea::Index;
+
+template <typename T>
+inline T clamp(T val, T min_val, T max_val) {
+  if (val < min_val) {
+    return min_val;
+  }
+  if (val > max_val) {
+    return max_val;
+  }
+  return val;
+}
+
+inline Scalar triangle_area_twice(const Vec2s& a, const Vec2s& b,
+                                  const Vec2s& c) {
+  const Vec2s ab = b - a;
+  const Vec2s ac = c - a;
+  return ab.x() * ac.y() - ab.y() * ac.x();
+}
+
+Scalar compute_triangle_area(const ContactPatch::Polygon& pts,
+                             const std::vector<int>& prev,
+                             const std::vector<int>& next, int vertex) {
+  const int prev_idx = prev[static_cast<Index>(vertex)];
+  const int next_idx = next[static_cast<Index>(vertex)];
+  if (prev_idx == vertex || next_idx == vertex) {
+    return Scalar(0);
+  }
+  const Vec2s& a = pts[static_cast<Index>(prev_idx)];
+  const Vec2s& b = pts[static_cast<Index>(vertex)];
+  const Vec2s& c = pts[static_cast<Index>(next_idx)];
+  return std::abs(triangle_area_twice(a, b, c)) * Scalar(0.5);
+}
+
+}  // namespace
+
+void ContactPatchSimplifierGreedy::compute(const ContactPatch& patch_in,
+                                           Index target_vertices,
+                                           ContactPatch& patch_out) {
+  const auto& pts = patch_in.points();
+  const Index n = pts.size();
+  simplified_buffer_.clear();
+  simplified_buffer_.reserve(std::min(target_vertices, static_cast<size_t>(n)));
+
+  if (n == 0 || target_vertices == 0 || target_vertices >= n) {
+    simplified_buffer_.assign(pts.begin(), pts.end());
+  } else {
+    const Index desired = clamp<Index>(target_vertices, 1, n);
+
+    prev_.resize(n);
+    next_.resize(n);
+    removed_.resize(n);
+    versions_.resize(n);
+    heap_storage_.clear();
+    heap_storage_.reserve(n);
+
+    for (Index i = 0; i < n; ++i) {
+      prev_[i] = static_cast<int>((i + n - 1) % n);
+      next_[i] = static_cast<int>((i + 1) % n);
+      removed_[i] = false;
+      versions_[i] = 0;
+
+      const Scalar area =
+          compute_triangle_area(pts, prev_, next_, static_cast<int>(i));
+      heap_storage_.push_back({i, area, versions_[i]});
+    }
+
+    const auto comp = [](const HeapEntry& lhs, const HeapEntry& rhs) {
+      return lhs.area > rhs.area;
+    };
+
+    std::make_heap(heap_storage_.begin(), heap_storage_.end(), comp);
+
+    Index remaining = n;
+    while (remaining > desired && !heap_storage_.empty()) {
+      std::pop_heap(heap_storage_.begin(), heap_storage_.end(), comp);
+      HeapEntry node = heap_storage_.back();
+      heap_storage_.pop_back();
+
+      if (removed_[node.idx]) {
+        continue;
+      }
+      if (node.version != versions_[node.idx]) {
+        continue;
+      }
+
+      const Index prev_idx = static_cast<Index>(prev_[node.idx]);
+      const Index next_idx = static_cast<Index>(next_[node.idx]);
+      if (prev_idx == node.idx || next_idx == node.idx) {
+        break;
+      }
+
+      removed_[node.idx] = true;
+      --remaining;
+
+      next_[prev_idx] = static_cast<int>(next_idx);
+      prev_[next_idx] = static_cast<int>(prev_idx);
+
+      if (!removed_[prev_idx]) {
+        ++versions_[prev_idx];
+        const Scalar area_prev = compute_triangle_area(
+            pts, prev_, next_, static_cast<int>(prev_idx));
+        heap_storage_.push_back({prev_idx, area_prev, versions_[prev_idx]});
+        std::push_heap(heap_storage_.begin(), heap_storage_.end(), comp);
+      }
+
+      if (!removed_[next_idx]) {
+        ++versions_[next_idx];
+        const Scalar area_next = compute_triangle_area(
+            pts, prev_, next_, static_cast<int>(next_idx));
+        heap_storage_.push_back({next_idx, area_next, versions_[next_idx]});
+        std::push_heap(heap_storage_.begin(), heap_storage_.end(), comp);
+      }
+    }
+
+    for (Index i = 0; i < n; ++i) {
+      if (!removed_[i]) {
+        simplified_buffer_.push_back(pts[i]);
+      }
+    }
+  }
+
+  if (&patch_in != &patch_out) {
+    patch_out = patch_in;
+  }
+
+  auto& polygon = patch_out.points();
+  polygon.assign(simplified_buffer_.begin(), simplified_buffer_.end());
+}
+
+void ContactPatchSimplifierGreedy::simplify(ContactPatch& patch,
+                                            Index target_vertices) {
+  compute(patch, target_vertices, patch);
+}
+
+void ContactPatchSimplifierMaxArea::compute(const ContactPatch& patch_in,
+                                            Index target_vertices,
+                                            ContactPatch& patch_out) {
+  const auto& pts = patch_in.points();
+  const Index n = pts.size();
+  simplified_buffer_.clear();
+  simplified_buffer_.reserve(std::min(target_vertices, n));
+
+  if (n == 0 || target_vertices == 0 || target_vertices >= n) {
+    simplified_buffer_.assign(pts.begin(), pts.end());
+  } else {
+    const Index desired = clamp<Index>(target_vertices, 1, n);
+
+    ordered_indices_.resize(n);
+    const Index dp_width = desired + 1;
+    dp_area_.assign(n * dp_width, -std::numeric_limits<Scalar>::infinity());
+    dp_prev_.assign(n * dp_width, -1);
+    selection_indices_temp_.clear();
+    selection_indices_temp_.reserve(desired);
+    best_indices_.clear();
+    best_indices_.reserve(desired);
+
+    const Scalar invalid_area = -std::numeric_limits<Scalar>::infinity();
+    Scalar best_area = invalid_area;
+
+    const auto dp_index = [dp_width](Index i, Index k) {
+      return static_cast<Index>(i * dp_width + k);
+    };
+
+    for (Index anchor = 0; anchor < n; ++anchor) {
+      for (Index i = 0; i < n; ++i) {
+        ordered_indices_[i] = (anchor + i) % n;
+      }
+
+      std::fill(dp_area_.begin(), dp_area_.end(), invalid_area);
+      std::fill(dp_prev_.begin(), dp_prev_.end(), -1);
+      selection_indices_temp_.clear();
+
+      dp_area_[dp_index(0, 1)] = Scalar(0);
+      dp_prev_[dp_index(0, 1)] = -1;
+
+      Scalar anchor_best_area = invalid_area;
+      int anchor_best_end = -1;
+
+      if (desired == 1) {
+        anchor_best_area = Scalar(0);
+        anchor_best_end = 0;
+      } else {
+        for (Index i = 1; i < n; ++i) {
+          const Index max_k = std::min(desired, i + 1);
+          for (Index k = 2; k <= max_k; ++k) {
+            for (Index j = k - 2; j < i; ++j) {
+              const Scalar prev_area = dp_area_[dp_index(j, k - 1)];
+              if (prev_area == invalid_area) {
+                continue;
+              }
+
+              const Scalar tri_area = std::abs(triangle_area_twice(
+                  pts[ordered_indices_[0]], pts[ordered_indices_[j]],
+                  pts[ordered_indices_[i]]));
+              const Scalar candidate_area = prev_area + tri_area;
+              const Index cur_idx = dp_index(i, k);
+              if (candidate_area > dp_area_[cur_idx]) {
+                dp_area_[cur_idx] = candidate_area;
+                dp_prev_[cur_idx] = static_cast<int>(j);
+              }
+            }
+          }
+        }
+
+        for (Index i = desired - 1; i < n; ++i) {
+          const Scalar area = dp_area_[dp_index(i, desired)];
+          if (area > anchor_best_area) {
+            anchor_best_area = area;
+            anchor_best_end = static_cast<int>(i);
+          }
+        }
+      }
+
+      if (anchor_best_area == invalid_area || anchor_best_end < 0) {
+        continue;
+      }
+
+      selection_indices_temp_.clear();
+
+      Index current = static_cast<Index>(anchor_best_end);
+      Index current_k = desired;
+      selection_indices_temp_.push_back(ordered_indices_[current]);
+
+      while (current_k > 1) {
+        const int predecessor = dp_prev_[dp_index(current, current_k)];
+        if (predecessor < 0) {
+          anchor_best_area = invalid_area;
+          break;
+        }
+        current = static_cast<Index>(predecessor);
+        --current_k;
+        selection_indices_temp_.push_back(ordered_indices_[current]);
+      }
+
+      if (anchor_best_area == invalid_area) {
+        continue;
+      }
+
+      std::reverse(selection_indices_temp_.begin(),
+                   selection_indices_temp_.end());
+
+      if (anchor_best_area > best_area) {
+        best_area = anchor_best_area;
+        best_indices_ = selection_indices_temp_;
+      }
+    }
+
+    if (best_indices_.empty()) {
+      best_indices_.clear();
+      for (Index i = 0; i < desired; ++i) {
+        best_indices_.push_back(i);
+      }
+    }
+
+    keep_.resize(n);
+    std::fill(keep_.begin(), keep_.end(), uint8_t(0));
+    for (Index idx : best_indices_) {
+      if (idx < n) {
+        keep_[idx] = uint8_t(1);
+      }
+    }
+
+    for (Index i = 0; i < n; ++i) {
+      if (keep_[i]) {
+        simplified_buffer_.push_back(pts[i]);
+      }
+    }
+  }
+
+  if (&patch_in != &patch_out) {
+    patch_out = patch_in;
+  }
+
+  auto& polygon = patch_out.points();
+  polygon.assign(simplified_buffer_.begin(), simplified_buffer_.end());
+}
+
+void ContactPatchSimplifierMaxArea::simplify(ContactPatch& patch,
+                                             Index target_vertices) {
+  compute(patch, target_vertices, patch);
+}
+
+}  // namespace coal

--- a/test/contact_patch.cpp
+++ b/test/contact_patch.cpp
@@ -225,6 +225,84 @@ BOOST_AUTO_TEST_CASE(halfspace_box) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(cylinder_plane_simplification) {
+  const Scalar radius = Scalar(0.25);
+  const Scalar length = Scalar(1.0);
+  const Cylinder cylinder(radius, length);
+  const Halfspace plane(Vec3s(0, 0, 1), Scalar(0));
+
+  Transform3s tf_cylinder;
+  tf_cylinder.setIdentity();
+  const Scalar penetration = -Scalar(0.02);
+  tf_cylinder.translation() = Vec3s(0, 0, cylinder.halfLength + penetration);
+
+  const Transform3s tf_plane;
+
+  const CollisionRequest col_req;
+  CollisionResult col_res;
+  coal::collide(&cylinder, tf_cylinder, &plane, tf_plane, col_req, col_res);
+
+  BOOST_REQUIRE(col_res.isCollision());
+
+  const ContactPatchRequest patch_req(col_req);
+  ContactPatchResult patch_res(patch_req);
+  coal::computeContactPatch(&cylinder, tf_cylinder, &plane, tf_plane, col_res,
+                            patch_req, patch_res);
+
+  BOOST_REQUIRE_EQUAL(patch_res.numContactPatches(), 1);
+  const ContactPatch& patch = patch_res.getContactPatch(0);
+  BOOST_REQUIRE_GE(patch.size(), static_cast<size_t>(6));
+
+  const Scalar tol = Scalar(1e-8);
+  BOOST_CHECK(
+      patch.tf.translation().isApprox(Vec3s(0, 0, penetration / 2), tol));
+  BOOST_CHECK_SMALL(std::abs(patch.penetration_depth - penetration), tol);
+
+  const auto point_subset_check = [&](const ContactPatch& reduced,
+                                      const size_t target) {
+    BOOST_CHECK_EQUAL(reduced.size(), target);
+    BOOST_CHECK(reduced.tf.translation().isApprox(patch.tf.translation(), tol));
+    BOOST_CHECK(reduced.tf.rotation().isApprox(patch.tf.rotation(), tol));
+    BOOST_CHECK_SMALL(
+        std::abs(reduced.penetration_depth - patch.penetration_depth), tol);
+
+    for (size_t i = 0; i < reduced.size(); ++i) {
+      bool found = false;
+      for (size_t j = 0; j < patch.size(); ++j) {
+        if (reduced.point(i).isApprox(patch.point(j), tol)) {
+          found = true;
+          break;
+        }
+      }
+      BOOST_CHECK(found);
+    }
+  };
+
+  ContactPatchSimplifierGreedy greedy;
+  ContactPatch greedy_out(patch.size());
+  greedy.compute(patch, 4, greedy_out);
+  point_subset_check(greedy_out, 4);
+
+  greedy.compute(patch, 3, greedy_out);
+  point_subset_check(greedy_out, 3);
+
+  ContactPatch patch_inplace = patch;
+  greedy.simplify(patch_inplace, 4);
+  point_subset_check(patch_inplace, 4);
+
+  ContactPatchSimplifierMaxArea max_area;
+  ContactPatch max_out(patch.size());
+  max_area.compute(patch, 4, max_out);
+  point_subset_check(max_out, 4);
+
+  max_area.compute(patch, 2, max_out);
+  point_subset_check(max_out, 2);
+
+  ContactPatch max_inplace = patch;
+  max_area.simplify(max_inplace, 3);
+  point_subset_check(max_inplace, 3);
+}
+
 BOOST_AUTO_TEST_CASE(halfspace_capsule) {
   const Halfspace hspace(0, 0, 1, 0);
   const Scalar radius = Scalar(0.25);


### PR DESCRIPTION
This PR provides helpers to compute a simplified contact patch from a given one.
Say you have a contact patch with N points but you'd like to extract n points of this patch, the `ContactPatchSimplifierMaxArea` helper will find the inscribed polygon with n points that has the largest area. The `ContactPatchSimplifierGreedy` approximates the max area one.