### PR TITLE
Add missing override specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix octree against octree collision check ([#811](https://github.com/coal-library/coal/pull/811))
 - Fix condition for negative bounding volume check ([#816](https://github.com/coal-library/coal/pull/816))
 - Add missing calls to computeLocalAABB for internal objects ([#819](https://github.com/coal-library/coal/pull/819))
+- Add missing override specifiers ([#820](https://github.com/coal-library/coal/pull/820))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/include/coal/BVH/BVH_model.h
+++ b/include/coal/BVH/BVH_model.h
@@ -110,10 +110,10 @@ class COAL_DLLAPI BVHModelBase : public CollisionGeometry {
   virtual ~BVHModelBase() {}
 
   /// @brief Get the object type: it is a BVH
-  OBJECT_TYPE getObjectType() const { return OT_BVH; }
+  OBJECT_TYPE getObjectType() const override { return OT_BVH; }
 
   /// @brief Compute the AABB for the BVH, used for broad-phase collision
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Begin a new BVH model
   int beginModel(unsigned int num_tris = 0, unsigned int num_vertices = 0);
@@ -203,7 +203,7 @@ class COAL_DLLAPI BVHModelBase : public CollisionGeometry {
   /// save one matrix transformation.
   virtual void makeParentRelative() = 0;
 
-  Vec3s computeCOM() const {
+  Vec3s computeCOM() const override {
     Scalar vol = 0;
     Vec3s com(0, 0, 0);
     if (!(vertices.get())) {
@@ -233,7 +233,7 @@ class COAL_DLLAPI BVHModelBase : public CollisionGeometry {
     return com / (vol * 4);
   }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     Scalar vol = 0;
     if (!(vertices.get())) {
       std::cerr << "BVH Error in `computeCOM`! The BVHModel does not contain "
@@ -259,7 +259,7 @@ class COAL_DLLAPI BVHModelBase : public CollisionGeometry {
     return vol / 6;
   }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Matrix3s C = Matrix3s::Zero();
 
     Matrix3s C_canonical;
@@ -316,7 +316,7 @@ class COAL_DLLAPI BVHModelBase : public CollisionGeometry {
 
  protected:
   /// \brief Comparison operators
-  virtual bool isEqual(const CollisionGeometry& other) const;
+  virtual bool isEqual(const CollisionGeometry& other) const override;
 };
 
 /// @brief A class describing the bounding hierarchy of a mesh model or a point
@@ -346,7 +346,7 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
   BVHModel(const BVHModel& other);
 
   /// @brief Clone *this into a new BVHModel
-  virtual BVHModel<BV>* clone() const { return new BVHModel(*this); }
+  virtual BVHModel<BV>* clone() const override { return new BVHModel(*this); }
 
   /// @brief deconstruction, delete mesh data related.
   ~BVHModel() {}
@@ -370,23 +370,23 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
   unsigned int getNumBVs() const { return num_bvs; }
 
   /// @brief Get the BV type: default is unknown
-  NODE_TYPE getNodeType() const { return BV_UNKNOWN; }
+  NODE_TYPE getNodeType() const override { return BV_UNKNOWN; }
 
   /// @brief Check the number of memory used
-  int memUsage(const bool msg) const;
+  int memUsage(const bool msg) const override;
 
   /// @brief This is a special acceleration: BVH_model default stores the BV's
   /// transform in world coordinate. However, we can also store each BV's
   /// transform related to its parent BV node. When traversing the BVH, this can
   /// save one matrix transformation.
-  void makeParentRelative() {
+  void makeParentRelative() override {
     Matrix3s I(Matrix3s::Identity());
     makeParentRelativeRecurse(0, I, Vec3s::Zero());
   }
 
  protected:
-  void deleteBVs();
-  bool allocateBVs();
+  void deleteBVs() override;
+  bool allocateBVs() override;
 
   unsigned int num_bvs_allocated;
   std::shared_ptr<std::vector<unsigned int>> primitive_indices;
@@ -398,10 +398,10 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
   unsigned int num_bvs;
 
   /// @brief Build the bounding volume hierarchy
-  int buildTree();
+  int buildTree() override;
 
   /// @brief Refit the bounding volume hierarchy
-  int refitTree(bool bottomup);
+  int refitTree(bool bottomup) override;
 
   /// @brief Refit the bounding volume hierarchy in a top-down way (slow but
   /// more compact)
@@ -439,7 +439,7 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const BVHModel* other_ptr = dynamic_cast<const BVHModel*>(&_other);
     if (other_ptr == nullptr) return false;
     const BVHModel& other = *other_ptr;

--- a/include/coal/hfield.h
+++ b/include/coal/hfield.h
@@ -265,7 +265,9 @@ class COAL_DLLAPI HeightField : public CollisionGeometry {
   /// @brief Returns the maximal height value of the Height Field.
   Scalar getMaxHeight() const { return max_height; }
 
-  virtual HeightField<BV>* clone() const { return new HeightField(*this); }
+  virtual HeightField<BV>* clone() const override {
+    return new HeightField(*this);
+  }
 
   const BVS& getNodes() const { return bvs; }
 
@@ -274,7 +276,7 @@ class COAL_DLLAPI HeightField : public CollisionGeometry {
 
   /// @brief Compute the AABB for the HeightField, used for broad-phase
   /// collision
-  void computeLocalAABB() {
+  void computeLocalAABB() override {
     const Vec3s A(x_grid[0], y_grid[0], min_height);
     const Vec3s B(x_grid[x_grid.size() - 1], y_grid[y_grid.size() - 1],
                   max_height);
@@ -331,13 +333,13 @@ class COAL_DLLAPI HeightField : public CollisionGeometry {
   }
 
   /// @brief Get the object type: it is a HFIELD
-  OBJECT_TYPE getObjectType() const { return OT_HFIELD; }
+  OBJECT_TYPE getObjectType() const override { return OT_HFIELD; }
 
-  Vec3s computeCOM() const { return Vec3s::Zero(); }
+  Vec3s computeCOM() const override { return Vec3s::Zero(); }
 
-  Scalar computeVolume() const { return 0; }
+  Scalar computeVolume() const override { return 0; }
 
-  Matrix3s computeMomentofInertia() const { return Matrix3s::Zero(); }
+  Matrix3s computeMomentofInertia() const override { return Matrix3s::Zero(); }
 
  protected:
   /// @brief Dimensions in meters along X and Y directions
@@ -493,10 +495,10 @@ class COAL_DLLAPI HeightField : public CollisionGeometry {
   }
 
   /// @brief Get the BV type: default is unknown
-  NODE_TYPE getNodeType() const { return BV_UNKNOWN; }
+  NODE_TYPE getNodeType() const override { return BV_UNKNOWN; }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const HeightField* other_ptr = dynamic_cast<const HeightField*>(&_other);
     if (other_ptr == nullptr) return false;
     const HeightField& other = *other_ptr;

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -95,7 +95,7 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
         free_threshold(other.free_threshold) {}
 
   /// \brief Clone *this into a new Octree
-  OcTree* clone() const { return new OcTree(*this); }
+  OcTree* clone() const override { return new OcTree(*this); }
 
   /// \brief Returns the tree associated to the underlying octomap OcTree.
   shared_ptr<const octomap::OcTree> getTree() const { return tree; }
@@ -103,7 +103,7 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
   void exportAsObjFile(const std::string& filename) const;
 
   /// @brief compute the AABB for the octree in its local coordinate system
-  void computeLocalAABB() {
+  void computeLocalAABB() override {
     typedef Eigen::Matrix<float, 3, 1> Vec3float;
     Vec3float max_extent, min_extent;
 
@@ -259,13 +259,13 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
   }
 
   /// @brief return object type, it is an octree
-  OBJECT_TYPE getObjectType() const { return OT_OCTREE; }
+  OBJECT_TYPE getObjectType() const override { return OT_OCTREE; }
 
   /// @brief return node type, it is an octree
-  NODE_TYPE getNodeType() const { return GEOM_OCTREE; }
+  NODE_TYPE getNodeType() const override { return GEOM_OCTREE; }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const OcTree* other_ptr = dynamic_cast<const OcTree*>(&_other);
     if (other_ptr == nullptr) return false;
     const OcTree& other = *other_ptr;

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -69,7 +69,7 @@ class COAL_DLLAPI ShapeBase : public CollisionGeometry {
   virtual ~ShapeBase() {};
 
   /// @brief Get object type: a geometric shape
-  OBJECT_TYPE getObjectType() const { return OT_GEOM; }
+  OBJECT_TYPE getObjectType() const override { return OT_GEOM; }
 
   /// @brief Set radius of sphere swept around the shape.
   /// Must be >= 0.
@@ -116,12 +116,12 @@ class COAL_DLLAPI TriangleP : public ShapeBase {
       : ShapeBase(other), a(other.a), b(other.b), c(other.c) {}
 
   /// @brief Clone *this into a new TriangleP
-  virtual TriangleP* clone() const { return new TriangleP(*this); };
+  virtual TriangleP* clone() const override { return new TriangleP(*this); };
 
   /// @brief virtual function of compute AABB in local coordinate
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
-  NODE_TYPE getNodeType() const { return GEOM_TRIANGLE; }
+  NODE_TYPE getNodeType() const override { return GEOM_TRIANGLE; }
 
   //  std::pair<ShapeBase*, Transform3s> inflated(const Scalar value) const
   //  {
@@ -147,7 +147,7 @@ class COAL_DLLAPI TriangleP : public ShapeBase {
   Vec3s a, b, c;
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const TriangleP* other_ptr = dynamic_cast<const TriangleP*>(&_other);
     if (other_ptr == nullptr) return false;
     const TriangleP& other = *other_ptr;
@@ -178,7 +178,7 @@ class COAL_DLLAPI Box : public ShapeBase {
   }
 
   /// @brief Clone *this into a new Box
-  virtual Box* clone() const { return new Box(*this); };
+  virtual Box* clone() const override { return new Box(*this); };
 
   /// @brief Default constructor
   Box() {}
@@ -187,14 +187,14 @@ class COAL_DLLAPI Box : public ShapeBase {
   Vec3s halfSide;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a box
-  NODE_TYPE getNodeType() const { return GEOM_BOX; }
+  NODE_TYPE getNodeType() const override { return GEOM_BOX; }
 
-  Scalar computeVolume() const { return 8 * halfSide.prod(); }
+  Scalar computeVolume() const override { return 8 * halfSide.prod(); }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar V = computeVolume();
     Vec3s s(halfSide.cwiseAbs2() * V);
     return (Vec3s(s[1] + s[2], s[0] + s[2], s[0] + s[1]) / 3).asDiagonal();
@@ -221,7 +221,7 @@ class COAL_DLLAPI Box : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Box* other_ptr = dynamic_cast<const Box*>(&_other);
     if (other_ptr == nullptr) return false;
     const Box& other = *other_ptr;
@@ -245,23 +245,23 @@ class COAL_DLLAPI Sphere : public ShapeBase {
   Sphere(const Sphere& other) : ShapeBase(other), radius(other.radius) {}
 
   /// @brief Clone *this into a new Sphere
-  virtual Sphere* clone() const { return new Sphere(*this); };
+  virtual Sphere* clone() const override { return new Sphere(*this); };
 
   /// @brief Radius of the sphere
   Scalar radius;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a sphere
-  NODE_TYPE getNodeType() const { return GEOM_SPHERE; }
+  NODE_TYPE getNodeType() const override { return GEOM_SPHERE; }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar I = Scalar(0.4) * radius * radius * computeVolume();
     return I * Matrix3s::Identity();
   }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     return 4 * boost::math::constants::pi<Scalar>() * radius * radius * radius /
            3;
   }
@@ -286,7 +286,7 @@ class COAL_DLLAPI Sphere : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Sphere* other_ptr = dynamic_cast<const Sphere*>(&_other);
     if (other_ptr == nullptr) return false;
     const Sphere& other = *other_ptr;
@@ -312,19 +312,19 @@ class COAL_DLLAPI Ellipsoid : public ShapeBase {
   Ellipsoid(const Ellipsoid& other) : ShapeBase(other), radii(other.radii) {}
 
   /// @brief Clone *this into a new Ellipsoid
-  virtual Ellipsoid* clone() const { return new Ellipsoid(*this); };
+  virtual Ellipsoid* clone() const override { return new Ellipsoid(*this); };
 
   /// @brief Radii of the Ellipsoid (such that on boundary: x^2/rx^2 + y^2/ry^2
   /// + z^2/rz^2 = 1)
   Vec3s radii;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: an ellipsoid
-  NODE_TYPE getNodeType() const { return GEOM_ELLIPSOID; }
+  NODE_TYPE getNodeType() const override { return GEOM_ELLIPSOID; }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar V = computeVolume();
     Scalar a2 = V * radii[0] * radii[0];
     Scalar b2 = V * radii[1] * radii[1];
@@ -335,7 +335,7 @@ class COAL_DLLAPI Ellipsoid : public ShapeBase {
         .finished();
   }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     return 4 * boost::math::constants::pi<Scalar>() * radii[0] * radii[1] *
            radii[2] / 3;
   }
@@ -361,7 +361,7 @@ class COAL_DLLAPI Ellipsoid : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Ellipsoid* other_ptr = dynamic_cast<const Ellipsoid*>(&_other);
     if (other_ptr == nullptr) return false;
     const Ellipsoid& other = *other_ptr;
@@ -391,7 +391,7 @@ class COAL_DLLAPI Capsule : public ShapeBase {
       : ShapeBase(other), radius(other.radius), halfLength(other.halfLength) {}
 
   /// @brief Clone *this into a new Capsule
-  virtual Capsule* clone() const { return new Capsule(*this); };
+  virtual Capsule* clone() const override { return new Capsule(*this); };
 
   /// @brief Radius of capsule
   Scalar radius;
@@ -400,17 +400,17 @@ class COAL_DLLAPI Capsule : public ShapeBase {
   Scalar halfLength;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a capsule
-  NODE_TYPE getNodeType() const { return GEOM_CAPSULE; }
+  NODE_TYPE getNodeType() const override { return GEOM_CAPSULE; }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     return boost::math::constants::pi<Scalar>() * radius * radius *
            ((halfLength * 2) + radius * 4 / Scalar(3));
   }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar v_cyl = radius * radius * (halfLength * 2) *
                    boost::math::constants::pi<Scalar>();
     Scalar v_sph = radius * radius * radius *
@@ -447,7 +447,7 @@ class COAL_DLLAPI Capsule : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Capsule* other_ptr = dynamic_cast<const Capsule*>(&_other);
     if (other_ptr == nullptr) return false;
     const Capsule& other = *other_ptr;
@@ -476,7 +476,7 @@ class COAL_DLLAPI Cone : public ShapeBase {
       : ShapeBase(other), radius(other.radius), halfLength(other.halfLength) {}
 
   /// @brief Clone *this into a new Cone
-  virtual Cone* clone() const { return new Cone(*this); };
+  virtual Cone* clone() const override { return new Cone(*this); };
 
   /// @brief Radius of the cone
   Scalar radius;
@@ -485,17 +485,17 @@ class COAL_DLLAPI Cone : public ShapeBase {
   Scalar halfLength;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a cone
-  NODE_TYPE getNodeType() const { return GEOM_CONE; }
+  NODE_TYPE getNodeType() const override { return GEOM_CONE; }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     return boost::math::constants::pi<Scalar>() * radius * radius *
            (halfLength * 2) / 3;
   }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar V = computeVolume();
     Scalar ix =
         V * (Scalar(0.4) * halfLength * halfLength + 3 * radius * radius / 20);
@@ -504,7 +504,9 @@ class COAL_DLLAPI Cone : public ShapeBase {
     return (Matrix3s() << ix, 0, 0, 0, ix, 0, 0, 0, iz).finished();
   }
 
-  Vec3s computeCOM() const { return Vec3s(0, 0, -Scalar(0.5) * halfLength); }
+  Vec3s computeCOM() const override {
+    return Vec3s(0, 0, -Scalar(0.5) * halfLength);
+  }
 
   Scalar minInflationValue() const { return -(std::min)(radius, halfLength); }
 
@@ -538,7 +540,7 @@ class COAL_DLLAPI Cone : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Cone* other_ptr = dynamic_cast<const Cone*>(&_other);
     if (other_ptr == nullptr) return false;
     const Cone& other = *other_ptr;
@@ -574,7 +576,7 @@ class COAL_DLLAPI Cylinder : public ShapeBase {
   }
 
   /// @brief Clone *this into a new Cylinder
-  virtual Cylinder* clone() const { return new Cylinder(*this); };
+  virtual Cylinder* clone() const override { return new Cylinder(*this); };
 
   /// @brief Radius of the cylinder
   Scalar radius;
@@ -583,17 +585,17 @@ class COAL_DLLAPI Cylinder : public ShapeBase {
   Scalar halfLength;
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a cylinder
-  NODE_TYPE getNodeType() const { return GEOM_CYLINDER; }
+  NODE_TYPE getNodeType() const override { return GEOM_CYLINDER; }
 
-  Scalar computeVolume() const {
+  Scalar computeVolume() const override {
     return boost::math::constants::pi<Scalar>() * radius * radius *
            (halfLength * 2);
   }
 
-  Matrix3s computeMomentofInertia() const {
+  Matrix3s computeMomentofInertia() const override {
     Scalar V = computeVolume();
     Scalar ix = V * (radius * radius / 4 + halfLength * halfLength / 3);
     Scalar iz = V * radius * radius / 2;
@@ -621,7 +623,7 @@ class COAL_DLLAPI Cylinder : public ShapeBase {
   }
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Cylinder* other_ptr = dynamic_cast<const Cylinder*>(&_other);
     if (other_ptr == nullptr) return false;
     const Cylinder& other = *other_ptr;
@@ -742,7 +744,7 @@ class ConvexBaseTpl : public ShapeBase {
 
   /// @brief Clone (deep copy).
   COAL_DEPRECATED_MESSAGE(Use deepcopy instead.)
-  virtual ConvexBaseTpl* clone() const { return this->deepcopy(); }
+  virtual ConvexBaseTpl* clone() const override { return this->deepcopy(); }
 
   /// @brief Deep copy of the ConvexBaseTpl.
   /// This method deep copies every field of the class.
@@ -762,10 +764,10 @@ class ConvexBaseTpl : public ShapeBase {
   }
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a convex polytope
-  NODE_TYPE getNodeType() const;
+  NODE_TYPE getNodeType() const override;
 
 #ifdef COAL_HAS_QHULL
   /// @brief Builds the double description of the convex polytope, i.e. the set
@@ -869,7 +871,7 @@ class ConvexBaseTpl : public ShapeBase {
 
   void computeCenter();
 
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const ConvexBaseTpl* other_ptr =
         dynamic_cast<const ConvexBaseTpl*>(&_other);
     if (other_ptr == nullptr) return false;
@@ -987,7 +989,7 @@ class COAL_DLLAPI Halfspace : public ShapeBase {
   }
 
   /// @brief Clone *this into a new Halfspace
-  virtual Halfspace* clone() const { return new Halfspace(*this); };
+  virtual Halfspace* clone() const override { return new Halfspace(*this); };
 
   Scalar signedDistance(const Vec3s& p) const {
     return n.dot(p) - (d + this->getSweptSphereRadius());
@@ -998,10 +1000,10 @@ class COAL_DLLAPI Halfspace : public ShapeBase {
   }
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a half space
-  NODE_TYPE getNodeType() const { return GEOM_HALFSPACE; }
+  NODE_TYPE getNodeType() const override { return GEOM_HALFSPACE; }
 
   Scalar minInflationValue() const {
     return std::numeric_limits<Scalar>::lowest();
@@ -1035,7 +1037,7 @@ class COAL_DLLAPI Halfspace : public ShapeBase {
   void unitNormalTest();
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Halfspace* other_ptr = dynamic_cast<const Halfspace*>(&_other);
     if (other_ptr == nullptr) return false;
     const Halfspace& other = *other_ptr;
@@ -1077,7 +1079,7 @@ class COAL_DLLAPI Plane : public ShapeBase {
   }
 
   /// @brief Clone *this into a new Plane
-  virtual Plane* clone() const { return new Plane(*this); };
+  virtual Plane* clone() const override { return new Plane(*this); };
 
   Scalar signedDistance(const Vec3s& p) const {
     const Scalar dist = n.dot(p) - d;
@@ -1096,10 +1098,10 @@ class COAL_DLLAPI Plane : public ShapeBase {
   }
 
   /// @brief Compute AABB
-  void computeLocalAABB();
+  void computeLocalAABB() override;
 
   /// @brief Get node type: a plane
-  NODE_TYPE getNodeType() const { return GEOM_PLANE; }
+  NODE_TYPE getNodeType() const override { return GEOM_PLANE; }
 
   /// @brief Plane normal
   Vec3s n;
@@ -1112,7 +1114,7 @@ class COAL_DLLAPI Plane : public ShapeBase {
   void unitNormalTest();
 
  private:
-  virtual bool isEqual(const CollisionGeometry& _other) const {
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
     const Plane* other_ptr = dynamic_cast<const Plane*>(&_other);
     if (other_ptr == nullptr) return false;
     const Plane& other = *other_ptr;


### PR DESCRIPTION
This adds a number of missing override specifiers. Although the code compiles fine without them, if the base class method signature changes, these functions suddenly will not override anymore and the compiler will not warn you, unless override is specified.