### PR TITLE
Add missing calls to computeLocalAABB for internal objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - convex: a point can have more than 256 neighbors now. In fact, a point can have `std::numeric_limits<IndexType>::max()` number of neighbors, where IndexType is typically int16 or int32 ([805](https://github.com/coal-library/coal/pull/805))
 - Fix octree against octree collision check ([#811](https://github.com/coal-library/coal/pull/811))
 - Fix condition for negative bounding volume check ([#816](https://github.com/coal-library/coal/pull/816))
+- Add missing calls to computeLocalAABB for internal objects ([#819](https://github.com/coal-library/coal/pull/819))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/include/coal/internal/traversal_node_octree.h
+++ b/include/coal/internal/traversal_node_octree.h
@@ -382,16 +382,17 @@ class COAL_DLLAPI OcTreeSolver {
         Transform3s box_tf;
         constructBox(bv1, tf1, box, box_tf);
 
-        if (solver->gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
-          box.computeLocalAABB();
-        }
-
         size_t primitive_id =
             static_cast<size_t>(tree2->getBV(root2).primitiveId());
         const Triangle32& tri_id = (*(tree2->tri_indices))[primitive_id];
-        const TriangleP tri((*(tree2->vertices))[tri_id[0]],
-                            (*(tree2->vertices))[tri_id[1]],
-                            (*(tree2->vertices))[tri_id[2]]);
+        TriangleP tri((*(tree2->vertices))[tri_id[0]],
+                      (*(tree2->vertices))[tri_id[1]],
+                      (*(tree2->vertices))[tri_id[2]]);
+
+        if (solver->gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
+          box.computeLocalAABB();
+          tri.computeLocalAABB();
+        }
 
         Vec3s p1, p2, normal;
         const Scalar distance = internal::ShapeShapeDistance<Box, TriangleP>(
@@ -500,15 +501,17 @@ class COAL_DLLAPI OcTreeSolver {
       Box box;
       Transform3s box_tf;
       constructBox(bv1, tf1, box, box_tf);
-      if (solver->gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
-        box.computeLocalAABB();
-      }
 
       size_t primitive_id = static_cast<size_t>(bvn2.primitiveId());
       const Triangle32& tri_id = (*(tree2->tri_indices))[primitive_id];
-      const TriangleP tri((*(tree2->vertices))[tri_id[0]],
-                          (*(tree2->vertices))[tri_id[1]],
-                          (*(tree2->vertices))[tri_id[2]]);
+      TriangleP tri((*(tree2->vertices))[tri_id[0]],
+                    (*(tree2->vertices))[tri_id[1]],
+                    (*(tree2->vertices))[tri_id[2]]);
+
+      if (solver->gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
+        box.computeLocalAABB();
+        tri.computeLocalAABB();
+      }
 
       // When reaching this point, `this->solver` has already been set up
       // by the CollisionRequest `this->crequest`.

--- a/include/coal/narrowphase/narrowphase.h
+++ b/include/coal/narrowphase/narrowphase.h
@@ -328,6 +328,10 @@ struct COAL_DLLAPI GJKSolver {
     TriangleP tri(tf_1M2.transform(s2.a), tf_1M2.transform(s2.b),
                   tf_1M2.transform(s2.c));
 
+    if (this->gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
+      tri.computeLocalAABB();
+    }
+
     constexpr bool relative_transformation_already_computed = true;
     Scalar distance;
     this->runGJKAndEPA(s1, tf1, tri, tf_1M2, compute_penetration, distance, p1,

--- a/src/BVH/BVH_utility.cpp
+++ b/src/BVH/BVH_utility.cpp
@@ -59,6 +59,10 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3s& pose,
   // Early-stop GJK as soon as a separating plane is found
   gjk.gjk.setDistanceEarlyBreak(Scalar(1e-3));
 
+  if (gjk.gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
+    box.computeLocalAABB();
+  }
+
   // Check what triangles should be kept.
   // TODO use the BV hierarchy
   std::vector<bool> keep_vertex(model.num_vertices, false);
@@ -80,8 +84,13 @@ BVHModel<BV>* BVHExtract(const BVHModel<BV>& model, const Transform3s& pose,
         }
       }
 
-      const TriangleP tri(model_vertices_[t[0]], model_vertices_[t[1]],
-                          model_vertices_[t[2]]);
+      TriangleP tri(model_vertices_[t[0]], model_vertices_[t[1]],
+                    model_vertices_[t[2]]);
+
+      if (gjk.gjk_initial_guess == GJKInitialGuess::BoundingVolumeGuess) {
+        tri.computeLocalAABB();
+      }
+
       const bool enable_nearest_points = false;
       const bool compute_penetration = false;  // we only need to know if there
                                                // is a collision or not


### PR DESCRIPTION
When an internal collision object is constructed it needs a local AABB for the GJK BoundingVolumeGuess. In most places computeLocalAABB is correctly called, this PR adds a few missed cases.