### PR TITLE
Fix condition for negative bounding volume check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove Windows warnings when building benchmakrs ([789](https://github.com/coal-library/coal/pull/789))
 - convex: a point can have more than 256 neighbors now. In fact, a point can have `std::numeric_limits<IndexType>::max()` number of neighbors, where IndexType is typically int16 or int32 ([805](https://github.com/coal-library/coal/pull/805))
 - Fix octree against octree collision check ([#811](https://github.com/coal-library/coal/pull/811))
+- Fix condition for negative bounding volume check ([#816](https://github.com/coal-library/coal/pull/816))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/src/broadphase/broadphase_dynamic_AABB_tree.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree.cpp
@@ -578,7 +578,7 @@ void DynamicAABBTreeCollisionManager::update() {
     CollisionObject* obj = it->first;
     DynamicAABBNode* node = it->second;
     node->bv = obj->getAABB();
-    if (node->bv.volume() <= 0.)
+    if (node->bv.volume() < 0.)
       COAL_THROW_PRETTY("The bounding volume has a negative volume.",
                         std::invalid_argument)
   }


### PR DESCRIPTION
A triangle has a volume of zero, but gets flagged here as having a negative volume.