### PR TITLE
Fix octree against octree collision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix nanobind bindings' stub file ([#781](https://github.com/coal-library/coal/pull/781#event-20983199417))
 - Remove Windows warnings when building benchmakrs ([789](https://github.com/coal-library/coal/pull/789))
 - convex: a point can have more than 256 neighbors now. In fact, a point can have `std::numeric_limits<IndexType>::max()` number of neighbors, where IndexType is typically int16 or int32 ([805](https://github.com/coal-library/coal/pull/805))
+- Fix octree against octree collision check ([#811](https://github.com/coal-library/coal/pull/811))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/include/coal/internal/traversal_node_octree.h
+++ b/include/coal/internal/traversal_node_octree.h
@@ -924,7 +924,12 @@ class COAL_DLLAPI OcTreeSolver {
               sqrt(sqrDistLowerBound) - crequest->security_margin;
         return false;
       }
-      if (crequest->enable_contact) {  // Overlap
+      if (bothAreLeaves) {  // Both are leaf nodes and overlap
+        if (cresult->distance_lower_bound > 0 &&
+            sqrDistLowerBound <
+                cresult->distance_lower_bound * cresult->distance_lower_bound)
+          cresult->distance_lower_bound =
+              sqrt(sqrDistLowerBound) - crequest->security_margin;
         if (cresult->numContacts() < crequest->num_max_contacts)
           cresult->addContact(
               Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()),


### PR DESCRIPTION
This fixes issue #603. Thanks to @Everest-Zhao for the fix.

Summary by Copilot:

**Key changes made:**
1. **Changed condition** from `if (crequest->enable_contact)` to `if (bothAreLeaves)` - now contacts are only added when both nodes are actually leaves
2. **Added distance_lower_bound update** inside the new condition - this fixes the infinity bug by updating the distance even when both leaves overlap

This ensures:
- Contacts are only added for leaf-to-leaf collisions (not for intermediate nodes)  
- `distance_lower_bound` is properly updated when leaf nodes overlap
- More efficient computation when contact information isn't required

The fix addresses the original issue where `distance_lower_bound` was always returning infinity for Octree-to-Octree collision checks.