### PR TITLE
Remove windows.h and fixes some warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix contact patch computation by enforcing CCW construction of support sets ([#772](https://github.com/coal-library/coal/pull/772))
 - Remove pixi 0.57 warnings ([#774](https://github.com/coal-library/coal/pull/774))
 - Fix nanobind bindings' stub file ([#781](https://github.com/coal-library/coal/pull/781#event-20983199417))
+- Remove Windows warnings when building benchmakrs ([789](https://github.com/coal-library/coal/pull/789))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/include/coal/fwd.hh
+++ b/include/coal/fwd.hh
@@ -47,7 +47,7 @@
 #include "coal/deprecated.hh"
 #include "coal/warning.hh"
 
-#if _WIN32
+#if defined(_WIN32)
 #define COAL_PRETTY_FUNCTION __FUNCSIG__
 #else
 #define COAL_PRETTY_FUNCTION __PRETTY_FUNCTION__
@@ -108,7 +108,7 @@
 #else
 #define COAL_COMPILER_DIAGNOSTIC_IGNORED_MAYBE_UNINITIALIZED
 #endif
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define COAL_COMPILER_DIAGNOSTIC_PUSH _Pragma("warning(push)")
 #define COAL_COMPILER_DIAGNOSTIC_POP _Pragma("warning(pop)")
 #define COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS \

--- a/include/coal/serialization/fwd.h
+++ b/include/coal/serialization/fwd.h
@@ -74,10 +74,14 @@ struct cast_register_initializer {
   void init(std::false_type) const {}
 
   cast_register_initializer const& init() const {
+#ifndef _WIN32
     COAL_COMPILER_DIAGNOSTIC_PUSH
     _Pragma("GCC diagnostic ignored \"-Wconversion\"")
+#endif
         BOOST_STATIC_WARNING((std::is_base_of<Base, Derived>::value));
+#ifndef _WIN32
     COAL_COMPILER_DIAGNOSTIC_POP
+#endif
     init(std::is_base_of<Base, Derived>());
     return *this;
   }

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,6 +3,8 @@ environments:
   all:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -360,6 +362,8 @@ environments:
   all-boost-python:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -733,6 +737,8 @@ environments:
   all-clang-cl:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hfc39600_1.conda
@@ -811,6 +817,8 @@ environments:
   all-python-oldest:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1169,6 +1177,8 @@ environments:
   clang:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1272,6 +1282,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1618,6 +1630,8 @@ environments:
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2024,6 +2038,8 @@ environments:
   new-version:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2385,6 +2401,8 @@ environments:
   octomap:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2735,6 +2753,8 @@ environments:
   python-oldest:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3082,6 +3102,8 @@ environments:
   qhull:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3435,6 +3457,8 @@ environments:
   test-pixi-build:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3494,7 +3518,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-h3691f8a_4.conda
       - conda: .
-        subdir: linux-64
+        build: hb0f4dca_0
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hd65d9c6_1.conda
@@ -3547,7 +3571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h281d3d1_4.conda
       - conda: .
-        subdir: osx-64
+        build: h0dc7051_0
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-h31c7375_1.conda
@@ -3600,7 +3624,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hd0aec43_4.conda
       - conda: .
-        subdir: osx-arm64
+        build: h60d57d3_0
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hfc39600_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
@@ -3650,7 +3674,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h1b5488d_4.conda
       - conda: .
-        build: h9352c13_0
+        build: h2433df5_0
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -4411,8 +4435,31 @@ packages:
 - conda: .
   name: coal
   version: 3.0.2
-  build: h9352c13_0
+  build: h0dc7051_0
+  subdir: osx-64
+  variants:
+    target_platform: osx-64
+  depends:
+  - libcxx >=21
+  - octomap >=1.10.0,<1.11.0a0
+  - libboost >=1.88.0,<1.89.0a0
+  - assimp >=5.4.3,<5.4.4.0a0
+  - libboost-python >=1.88.0,<1.89.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.13.* *_cp313
+  - eigenpy >=3.12.0,<3.12.1.0a0
+  - qhull >=2020.2,<2020.3.0a0
+  input:
+    hash: de8e435fc8bb973559d7388ac00a9ba587e3fcae7be95b859bfe137030ac01d2
+    globs: []
+- conda: .
+  name: coal
+  version: 3.0.2
+  build: h2433df5_0
   subdir: win-64
+  variants:
+    cxx_compiler: vs2019
+    target_platform: win-64
   depends:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -4431,11 +4478,12 @@ packages:
 - conda: .
   name: coal
   version: 3.0.2
-  build: hbf21a9e_0
-  subdir: linux-64
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
   depends:
-  - libstdcxx >=15
-  - libgcc >=15
+  - libcxx >=21
   - octomap >=1.10.0,<1.11.0a0
   - libboost >=1.88.0,<1.89.0a0
   - assimp >=5.4.3,<5.4.4.0a0
@@ -4450,28 +4498,13 @@ packages:
 - conda: .
   name: coal
   version: 3.0.2
-  build: hbf21a9e_0
-  subdir: osx-64
+  build: hb0f4dca_0
+  subdir: linux-64
+  variants:
+    target_platform: linux-64
   depends:
-  - libcxx >=21
-  - octomap >=1.10.0,<1.11.0a0
-  - libboost >=1.88.0,<1.89.0a0
-  - assimp >=5.4.3,<5.4.4.0a0
-  - libboost-python >=1.88.0,<1.89.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.13.* *_cp313
-  - eigenpy >=3.12.0,<3.12.1.0a0
-  - qhull >=2020.2,<2020.3.0a0
-  input:
-    hash: de8e435fc8bb973559d7388ac00a9ba587e3fcae7be95b859bfe137030ac01d2
-    globs: []
-- conda: .
-  name: coal
-  version: 3.0.2
-  build: hbf21a9e_0
-  subdir: osx-arm64
-  depends:
-  - libcxx >=21
+  - libstdcxx >=15
+  - libgcc >=15
   - octomap >=1.10.0,<1.11.0a0
   - libboost >=1.88.0,<1.89.0a0
   - assimp >=5.4.3,<5.4.4.0a0

--- a/python/broadphase/broadphase_collision_manager.hh
+++ b/python/broadphase/broadphase_collision_manager.hh
@@ -215,7 +215,7 @@ struct BroadPhaseCollisionManagerWrapper
   static void exposeDerived() {
     std::string class_name = boost::typeindex::type_id<Derived>().pretty_name();
     boost::algorithm::replace_all(class_name, "coal::", "");
-#if defined(WIN32)
+#if defined(_WIN32)
     boost::algorithm::replace_all(class_name, "class ", "");
 #endif
 

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -109,7 +109,6 @@ double distance(const std::vector<Transform3s>& tf, const BVHModel<BV>& m1,
 
     distance(&node, NULL);
   }
-  timer.stop();
   return timer.getElapsedTimeInMicroSec();
 }
 
@@ -136,7 +135,6 @@ double collide(const std::vector<Transform3s>& tf, const BVHModel<BV>& m1,
     collide(&node, request, result);
   }
 
-  timer.stop();
   return timer.getElapsedTimeInMicroSec();
 }
 

--- a/test/broadphase.cpp
+++ b/test/broadphase.cpp
@@ -366,15 +366,15 @@ void broad_phase_self_distance_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->registerObjects(env);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->setup();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   std::vector<DistanceCallBackDefault> self_callbacks(managers.size());
@@ -382,8 +382,8 @@ void broad_phase_self_distance_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < self_callbacks.size(); ++i) {
     timers[i].start();
     managers[i]->distance(&self_callbacks[i]);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
     // std::cout << self_data[i].result.min_distance << " ";
   }
   // std::cout << std::endl;
@@ -515,15 +515,15 @@ void broad_phase_distance_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->registerObjects(env);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->setup();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < query.size(); ++i) {
@@ -531,8 +531,8 @@ void broad_phase_distance_test(Scalar env_scale, std::size_t env_size,
     for (size_t j = 0; j < managers.size(); ++j) {
       timers[j].start();
       managers[j]->distance(query[i], &query_callbacks[j]);
-      timers[j].stop();
-      ts[j].push_back(timers[j].getElapsedTime());
+      const auto elapsed_s = timers[j].getElapsedTime();
+      ts[j].push_back(elapsed_s);
       std::cout << query_callbacks[j].data.result.min_distance << " ";
     }
     std::cout << std::endl;

--- a/test/broadphase_collision_1.cpp
+++ b/test/broadphase_collision_1.cpp
@@ -251,15 +251,15 @@ void broad_phase_duplicate_check_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->registerObjects(env);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->setup();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   // update the environment
@@ -296,8 +296,8 @@ void broad_phase_duplicate_check_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->update();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   std::vector<CollisionDataForUniquenessChecking> self_data(managers.size());
@@ -306,8 +306,8 @@ void broad_phase_duplicate_check_test(Scalar env_scale, std::size_t env_size,
     CollisionFunctionForUniquenessChecking callback;
     timers[i].start();
     managers[i]->collide(&callback);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (auto obj : env) delete obj;
@@ -424,15 +424,15 @@ void broad_phase_update_collision_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->registerObjects(env);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->setup();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   // update the environment
@@ -469,8 +469,8 @@ void broad_phase_update_collision_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->update();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   std::vector<CollisionData> self_data(managers.size());
@@ -485,8 +485,8 @@ void broad_phase_update_collision_test(Scalar env_scale, std::size_t env_size,
     CollisionCallBackDefault callback;
     timers[i].start();
     managers[i]->collide(&callback);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i)
@@ -523,8 +523,8 @@ void broad_phase_update_collision_test(Scalar env_scale, std::size_t env_size,
     for (size_t j = 0; j < query_callbacks.size(); ++j) {
       timers[j].start();
       managers[j]->collide(query[i], &query_callbacks[j]);
-      timers[j].stop();
-      ts[j].push_back(timers[j].getElapsedTime());
+      const auto elapsed_s = timers[j].getElapsedTime();
+      ts[j].push_back(elapsed_s);
     }
 
     // for(size_t j = 0; j < managers.size(); ++j)

--- a/test/broadphase_collision_2.cpp
+++ b/test/broadphase_collision_2.cpp
@@ -254,15 +254,15 @@ void broad_phase_collision_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->registerObjects(env);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->setup();
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   std::vector<CollisionCallBackDefault> callbacks(managers.size());
@@ -276,8 +276,8 @@ void broad_phase_collision_test(Scalar env_scale, std::size_t env_size,
   for (size_t i = 0; i < managers.size(); ++i) {
     timers[i].start();
     managers[i]->collide(&callbacks[i]);
-    timers[i].stop();
-    ts[i].push_back(timers[i].getElapsedTime());
+    const auto elapsed_s = timers[i].getElapsedTime();
+    ts[i].push_back(elapsed_s);
   }
 
   for (size_t i = 0; i < managers.size(); ++i)
@@ -313,8 +313,8 @@ void broad_phase_collision_test(Scalar env_scale, std::size_t env_size,
     for (size_t j = 0; j < managers.size(); ++j) {
       timers[j].start();
       managers[j]->collide(query[i], &callbacks[j]);
-      timers[j].stop();
-      ts[j].push_back(timers[j].getElapsedTime());
+      const auto elapsed_s = timers[j].getElapsedTime();
+      ts[j].push_back(elapsed_s);
     }
 
     // for(size_t j = 0; j < managers.size(); ++j)

--- a/test/profiling.cpp
+++ b/test/profiling.cpp
@@ -91,8 +91,8 @@ void collide(const std::vector<Transform3s>& tf, const CollisionGeometry* o1,
     timer.start();
     /* int num_contact = */
     collide(o1, tf[i], o2, Id, request, results.rs[i]);
-    timer.stop();
-    results.times[(Eigen::DenseIndex)i] = timer.getElapsedTimeInMicroSec();
+    const auto elapsed_us = timer.getElapsedTimeInMicroSec();
+    results.times[(Eigen::DenseIndex)i] = elapsed_us;
   }
 }
 

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -16,69 +16,20 @@
 
 namespace coal {
 
-BenchTimer::BenchTimer() {
-#ifdef _WIN32
-  QueryPerformanceFrequency(&frequency);
-  startCount.QuadPart = 0;
-  endCount.QuadPart = 0;
-#else
-  startCount.tv_sec = startCount.tv_usec = 0;
-  endCount.tv_sec = endCount.tv_usec = 0;
-#endif
-
-  stopped = 0;
-  startTimeInMicroSec = 0;
-  endTimeInMicroSec = 0;
-}
-
-BenchTimer::~BenchTimer() {}
-
-void BenchTimer::start() {
-  stopped = 0;  // reset stop flag
-#ifdef _WIN32
-  QueryPerformanceCounter(&startCount);
-#else
-  gettimeofday(&startCount, NULL);
-#endif
-}
-
-void BenchTimer::stop() {
-  stopped = 1;  // set timer stopped flag
-
-#ifdef _WIN32
-  QueryPerformanceCounter(&endCount);
-#else
-  gettimeofday(&endCount, NULL);
-#endif
-}
-
-double BenchTimer::getElapsedTimeInMicroSec() {
-#ifdef _WIN32
-  if (!stopped) QueryPerformanceCounter(&endCount);
-
-  startTimeInMicroSec = startCount.QuadPart * (1000000.0 / frequency.QuadPart);
-  endTimeInMicroSec = endCount.QuadPart * (1000000.0 / frequency.QuadPart);
-#else
-  if (!stopped) gettimeofday(&endCount, NULL);
-
-  startTimeInMicroSec =
-      ((double)startCount.tv_sec * 1000000.0) + (double)startCount.tv_usec;
-  endTimeInMicroSec =
-      ((double)endCount.tv_sec * 1000000.0) + (double)endCount.tv_usec;
-#endif
-
-  return endTimeInMicroSec - startTimeInMicroSec;
+void BenchTimer::start() { start_time_ = clock::now(); }
+double BenchTimer::getElapsedTime() { return getElapsedTimeInSec(); }
+double BenchTimer::getElapsedTimeInSec() {
+  return std::chrono::duration<double>(clock::now() - start_time_).count();
 }
 
 double BenchTimer::getElapsedTimeInMilliSec() {
-  return this->getElapsedTimeInMicroSec() * 0.001;
+  return std::chrono::duration<double, std::milli>(clock::now() - start_time_)
+      .count();
 }
-
-double BenchTimer::getElapsedTimeInSec() {
-  return this->getElapsedTimeInMicroSec() * 0.000001;
+double BenchTimer::getElapsedTimeInMicroSec() {
+  return std::chrono::duration<double, std::micro>(clock::now() - start_time_)
+      .count();
 }
-
-double BenchTimer::getElapsedTime() { return this->getElapsedTimeInMilliSec(); }
 
 const Eigen::IOFormat vfmt = Eigen::IOFormat(
     Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", "", "");

--- a/test/utility.h
+++ b/test/utility.h
@@ -43,6 +43,7 @@
 #include "coal/collision_object.h"
 #include "coal/broadphase/default_broadphase_callbacks.h"
 #include "coal/shape/convex.h"
+#include <chrono>
 
 #ifdef COAL_HAS_OCTOMAP
 #include "coal/octree.h"
@@ -77,12 +78,11 @@ typedef coal::shared_ptr<octomap::OcTree> OcTreePtr_t;
 namespace coal {
 
 class BenchTimer {
- public:
-  BenchTimer();
-  ~BenchTimer();
+  using clock = std::chrono::steady_clock;
+  using time_point = clock::time_point;
 
+ public:
   void start();                       ///< start timer
-  void stop();                        ///< stop the timer
   double getElapsedTime();            ///< get elapsed time in milli-second
   double getElapsedTimeInSec();       ///< get elapsed time in second (same as
                                       ///< getElapsedTime)
@@ -90,17 +90,7 @@ class BenchTimer {
   double getElapsedTimeInMicroSec();  ///< get elapsed time in micro-second
 
  private:
-  double startTimeInMicroSec;  ///< starting time in micro-second
-  double endTimeInMicroSec;    ///< ending time in micro-second
-  int stopped;                 ///< stop flag
-#ifdef _WIN32
-  LARGE_INTEGER frequency;  ///< ticks per second
-  LARGE_INTEGER startCount;
-  LARGE_INTEGER endCount;
-#else
-  timeval startCount;
-  timeval endCount;
-#endif
+  time_point start_time_ = clock::now();
 };
 
 struct TStruct {

--- a/test/utility.h
+++ b/test/utility.h
@@ -48,12 +48,6 @@
 #include "coal/octree.h"
 #endif
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <sys/time.h>
-#endif
-
 #define EIGEN_VECTOR_IS_APPROX(Va, Vb, precision)                            \
   BOOST_CHECK_MESSAGE(((Va) - (Vb)).isZero(precision),                       \
                       "check " #Va ".isApprox(" #Vb ") failed at precision " \


### PR DESCRIPTION
In an attempt to fix https://github.com/coal-library/coal/issues/785, I found some old `windows.h` used in the tests.
This PR replaces the windows calls by `<chrono>`.
Fixes a pragma warning on Windows as well.