### PR TITLE
Enable specifying extra margins for objects in DynamicAABBTreeArray broadphase manager.

### DIFF
--- a/include/coal/BV/AABB.h
+++ b/include/coal/BV/AABB.h
@@ -226,6 +226,12 @@ class COAL_DLLAPI AABB {
     return *this;
   }
 
+  inline AABB expandCopy(const Scalar delta) const {
+    AABB expanded = *this;
+    expanded.expand(delta);
+    return expanded;
+  }
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 

--- a/include/coal/broadphase/broadphase_dynamic_AABB_tree_array.h
+++ b/include/coal/broadphase/broadphase_dynamic_AABB_tree_array.h
@@ -58,7 +58,6 @@ class COAL_DLLAPI DynamicAABBTreeArrayCollisionManager
   using Base::getObjects;
 
   using DynamicAABBNode = detail::implementation_array::NodeBase<AABB>;
-  using DynamicAABBTable = std::unordered_map<CollisionObject*, size_t>;
 
   int max_tree_nonbalanced_level;
   int tree_incremental_balance_pass;
@@ -76,6 +75,11 @@ class COAL_DLLAPI DynamicAABBTreeArrayCollisionManager
 
   /// @brief add one object to the manager
   void registerObject(CollisionObject* obj);
+
+  /// @brief add one object to the manager with an AABB expanded by margin. This
+  /// is useful when the narrowphase checks use a security margin. margin must
+  /// be >= 0.
+  void registerObject(CollisionObject* obj, Scalar margin);
 
   /// @brief remove one object from the manager
   void unregisterObject(CollisionObject* obj);
@@ -132,7 +136,12 @@ class COAL_DLLAPI DynamicAABBTreeArrayCollisionManager
 
  private:
   detail::implementation_array::HierarchyTree<AABB> dtree{};
-  std::unordered_map<CollisionObject*, size_t> table;
+  struct ObjectInfo {
+    size_t index = 0;
+    Scalar margin = 0.0;
+  };
+  using DynamicAABBTable = std::unordered_map<CollisionObject*, ObjectInfo>;
+  DynamicAABBTable table;
 
   bool setup_;
 

--- a/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
@@ -508,7 +508,9 @@ void DynamicAABBTreeArrayCollisionManager::registerObjects(
       leaves[i].parent = dtree.NULL_NODE;
       leaves[i].children[1] = dtree.NULL_NODE;
       leaves[i].data = other_objs[i];
-      table[other_objs[i]] = i;
+      ObjectInfo& info = table[other_objs[i]];
+      info.index = i;
+      info.margin = 0.0;
     }
 
     int n_leaves = (int)other_objs.size();
@@ -523,13 +525,28 @@ void DynamicAABBTreeArrayCollisionManager::registerObjects(
 void DynamicAABBTreeArrayCollisionManager::registerObject(
     CollisionObject* obj) {
   size_t node = dtree.insert(obj->getAABB(), obj);
-  table[obj] = node;
+  ObjectInfo& info = table[obj];
+  info.index = node;
+  info.margin = 0.0;
+}
+
+//==============================================================================
+void DynamicAABBTreeArrayCollisionManager::registerObject(
+    CollisionObject* obj, Scalar margin) {
+  if (margin < 0) {
+    COAL_THROW_PRETTY("margin must be non-negative", std::invalid_argument);
+  }
+  size_t node = dtree.insert(obj->getAABB().expandCopy(margin), obj);
+  ObjectInfo& info = table[obj];
+  info.index = node;
+  info.margin = margin;
 }
 
 //==============================================================================
 void DynamicAABBTreeArrayCollisionManager::unregisterObject(
     CollisionObject* obj) {
-  size_t node = table[obj];
+  ObjectInfo& info = table[obj];
+  size_t node = info.index;
   table.erase(obj);
   dtree.remove(node);
 }
@@ -557,10 +574,11 @@ void DynamicAABBTreeArrayCollisionManager::setup() {
 
 //==============================================================================
 void DynamicAABBTreeArrayCollisionManager::update() {
-  for (auto it = table.cbegin(), end = table.cend(); it != end; ++it) {
-    const CollisionObject* obj = it->first;
-    size_t node = it->second;
-    dtree.getNodes()[node].bv = obj->getAABB();
+  for (auto it = table.begin(), end = table.end(); it != end; ++it) {
+    CollisionObject* obj = it->first;
+    ObjectInfo& info = it->second;
+    size_t node = info.index;
+    dtree.getNodes()[node].bv = obj->getAABB().expandCopy(info.margin);
   }
 
   dtree.refit();
@@ -574,9 +592,11 @@ void DynamicAABBTreeArrayCollisionManager::update_(
     CollisionObject* updated_obj) {
   const auto it = table.find(updated_obj);
   if (it != table.end()) {
-    size_t node = it->second;
-    if (!(dtree.getNodes()[node].bv == updated_obj->getAABB()))
-      dtree.update(node, updated_obj->getAABB());
+    ObjectInfo& info = it->second;
+    size_t node = info.index;
+    AABB new_aabb = updated_obj->getAABB().expandCopy(info.margin);
+    if (!(dtree.getNodes()[node].bv == new_aabb))
+      dtree.update(node, new_aabb);
   }
   setup_ = false;
 }


### PR DESCRIPTION
Before this change, if a user wanted to do collision checking with a security margin, they couldn't use a broadphase manager because the broadphase may discard pairs of objects whose AABB's do not overlap.

This change allows users to specify margins on CollisionObjects that they add to DynamicAABBTreeArrayCollisionManager. The broadphase will operate on these objects as if they had larger AABBs, but the objects themselves are unchanged.

This change enables the following useful patterns:
- Add objects with a margin _m_ to the broadphase, then use a CollisionCallback that checks for narrow phase collisions with a security margin equal to _m_. Now we can do `collide()` queries and catch all collisions within the security margin.
- Create two separate broadphase managers, where both have objects with margin _m_. When checking for collisions between the two managers, you can set the narrow phase security margin as high as _2*m_ and detect all collisions.

I don't consider this PR complete at all! I wanted to use it to start a conversation:
- Is this feature useful to other people?
- Does my implementation actually work as expected?
- Should it be generalized to other broadphase managers?