### PR TITLE
Nanobind bindings : fix `shared_ptr<>` for BVH classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix condition for negative bounding volume check ([#816](https://github.com/coal-library/coal/pull/816))
 - Add missing calls to computeLocalAABB for internal objects ([#819](https://github.com/coal-library/coal/pull/819))
 - Add missing override specifiers ([#820](https://github.com/coal-library/coal/pull/820))
+- Fix Python error when accessing `geometry.convex` on BVH geometris ([#833](https://github.com/coal-library/coal/pull/833))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/python-nb/bvh.cc
+++ b/python-nb/bvh.cc
@@ -1,12 +1,15 @@
-/// Copyright 2025 INRIA
+/// Copyright 2025-2026 INRIA
 
 #include "coal/BVH/BVH_model.h"
 #include "coal/serialization/BVH_model.h"
+#include "coal/shape/convex.h"
 
 #include "pickle.hh"
 #include "serializable.hh"
 
 #include "fwd.h"
+
+#include <nanobind/stl/shared_ptr.h>
 
 using namespace coal;
 using namespace nb::literals;


### PR DESCRIPTION
- This fixes the use of `shared_ptr<ConvexBase>` on the BVH classes